### PR TITLE
Drain async sub-agent tasks on lifespan shutdown

### DIFF
--- a/docs/resilience/graceful-shutdown.md
+++ b/docs/resilience/graceful-shutdown.md
@@ -1,0 +1,51 @@
+# Graceful Shutdown
+
+Langgraph-kit drains in-flight background work during process shutdown so long-running agent runs finish cleanly — no half-written `Store` records, no lost Langfuse spans, no stuck `async_task` rows marked `RUNNING` forever.
+
+## What gets drained
+
+The lifespan teardown in [`contrib.fastapi.create_app_lifespan`](../integrations/fastapi.md) calls `drain_background_tasks(timeout)` before closing MCP connections, flushing Langfuse, and releasing the persistence context.
+
+The drain target is every [async sub-agent task](../orchestration/async-tasks.md) started via `AsyncTaskManager.start()` — these outlive the HTTP request that kicked them off and are the only work the HTTP layer cannot drain at the socket level.
+
+Draining does **not** cover:
+
+- In-flight HTTP requests — Uvicorn/Gunicorn already hold the connection open until the handler returns, so lifespan shutdown only runs once every active handler has finished.
+- Thread-level busy locks (`ThreadBusyTracker`) — these are advisory and auto-expire after 10 minutes; they need no explicit drain.
+
+## Timeout behavior
+
+A single `AgentConfig` field controls the wait:
+
+```python
+from langgraph_kit import AgentConfig, configure
+
+configure(AgentConfig(
+    shutdown_timeout_seconds=30.0,  # default
+))
+```
+
+- `> 0` — wait up to this many seconds for tasks to finish on their own, then cancel the rest.
+- `0` — cancel immediately (a ~10 ms window is still given so cancelled tasks can update their Store record to `CANCELLED`).
+- Negative values skip draining entirely (the lifespan teardown proceeds to MCP close and Langfuse flush without waiting).
+
+A task that is cancelled by the drain has its Store record updated from `RUNNING` to `CANCELLED`; readers checking task status after shutdown see the real terminal state instead of a stuck row.
+
+## Production checklist
+
+For Kubernetes, systemd, or any orchestrator that sends SIGTERM on shutdown:
+
+1. **Match the pod / service terminationGracePeriod to `shutdown_timeout_seconds` + headroom.** If your tasks typically take 20 s and `shutdown_timeout_seconds = 30`, set `terminationGracePeriodSeconds = 45` so the process has time to drain *and* flush Langfuse after.
+2. **Configure the load balancer / service mesh to stop routing first.** SIGTERM triggers lifespan shutdown, which includes the drain; any request that lands during the drain will wait on the server socket. Routing cutoff at the edge avoids that.
+3. **Tune `shutdown_timeout_seconds` to the 95th percentile of your sub-agent runs.** Setting it too low cancels useful work; setting it unreasonably high lets a single hung task hold up the whole pod's shutdown.
+4. **Check logs after rollouts.** The lifespan emits one line summarising the drain:
+   ```
+   shutdown drain: 4 async task(s) completed, 1 cancelled
+   ```
+   If `cancelled` is consistently > 0 in steady state, the timeout is too short for your workload.
+
+## Signal handling
+
+Langgraph-kit does not install its own signal handlers. It relies on the ASGI server (Uvicorn, Hypercorn, Gunicorn) to translate SIGTERM/SIGINT into a lifespan shutdown event. That event runs the cleanup block in `create_app_lifespan`, which is where the drain happens.
+
+If you embed the app in a custom entrypoint, make sure the shutdown pathway exits the `lifespan` context manager — otherwise the drain never runs.

--- a/docs/resilience/overview.md
+++ b/docs/resilience/overview.md
@@ -10,6 +10,7 @@ The resilience system provides middleware that catches failure modes and prevent
 | [Empty Turn](empty-turn.md) | Nudging the model when no output is produced |
 | [Tool Error](tool-error.md) | Structured error handling with transient retry |
 | [Post-Run Backstop](post-run.md) | Final checks after graph execution |
+| [Graceful Shutdown](graceful-shutdown.md) | Drain in-flight async sub-agent tasks on SIGTERM |
 
 ## Middleware Stack Position
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Empty turn: resilience/empty-turn.md
     - Tool error: resilience/tool-error.md
     - Post-run: resilience/post-run.md
