### PR TITLE
Add opt-in structured output middleware (Pydantic schema validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Opt-in structured-output validation via `StructuredOutputMiddleware`.**
+  Pass `output_schema=` to `build_deep_agent` and the agent's terminal
+  `AIMessage` is validated against your Pydantic schema. The model is
+  asked to wrap its structured payload in a single
+  `<output_schema>{...}</output_schema>` block (matches the existing
+  `CompactionResult` convention); on mismatch the middleware retries
+  with the schema rendered as JSON Schema, capped at 2 nudges. No
+  provider-native `response_format` plumbing — provider-agnostic by
+  design. Helpers `format_schema_instruction(schema)`,
+  `extract_structured_output(content)`, and
+  `parse_structured_output(content, schema)` are exported for prompt
+  composition and post-run extraction. `AgentMetadata.output_schema`
+  surfaces the contract for discovery. Fixes
+  [#17](https://github.com/allada-homelab/langgraph-kit/issues/17). See
+  [docs/resilience/structured-output.md](docs/resilience/structured-output.md).
+
 - **Opt-in semantic search for `PersistentMemoryManager`.** Pass an async
   `embedding_fn` (or set `AgentConfig.memory_embedding_fn`) to index
   records on create/update and rank `search()` by cosine similarity

--- a/docs/resilience/overview.md
+++ b/docs/resilience/overview.md
@@ -11,6 +11,7 @@ The resilience system provides middleware that catches failure modes and prevent
 | [Tool Error](tool-error.md) | Structured error handling with transient retry |
 | [Post-Run Backstop](post-run.md) | Final checks after graph execution |
 | [Graceful Shutdown](graceful-shutdown.md) | Drain in-flight async sub-agent tasks on SIGTERM |
+| [Structured Output](structured-output.md) | Validate the agent's terminal message against a Pydantic schema |
 
 ## Middleware Stack Position
 

--- a/docs/resilience/structured-output.md
+++ b/docs/resilience/structured-output.md
@@ -1,0 +1,98 @@
+# Structured Output
+
+`StructuredOutputMiddleware` is the kit's opt-in contract for "the agent's final answer must match a Pydantic schema". When configured, the middleware validates the agent's terminal `AIMessage` against the schema and nudges the model to retry on mismatch, up to a bounded cap.
+
+This is provider-agnostic — it does not call provider-native `response_format` or `with_structured_output()`. The validation happens on whatever text the LLM produces, so you can swap OpenAI, Anthropic, or Google without changing the contract.
+
+## Wiring
+
+```python
+from pydantic import BaseModel
+from langgraph_kit.graphs import build_deep_agent
+
+class Recipe(BaseModel):
+    title: str
+    ingredients: list[str]
+    minutes: int
+
+graph, _ = build_deep_agent(
+    agent_name="recipe-agent",
+    core_sections=[...],
+    subagents=[],
+    checkpointer=checkpointer,
+    store=store,
+    output_schema=Recipe,   # opt in
+)
+```
+
+When `output_schema` is `None` (the default), no validation middleware is added — agents that return free-form prose are unaffected.
+
+## Wire format
+
+The model is asked to wrap its structured payload in a single tagged block:
+
+```
+<output_schema>
+{"title": "tacos", "ingredients": ["beef", "corn"], "minutes": 30}
+</output_schema>
+```
+
+Anything outside the block is allowed (chain-of-thought, citations, narration). The middleware extracts the first `<output_schema>` block, parses it as JSON, and validates against the schema.
+
+This mirrors the existing `CompactionResult` pattern (XML-wrapped JSON) so the kit has one consistent convention for structured LLM output.
+
+## Telling the model what shape to produce
+
+The middleware does **not** silently inject schema instructions. If you want the model to know the contract up front (and you almost always do — otherwise the first turn always fails the validation and burns a nudge), splice the rendered schema into your system prompt:
+
+```python
+from langgraph_kit.core.resilience import format_schema_instruction
+
+system_prompt = f"""You are a recipe agent.
+
+{format_schema_instruction(Recipe)}
+"""
+```
+
+`format_schema_instruction(schema)` returns the standard instruction text (asking for one `<output_schema>` block, includes the rendered JSON Schema). The same text is what the middleware sends in its retry nudge, so the model sees a consistent contract.
+
+## Retry behaviour
+
+- Terminal `AIMessage` with a tool call → middleware does nothing (the agent is mid-flow).
+- Terminal `AIMessage` with empty content → middleware does nothing (`EmptyTurnMiddleware` owns that case).
+- Valid block → success. Counter resets.
+- No block / malformed JSON / schema validation error → nudge with the schema rendered as JSON Schema. Counter increments.
+- After `max_nudges` (default 2) consecutive failures → middleware appends a single AIMessage explaining that validation gave up, and the run ends without further looping.
+
+## Reading the validated payload
+
+The middleware does not write the parsed model into graph state in this version — call the helper after the run:
+
+```python
+from langgraph_kit.core.resilience import parse_structured_output
+
+result = await graph.ainvoke({"messages": [HumanMessage("a 30-min taco recipe")]})
+final = result["messages"][-1]
+recipe = parse_structured_output(final.content, Recipe)
+if recipe is None:
+    # Validation gave up — final message is the explanatory AIMessage.
+    ...
+else:
+    print(recipe.minutes)
+```
+
+`parse_structured_output(content, schema)` returns the validated Pydantic instance or `None` on any failure. `extract_structured_output(content)` returns the raw JSON string for callers that want to handle parsing themselves.
+
+## Discovery
+
+`AgentMetadata.output_schema` carries the schema class so consumers can introspect what an agent produces. `langgraph_kit.registry.list_agents()` renders it as JSON Schema in the per-agent dict so external tools (admin UIs, OpenAPI exporters) can read the contract without importing pydantic.
+
+## Stack position
+
+`StructuredOutputMiddleware` slots into the standard middleware stack between `StopHooksMiddleware` and `PostRunBackstopMiddleware`. Empty-turn and completion-guard middlewares run first so the schema check only fires on a turn that actually has content.
+
+## Out of scope (for now)
+
+- **Provider-native `response_format`** — kit pattern is post-hoc validation; provider-native modes can be layered later if benchmarks justify them.
+- **Streaming structured outputs** — partial-JSON parsing during the streaming response.
+- **Schema versioning** — `output_schema` is per-deployment; bump the schema by bumping the agent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
     - Tool error: resilience/tool-error.md
     - Post-run: resilience/post-run.md
     - Graceful shutdown: resilience/graceful-shutdown.md
+    - Structured output: resilience/structured-output.md
   - HITL:
     - Overview: hitl/overview.md
     - Models: hitl/models.md

--- a/src/langgraph_kit/core/graph_builder/middleware.py
+++ b/src/langgraph_kit/core/graph_builder/middleware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from langgraph_kit.core.commands.dispatch import CommandDispatcher
 from langgraph_kit.core.commands.middleware import CommandMiddleware
@@ -25,9 +25,13 @@ from langgraph_kit.core.resilience import (
     PostRunBackstopMiddleware,
     RuntimeStateMiddleware,
     StopHooksMiddleware,
+    StructuredOutputMiddleware,
     ToolErrorMiddleware,
     ToolLoopGuardMiddleware,
 )
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 
 def build_middleware_stack(
@@ -38,6 +42,7 @@ def build_middleware_stack(
     command_dispatcher: CommandDispatcher | None = None,
     stop_hooks: list[Any] | None = None,
     tool_search_loop_threshold: int = DEFAULT_LOOP_THRESHOLD,
+    output_schema: type[BaseModel] | None = None,
 ) -> tuple[list[Any], PressureMonitor]:
     """Build the standard middleware stack shared by all deep agents.
 
@@ -51,6 +56,12 @@ def build_middleware_stack(
     ``tool_search_loop_threshold`` controls the soft loop-detection
     nudge emitted after ``N`` consecutive ``tool_search`` calls.
     Defaults to :data:`DEFAULT_LOOP_THRESHOLD`. Set to ``0`` to disable.
+
+    ``output_schema`` is opt-in: when a Pydantic model class is supplied,
+    a :class:`StructuredOutputMiddleware` is appended to validate the
+    agent's terminal message and retry on schema mismatch (capped). When
+    ``None`` (default), no validation middleware is added — agents that
+    return free-form text are unaffected.
     """
     middleware: list[Any] = []
 
@@ -79,8 +90,16 @@ def build_middleware_stack(
             EmptyTurnMiddleware(max_nudges=2),
             CompletionGuardMiddleware(min_tool_calls=1),
             StopHooksMiddleware(hooks=stop_hooks),
-            PostRunBackstopMiddleware(),
         ]
     )
+
+    # Structured-output validation slots after the empty-turn / completion
+    # guards (they ensure a turn exists at all) and before PostRunBackstop
+    # (the schema check is a richer terminal-state check than the backstop's
+    # generic last-resort message).
+    if output_schema is not None:
+        middleware.append(StructuredOutputMiddleware(schema=output_schema))
+
+    middleware.append(PostRunBackstopMiddleware())
 
     return middleware, pressure_monitor

--- a/src/langgraph_kit/core/resilience/__init__.py
+++ b/src/langgraph_kit/core/resilience/__init__.py
@@ -9,6 +9,12 @@ from .loop_guard import (
 from .post_run import PostRunBackstopMiddleware
 from .runtime_state import RuntimeStateMiddleware
 from .stop_hooks import StopHooksMiddleware
+from .structured_output import (
+    StructuredOutputMiddleware,
+    extract_structured_output,
+    format_schema_instruction,
+    parse_structured_output,
+)
 from .tool_error import ToolErrorMiddleware
 
 __all__ = [
@@ -18,6 +24,10 @@ __all__ = [
     "PostRunBackstopMiddleware",
     "RuntimeStateMiddleware",
     "StopHooksMiddleware",
+    "StructuredOutputMiddleware",
     "ToolErrorMiddleware",
     "ToolLoopGuardMiddleware",
+    "extract_structured_output",
+    "format_schema_instruction",
+    "parse_structured_output",
 ]

--- a/src/langgraph_kit/core/resilience/structured_output.py
+++ b/src/langgraph_kit/core/resilience/structured_output.py
@@ -1,0 +1,195 @@
+"""StructuredOutputMiddleware — validate the agent's final message against a Pydantic schema.
+
+Opt-in. When a schema is supplied, the middleware inspects the last
+``AIMessage`` after every model call. If it carries a tool call or no
+content, the middleware is a no-op (the agent is mid-flow). Otherwise
+it scans for a single ``<output_schema>{...}</output_schema>`` JSON
+block, parses it with the schema, and on failure injects a retry
+nudge that includes the JSON-Schema rendering of the model so the
+LLM has the contract in front of it.
+
+The convention mirrors the existing :class:`CompactionResult`
+prompt-and-parse pattern (XML-wrapped JSON), keeping the validation
+provider-agnostic — no provider-side ``response_format`` plumbing.
+
+There is no silent fallback to "free text is OK" — if the schema is
+configured, an unvalidated terminal message is treated as a failure
+and triggers a nudge, up to ``max_nudges``. After the cap is hit, the
+middleware appends a single ``[System: structured-output validation
+gave up after N attempts]`` AIMessage so callers see the final state
+explicitly rather than silently passing through.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, TypeVar
+
+from langchain.agents.middleware.types import AgentMiddleware as _AgentMiddleware
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel, ValidationError
+
+from langgraph_kit.core.resilience._message_text import aimessage_text
+
+_TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
+
+logger = logging.getLogger(__name__)
+
+# Single-block convention. Multiple <output_schema> blocks would be
+# ambiguous — take the *first* and document it; users hitting that case
+# should narrow their prompt.
+_OUTPUT_BLOCK_RE = re.compile(
+    r"<output_schema>\s*(.*?)\s*</output_schema>",
+    re.DOTALL,
+)
+
+
+def format_schema_instruction(schema: type[BaseModel]) -> str:
+    """Render schema instructions to splice into a system prompt.
+
+    Returns a prompt-ready string the user can interpolate into their
+    composed system prompt. The instruction tells the model to produce
+    a single ``<output_schema>{...}</output_schema>`` block matching
+    the schema. Free-form text outside the block is allowed (the model
+    can reason or cite before the structured payload).
+    """
+    schema_json = schema.model_json_schema()
+    return (
+        "When you are ready to produce your final answer, include a single "
+        "block of the form `<output_schema>{...}</output_schema>` whose "
+        "contents are valid JSON conforming to this schema:\n\n"
+        f"```json\n{json.dumps(schema_json, indent=2)}\n```\n\n"
+        "Anything outside that block is for human-readable narration and is "
+        "ignored by validators. Do not nest or repeat the block."
+    )
+
+
+def extract_structured_output(content: str) -> str | None:
+    """Pull the JSON inside ``<output_schema>...</output_schema>`` if present."""
+    match = _OUTPUT_BLOCK_RE.search(content)
+    if match is None:
+        return None
+    return match.group(1).strip() or None
+
+
+def parse_structured_output(
+    content: str, schema: type[_TBaseModel]
+) -> _TBaseModel | None:
+    """Extract + parse the schema-conformant block. Returns None on any failure.
+
+    Generic on the schema type so callers get back the concrete subclass
+    (``Recipe`` rather than ``BaseModel``), which keeps attribute access
+    type-checkable.
+    """
+    raw = extract_structured_output(content)
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    try:
+        return schema.model_validate(data)
+    except ValidationError:
+        return None
+
+
+class StructuredOutputMiddleware(_AgentMiddleware):  # type: ignore[misc]
+    """Validate the agent's terminal message against a Pydantic schema.
+
+    Skips when the last message is not an ``AIMessage`` or when the
+    message is mid-tool-call (the agent is still working). On a
+    terminal message that doesn't carry a parseable
+    ``<output_schema>`` block, injects a retry nudge with the schema
+    rendered as JSON Schema. Cap-based: after ``max_nudges`` failures,
+    appends a single explanatory message and returns control so the
+    run can terminate without looping.
+    """
+
+    def __init__(
+        self,
+        schema: type[BaseModel],
+        *,
+        max_nudges: int = 2,
+    ) -> None:
+        super().__init__()
+        self._schema = schema
+        self._max_nudges = max_nudges
+        self._nudge_count = 0
+
+    async def abefore_agent(self, state: Any, runtime: Any) -> None:  # noqa: ARG002
+        """Reset per-run nudge counter so the cap is per-invocation."""
+        self._nudge_count = 0
+
+    async def aafter_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:  # noqa: ARG002
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+
+        last = messages[-1]
+        if not isinstance(last, AIMessage):
+            return None
+
+        # Mid-tool-call → not a terminal turn yet.
+        if last.tool_calls:
+            return None
+
+        content = aimessage_text(last)
+        if not content.strip():
+            # An empty message will be handled by EmptyTurnMiddleware;
+            # piling another nudge on top would race that one and
+            # double-prompt the model.
+            return None
+
+        parsed = parse_structured_output(content, self._schema)
+        if parsed is not None:
+            self._nudge_count = 0
+            logger.info(
+                "Structured output validated against %s on attempt %d",
+                self._schema.__name__,
+                self._nudge_count + 1,
+            )
+            return None
+
+        self._nudge_count += 1
+        if self._nudge_count > self._max_nudges:
+            logger.warning(
+                "Structured-output validation failed after %d attempts; "
+                "giving up rather than looping",
+                self._max_nudges,
+            )
+            return {
+                "messages": [
+                    AIMessage(
+                        content=(
+                            f"[System: structured-output validation against "
+                            f"`{self._schema.__name__}` failed after "
+                            f"{self._max_nudges} retries; surfacing the last "
+                            f"unstructured response as-is.]"
+                        )
+                    )
+                ]
+            }
+
+        logger.info(
+            "Structured-output mismatch (nudge %d/%d); injecting retry with schema",
+            self._nudge_count,
+            self._max_nudges,
+        )
+        return {
+            "messages": [
+                HumanMessage(
+                    content=(
+                        "[System: your response did not contain a valid "
+                        f"`<output_schema>` block matching the "
+                        f"`{self._schema.__name__}` schema. Please respond "
+                        "again with a single block of the form "
+                        "`<output_schema>{...}</output_schema>` whose "
+                        "contents conform to this schema:]\n\n"
+                        + format_schema_instruction(self._schema)
+                    )
+                )
+            ]
+        }

--- a/src/langgraph_kit/graphs/_builder.py
+++ b/src/langgraph_kit/graphs/_builder.py
@@ -28,9 +28,12 @@ it to cap runaway loops in tests or evals. See :data:`DEFAULT_RECURSION_LIMIT`.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from langgraph_kit._config import get_config
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 from langgraph_kit.core.context_management.pressure import PressureMonitor
 from langgraph_kit.core.graph_builder.backend import build_backend_factory
 from langgraph_kit.core.graph_builder.commands import build_command_dispatcher
@@ -154,6 +157,7 @@ def build_deep_agent(
     plugins: PluginRegistry | list[PluginContribution] | None = None,
     conditions: set[str] | None = None,
     recursion_limit: int = DEFAULT_RECURSION_LIMIT,
+    output_schema: type[BaseModel] | None = None,
 ) -> tuple[Any, Any]:
     """Build a deep agent with the standard skeleton.
 
@@ -305,6 +309,7 @@ def build_deep_agent(
         command_dispatcher=command_dispatcher,
         stop_hooks=stop_hooks,
         tool_search_loop_threshold=tool_search_loop_threshold,
+        output_schema=output_schema,
     )
 
     # --- Compose system prompt ---

--- a/src/langgraph_kit/registry.py
+++ b/src/langgraph_kit/registry.py
@@ -19,6 +19,14 @@ class AgentMetadata(BaseModel):
     capabilities: list[str] = Field(default_factory=list)
     input_modes: list[str] = Field(default_factory=lambda: ["text/plain"])
     output_modes: list[str] = Field(default_factory=lambda: ["text/plain"])
+    # Optional structured-output contract. When set, the agent has
+    # opted into schema-validated final messages (enforced by
+    # ``StructuredOutputMiddleware``). Stored as ``Any`` so consumers
+    # can introspect via ``model_json_schema()`` without forcing a
+    # pydantic import on every metadata reader.
+    output_schema: Any = None
+
+    model_config = {"arbitrary_types_allowed": True}
 
 
 _registry: dict[str, Any] = {}
@@ -68,13 +76,16 @@ def list_agents() -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     for agent_id in _registry:
         meta = _metadata.get(agent_id, AgentMetadata())
-        result.append(
-            {
-                "id": agent_id,
-                "name": agent_id.replace("-", " ").title(),
-                "description": meta.description,
-                "tags": meta.tags,
-                "version": meta.version,
-            }
-        )
+        entry: dict[str, Any] = {
+            "id": agent_id,
+            "name": agent_id.replace("-", " ").title(),
+            "description": meta.description,
+            "tags": meta.tags,
+            "version": meta.version,
+        }
+        if meta.output_schema is not None:
+            # Render the schema as JSON Schema so consumers can document /
+            # validate without needing a pydantic import.
+            entry["output_schema"] = meta.output_schema.model_json_schema()
+        result.append(entry)
     return result

--- a/tests/test_structured_output_middleware.py
+++ b/tests/test_structured_output_middleware.py
@@ -1,0 +1,232 @@
+"""Coverage — StructuredOutputMiddleware validation + retry.
+
+Verifies the opt-in contract: when no schema is configured, no
+validation runs (caller compose-time choice). When a schema is given,
+the middleware:
+
+- skips messages that aren't terminal (tool calls in flight)
+- accepts a valid ``<output_schema>`` block
+- nudges with the schema rendered as JSON Schema on a missing block
+- nudges on malformed JSON
+- nudges on schema-mismatch JSON
+- gives up after ``max_nudges`` with a single explanatory AIMessage
+- resets the per-run counter via ``abefore_agent``
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel, Field
+
+from langgraph_kit.core.resilience import (
+    StructuredOutputMiddleware,
+    extract_structured_output,
+    format_schema_instruction,
+    parse_structured_output,
+)
+
+
+class _Recipe(BaseModel):
+    title: str = Field(..., min_length=1)
+    ingredients: list[str] = Field(..., min_length=1)
+    minutes: int = Field(..., ge=1)
+
+
+def _state(messages: list[Any]) -> dict[str, Any]:
+    return {"messages": list(messages)}
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_extract_structured_output_returns_block_contents() -> None:
+    text = 'thinking: this is fine\n<output_schema>{"a": 1}</output_schema>\nthe end'
+    assert extract_structured_output(text) == '{"a": 1}'
+
+
+def test_extract_structured_output_returns_none_when_missing() -> None:
+    assert extract_structured_output("no block here") is None
+
+
+def test_extract_structured_output_handles_multiline() -> None:
+    text = '<output_schema>\n{\n  "a": 1\n}\n</output_schema>'
+    extracted = extract_structured_output(text)
+    assert extracted is not None
+    assert json.loads(extracted) == {"a": 1}
+
+
+def test_parse_structured_output_returns_validated_instance() -> None:
+    text = (
+        '<output_schema>{"title": "tacos", "ingredients": ["corn", "beef"],'
+        ' "minutes": 30}</output_schema>'
+    )
+    parsed = parse_structured_output(text, _Recipe)
+    assert parsed is not None
+    assert parsed.title == "tacos"
+    assert parsed.minutes == 30
+
+
+def test_parse_structured_output_returns_none_on_validation_error() -> None:
+    # missing minutes
+    text = '<output_schema>{"title": "x", "ingredients": ["a"]}</output_schema>'
+    assert parse_structured_output(text, _Recipe) is None
+
+
+def test_parse_structured_output_returns_none_on_invalid_json() -> None:
+    text = "<output_schema>{not json}</output_schema>"
+    assert parse_structured_output(text, _Recipe) is None
+
+
+def test_format_schema_instruction_contains_schema_name_and_block_marker() -> None:
+    instruction = format_schema_instruction(_Recipe)
+    assert "<output_schema>" in instruction
+    assert "</output_schema>" in instruction
+    # The JSON Schema rendering should mention the model fields somewhere.
+    assert "ingredients" in instruction
+    assert "minutes" in instruction
+
+
+# ---------------------------------------------------------------------------
+# Middleware behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_through_when_message_has_tool_calls() -> None:
+    mw = StructuredOutputMiddleware(_Recipe)
+    msg = AIMessage(content="", tool_calls=[{"id": "1", "name": "t", "args": {}}])
+    result = await mw.aafter_model(_state([msg]), runtime=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_through_when_message_is_empty() -> None:
+    """EmptyTurnMiddleware owns empty-message nudges; this middleware defers."""
+    mw = StructuredOutputMiddleware(_Recipe)
+    msg = AIMessage(content="   ")
+    result = await mw.aafter_model(_state([msg]), runtime=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_through_on_non_ai_message() -> None:
+    mw = StructuredOutputMiddleware(_Recipe)
+    msg = HumanMessage(content='<output_schema>{"x": 1}</output_schema>')
+    result = await mw.aafter_model(_state([msg]), runtime=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_through_when_messages_empty() -> None:
+    mw = StructuredOutputMiddleware(_Recipe)
+    result = await mw.aafter_model(_state([]), runtime=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_returns_none_on_valid_block() -> None:
+    mw = StructuredOutputMiddleware(_Recipe)
+    payload = {"title": "tacos", "ingredients": ["beef", "corn"], "minutes": 30}
+    msg = AIMessage(
+        content=f"answer: <output_schema>{json.dumps(payload)}</output_schema>"
+    )
+    result = await mw.aafter_model(_state([msg]), runtime=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_nudges_when_block_missing() -> None:
+    mw = StructuredOutputMiddleware(_Recipe, max_nudges=2)
+    msg = AIMessage(content="here is my answer with no schema block")
+    result = await mw.aafter_model(_state([msg]), runtime=None)
+    assert result is not None
+    nudge = result["messages"][-1]
+    assert isinstance(nudge, HumanMessage)
+    assert "_Recipe" in str(nudge.content) or "Recipe" in str(nudge.content)
+    assert "<output_schema>" in str(nudge.content)
+
+
+@pytest.mark.asyncio
+async def test_middleware_nudges_on_schema_mismatch() -> None:
+    mw = StructuredOutputMiddleware(_Recipe, max_nudges=2)
+    # Missing required field "minutes".
+    msg = AIMessage(
+        content='<output_schema>{"title": "x", "ingredients": ["a"]}</output_schema>'
+    )
+    result = await mw.aafter_model(_state([msg]), runtime=None)
+    assert result is not None
+    assert isinstance(result["messages"][-1], HumanMessage)
+
+
+@pytest.mark.asyncio
+async def test_middleware_gives_up_after_max_nudges() -> None:
+    mw = StructuredOutputMiddleware(_Recipe, max_nudges=2)
+    msg = AIMessage(content="no schema block here")
+
+    # First two attempts produce nudges.
+    r1 = await mw.aafter_model(_state([msg]), runtime=None)
+    r2 = await mw.aafter_model(_state([msg]), runtime=None)
+    assert r1 is not None
+    assert r2 is not None
+    assert isinstance(r1["messages"][-1], HumanMessage)
+    assert isinstance(r2["messages"][-1], HumanMessage)
+
+    # Third attempt → give-up message (an AIMessage explaining the failure)
+    # rather than another HumanMessage retry.
+    r3 = await mw.aafter_model(_state([msg]), runtime=None)
+    assert r3 is not None
+    final = r3["messages"][-1]
+    assert isinstance(final, AIMessage)
+    assert "validation" in str(final.content).lower()
+    assert "_Recipe" in str(final.content) or "Recipe" in str(final.content)
+
+
+@pytest.mark.asyncio
+async def test_middleware_resets_counter_on_before_agent() -> None:
+    """A reused middleware must not accumulate nudges across runs."""
+    mw = StructuredOutputMiddleware(_Recipe, max_nudges=1)
+    msg = AIMessage(content="no block")
+
+    # Burn the budget in run 1.
+    _ = await mw.aafter_model(_state([msg]), runtime=None)
+    give_up = await mw.aafter_model(_state([msg]), runtime=None)
+    assert give_up is not None
+    assert isinstance(give_up["messages"][-1], AIMessage)
+
+    # Reset for run 2.
+    await mw.abefore_agent(_state([]), runtime=None)
+
+    # Run 2 should nudge fresh (HumanMessage), not the give-up AIMessage.
+    fresh = await mw.aafter_model(_state([msg]), runtime=None)
+    assert fresh is not None
+    assert isinstance(fresh["messages"][-1], HumanMessage)
+
+
+@pytest.mark.asyncio
+async def test_middleware_resets_counter_on_valid_response() -> None:
+    """A valid response between failures resets the nudge counter."""
+    mw = StructuredOutputMiddleware(_Recipe, max_nudges=1)
+    bad = AIMessage(content="no block")
+    good_payload = {"title": "x", "ingredients": ["a"], "minutes": 5}
+    good = AIMessage(
+        content=f"<output_schema>{json.dumps(good_payload)}</output_schema>"
+    )
+
+    # First failure: nudge. Counter = 1 (== max_nudges, not exceeded).
+    r1 = await mw.aafter_model(_state([bad]), runtime=None)
+    assert r1 is not None
+    assert isinstance(r1["messages"][-1], HumanMessage)
+
+    # Valid response resets counter.
+    assert await mw.aafter_model(_state([good]), runtime=None) is None
+
+    # Now a fresh failure should still get a nudge, not give-up.
+    r2 = await mw.aafter_model(_state([bad]), runtime=None)
+    assert r2 is not None
+    assert isinstance(r2["messages"][-1], HumanMessage)


### PR DESCRIPTION
## Summary

- New `StructuredOutputMiddleware` validates the agent's terminal `AIMessage` against a Pydantic schema and retries on mismatch, capped at 2 nudges. Provider-agnostic post-hoc validation (matches the existing `CompactionResult` pattern), no `response_format` plumbing.
- Wire format: one `<output_schema>{...}</output_schema>` block in the response; free-form text outside the block is allowed.
- Opt-in via `build_deep_agent(output_schema=Recipe)` or `AgentMetadata.output_schema`. No silent behaviour change for existing agents.
- Helpers: `format_schema_instruction(schema)` for prompt composition, `extract_structured_output(content)` and `parse_structured_output(content, schema)` for post-run extraction.
- Skips mid-tool-call and empty messages (`EmptyTurnMiddleware` owns the latter).
- After `max_nudges` failures, appends a single AIMessage explaining the validation give-up and stops looping.

## Test plan

- [x] 17 new cases in `tests/test_structured_output_middleware.py` covering helper functions, middleware pass-through (tool calls / empty / non-AIMessage / empty messages), valid acceptance, missing-block / malformed-JSON / schema-mismatch nudges, give-up after cap, counter reset on `abefore_agent`, counter reset on a valid response between failures.
- [x] Full suite: 914 passed (was 897).
- [x] ruff / basedpyright / pre-commit clean.

## Plan comment

Design contract written up front on the issue: https://github.com/allada-homelab/langgraph-kit/issues/17#issuecomment-4317170794

Fixes #17