+    - Graceful shutdown: resilience/graceful-shutdown.md
   - HITL:
     - Overview: hitl/overview.md
     - Models: hitl/models.md

--- a/src/langgraph_kit/_config.py
+++ b/src/langgraph_kit/_config.py
@@ -43,6 +43,11 @@ class AgentConfig:
     # Execution trace export
     trace_export_enabled: bool = False
 
+    # Graceful shutdown: max seconds to wait for in-flight async sub-agent
+    # tasks before cancelling them during FastAPI lifespan teardown.
+    # Set to 0 to skip draining (cancel immediately).
+    shutdown_timeout_seconds: float = 30.0
+
     def __repr__(self) -> str:
         """Mask secrets in repr to prevent accidental leakage in logs.
 

--- a/src/langgraph_kit/contrib/fastapi.py
+++ b/src/langgraph_kit/contrib/fastapi.py
@@ -160,6 +160,27 @@ def create_app_lifespan(
 
                 yield
         finally:
+            # Graceful shutdown: drain in-flight async sub-agent tasks while
+            # Store + Langfuse + checkpointer are still alive. Uvicorn has
+            # already stopped accepting new HTTP requests by the time the
+            # lifespan shutdown phase runs (SIGTERM/SIGINT -> lifespan exit),
+            # so we only need to wait on work that outlives a single request.
+            from langgraph_kit.core.orchestration.async_tasks import (
+                drain_background_tasks,
+            )
+
+            cfg = get_config()
+            if cfg.shutdown_timeout_seconds >= 0:
+                drained, cancelled = await drain_background_tasks(
+                    cfg.shutdown_timeout_seconds
+                )
+                if drained or cancelled:
+                    logger.info(
+                        "shutdown drain: %d async task(s) completed, %d cancelled",
+                        drained,
+                        cancelled,
+                    )
+
             if mcp_mgr is not None:
                 await mcp_mgr.close()
             shutdown_langfuse()

--- a/src/langgraph_kit/core/orchestration/async_tasks.py
+++ b/src/langgraph_kit/core/orchestration/async_tasks.py
@@ -53,6 +53,14 @@ class AsyncTask(BaseModel):
 _NAMESPACE_PREFIX = "async_tasks"
 
 
+# Module-level registry of every live background task created by any
+# AsyncTaskManager, used for graceful shutdown. We track at the task level
+# rather than the manager level because managers are constructed per request
+# and there is no single app-level owner to hold references to them.
+# Tasks auto-remove from this set when they finish (done_callback in start()).
+_background_tasks: set[asyncio.Task[Any]] = set()
+
+
 class AsyncTaskManager:
     """Manages background tasks with persistence via LangGraph Store.
 
@@ -128,6 +136,8 @@ class AsyncTaskManager:
             self._run_graph(task.task_id, graph, input_data, sub_config)
         )
         self._running_asyncio_tasks[task.task_id] = asyncio_task
+        _background_tasks.add(asyncio_task)
+        asyncio_task.add_done_callback(_background_tasks.discard)
         return task
 
     async def _run_graph(
@@ -152,6 +162,22 @@ class AsyncTaskManager:
                 task.status = AsyncTaskStatus.SUCCESS
                 task.result = content
                 await self._persist(task)
+        except asyncio.CancelledError:
+            # Graceful-shutdown drain (or explicit cancel via cancel()) landed
+            # on the running task. Persist CANCELLED so a later reader sees the
+            # real terminal state instead of a stuck "running" record, then
+            # re-raise so asyncio treats the task as cancelled.
+            try:
+                task = await self._load(task_id)
+                if task and not task.is_terminal():
+                    task.status = AsyncTaskStatus.CANCELLED
+                    task.result = task.result or "Cancelled."
+                    await self._persist(task)
+            except Exception:
+                # Store may already be tearing down during shutdown — don't
+                # block cancellation on a persistence failure.
+                logger.exception("Failed to persist cancellation for task %s", task_id)
+            raise
         except Exception as exc:
             logger.exception("Async task %s failed", task_id)
             task = await self._load(task_id)
@@ -197,6 +223,52 @@ class AsyncTaskManager:
         task.result = "Cancelled by user."
         await self._persist(task)
         return task
+
+
+# ---------------------------------------------------------------------------
+# Graceful shutdown
+# ---------------------------------------------------------------------------
+
+
+async def drain_background_tasks(timeout: float) -> tuple[int, int]:
+    """Wait for every tracked async-sub-agent task to finish, then cancel the rest.
+
+    Called during FastAPI lifespan teardown so in-flight background tasks
+    get a bounded window to complete before the Store / checkpointer /
+    Langfuse exporter go away. Cancelled tasks update their Store records
+    via :meth:`AsyncTaskManager._run_graph`'s CancelledError handler.
+
+    Parameters
+    ----------
+    timeout:
+        Seconds to wait for clean completion. Tasks still running after
+        this elapses are cancelled. ``timeout <= 0`` cancels immediately.
+
+    Returns
+    -------
+    ``(drained, cancelled)``: counts of tasks that finished cleanly vs
+    those that had to be cancelled.
+    """
+    tasks = list(_background_tasks)
+    if not tasks:
+        return (0, 0)
+
+    # Always give at least a small window so freshly-created tasks enter
+    # their try block before we cancel. Without this, asyncio cancels a
+    # not-yet-scheduled task before its CancelledError handler runs, which
+    # leaves the Store record stuck in RUNNING. 10 ms is negligible during
+    # shutdown and guarantees the handler fires.
+    effective_timeout = max(timeout, 0.01)
+    done, pending = await asyncio.wait(tasks, timeout=effective_timeout)
+
+    if pending:
+        for t in pending:
+            t.cancel()
+        # Let cancellation propagate. return_exceptions prevents a spurious
+        # re-raise of CancelledError from the gather itself.
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    return (len(done), len(pending))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,197 @@
+"""Coverage — graceful shutdown drain for async sub-agent tasks.
+
+Exercises :func:`drain_background_tasks` end-to-end:
+
+- no-op when no tasks are in flight
+- tasks that finish inside the window are drained cleanly
+- tasks exceeding the window are cancelled, and their Store records
+  get updated from RUNNING to CANCELLED so later readers see the real
+  terminal state instead of a stuck row
+- ``timeout=0`` cancels everything immediately
+- the module-level task set auto-cleans via ``done_callback`` so a
+  natural-completion flow does not leak entries into subsequent drains
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from langgraph_kit.core.orchestration.async_tasks import (
+    AsyncTaskManager,
+    AsyncTaskStatus,
+    _background_tasks,
+    drain_background_tasks,
+)
+from tests.conftest import MockStore
+
+
+class _DummyMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeGraph:
+    """Minimal graph driven by AsyncTaskManager; optional gate keeps it running."""
+
+    def __init__(
+        self,
+        *,
+        gate: asyncio.Event | None = None,
+        result: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self._gate = gate
+        self._result = result or {"messages": [_DummyMessage("done")]}
+
+    async def ainvoke(
+        self, input_data: dict[str, Any], config: dict[str, Any]
+    ) -> dict[str, Any]:
+        _ = input_data
+        _ = config
+        if self._gate is not None:
+            await self._gate.wait()
+        return self._result
+
+
+@pytest.fixture
+def store() -> MockStore:
+    return MockStore()
+
+
+@pytest.fixture
+def manager(store: MockStore) -> AsyncTaskManager:
+    return AsyncTaskManager(store=store, parent_thread_id="parent-thread")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_task_set() -> Any:
+    """Clear the module-level background-task set around each test.
+
+    Other test files may (accidentally) leave tasks behind; draining those
+    would be slow and unrelated. Snapshot + restore so drain sees only the
+    tasks created in this test.
+    """
+    snapshot = set(_background_tasks)
+    _background_tasks.clear()
+    yield
+    _background_tasks.clear()
+    _background_tasks.update(snapshot)
+
+
+async def test_drain_with_no_tasks_is_noop() -> None:
+    drained, cancelled = await drain_background_tasks(timeout=5.0)
+    assert (drained, cancelled) == (0, 0)
+
+
+async def test_drain_completes_quickly_finishing_tasks(
+    manager: AsyncTaskManager,
+) -> None:
+    # No gate → graph returns immediately after event-loop handoff.
+    task = await manager.start(
+        agent_name="quick",
+        description="fast job",
+        graph=_FakeGraph(),
+        input_data={"messages": []},
+        config={},
+    )
+
+    drained, cancelled = await drain_background_tasks(timeout=5.0)
+    assert drained == 1
+    assert cancelled == 0
+
+    record = await manager.check(task.task_id)
+    assert record is not None
+    assert record.status == AsyncTaskStatus.SUCCESS
+
+
+async def test_drain_cancels_tasks_exceeding_timeout(
+    manager: AsyncTaskManager,
+) -> None:
+    gate = asyncio.Event()  # never set → graph blocks forever
+    task = await manager.start(
+        agent_name="slow",
+        description="hung job",
+        graph=_FakeGraph(gate=gate),
+        input_data={"messages": []},
+        config={},
+    )
+
+    drained, cancelled = await drain_background_tasks(timeout=0.05)
+    assert drained == 0
+    assert cancelled == 1
+
+    # Store record must reflect the cancellation — otherwise a later
+    # reader sees RUNNING forever and would never know the task exited.
+    record = await manager.check(task.task_id)
+    assert record is not None
+    assert record.status == AsyncTaskStatus.CANCELLED
+
+
+async def test_drain_with_zero_timeout_cancels_immediately(
+    manager: AsyncTaskManager,
+) -> None:
+    gate = asyncio.Event()
+    task = await manager.start(
+        agent_name="zero",
+        description="immediate-cancel job",
+        graph=_FakeGraph(gate=gate),
+        input_data={"messages": []},
+        config={},
+    )
+
+    drained, cancelled = await drain_background_tasks(timeout=0.0)
+    assert drained == 0
+    assert cancelled == 1
+
+    record = await manager.check(task.task_id)
+    assert record is not None
+    assert record.status == AsyncTaskStatus.CANCELLED
+
+
+async def test_module_set_auto_cleans_after_natural_completion(
+    manager: AsyncTaskManager,
+) -> None:
+    _ = await manager.start(
+        agent_name="clean",
+        description="auto-clean job",
+        graph=_FakeGraph(),
+        input_data={"messages": []},
+        config={},
+    )
+    # Drain to force the task to complete and the done_callback to fire.
+    await drain_background_tasks(timeout=5.0)
+    assert len(_background_tasks) == 0
+
+
+async def test_drain_handles_mixed_fast_and_slow(
+    manager: AsyncTaskManager,
+) -> None:
+    fast_task = await manager.start(
+        agent_name="fast",
+        description="finishes in time",
+        graph=_FakeGraph(),
+        input_data={"messages": []},
+        config={},
+    )
+    slow_gate = asyncio.Event()
+    slow_task = await manager.start(
+        agent_name="slow",
+        description="does not finish",
+        graph=_FakeGraph(gate=slow_gate),
+        input_data={"messages": []},
+        config={},
+    )
+
+    drained, cancelled = await drain_background_tasks(timeout=0.2)
+    assert drained == 1
+    assert cancelled == 1
+
+    fast_rec = await manager.check(fast_task.task_id)
+    slow_rec = await manager.check(slow_task.task_id)
+    assert fast_rec is not None
+    assert fast_rec.status == AsyncTaskStatus.SUCCESS
+    assert slow_rec is not None
+    assert slow_rec.status == AsyncTaskStatus.CANCELLED


### PR DESCRIPTION
## Summary

- Drain in-flight `AsyncTaskManager` sub-agent tasks during the FastAPI lifespan shutdown instead of killing them. Cancelled tasks update their Store record from `RUNNING` to `CANCELLED` so readers see the real terminal state.
- New `AgentConfig.shutdown_timeout_seconds` (default 30s) controls how long to wait before cancelling. 0 = cancel immediately; negative = skip draining.
- Docs: new `resilience/graceful-shutdown.md` covering K8s `terminationGracePeriodSeconds` tuning and the load-balancer cutoff sequence; added to the Resilience nav + overview table.

## Test plan

- [x] 6 new tests in `tests/test_graceful_shutdown.py`: no-op, clean drain, timeout-cancel + Store update, zero-timeout (with the 10 ms floor so the CancelledError handler runs), done_callback auto-clean, mixed fast/slow.
- [x] Full suite: 881 passed (was 875).
- [x] `ruff check --fix`, `ruff format --check`, `basedpyright` all clean.
- [x] `pre-commit run --all-files` clean.

Fixes #26