### PR TITLE
Wire up four orphaned ToolCapability contracts (a, b, c, e from #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Wire up four `ToolCapability` orphan fields.** Three previously-advisory
+  fields are now enforced by bundled middleware (Fixes
+  [#6](https://github.com/allada-homelab/langgraph-kit/issues/6)):
+  - `max_output_chars` (new field) — per-tool override of
+    `ResultPersistenceMiddleware`'s threshold so chatty tools (`read_file`)
+    can declare their own caps. The legacy `max_output_tokens` is kept as
+    an advisory hint for caller-supplied tokenizer-aware middleware.
+  - `offload_large_results` — `ResultPersistenceMiddleware` now consults
+    the flag; setting `False` opts the tool out of persistence regardless
+    of size. **Default flipped from `False` to `True`** (see Changed).
+  - `interrupt_before` — new `AutoInterruptMiddleware` (in
+    `core.hitl.auto_interrupt`) auto-pauses for HITL approval before any
+    tool whose capability declares this flag. Coexists with the manual
+    `approve_action` tool: use `interrupt_before` for tools whose risk is
+    intrinsic, `approve_action` when the agent should decide whether to
+    ask.
+  - `coordinator=True` keyword on `build_deep_agent` wires `CoordinatorMode`
+    (was previously unreachable from the public builder): narrows the tool
+    surface to `ToolRisk.READ_ONLY`, merges coordinator prompt sections,
+    and activates the `coordinator` / `orchestration` section conditions.
+  - The `SkillMetadata.allowed_tools` re-add is deferred — it depends on
+    `#7` (active skill state) and re-adding the field without that
+    plumbing would re-introduce the same dead-contract problem.
+
+### Changed
+
+- **`ToolCapability.offload_large_results` default flipped from `False`
+  to `True`** to match the expected meaning of the flag now that
+  `ResultPersistenceMiddleware` honors it. Pre-flip the field was an
+  ignored hint; callers who set `False` explicitly now get the opt-out
+  behaviour they were trying to express. Callers who relied on the
+  silent default see no behaviour change for over-threshold results
+  (which were already being persisted unconditionally).
+
 - **Opt-in structured-output validation via `StructuredOutputMiddleware`.**
   Pass `output_schema=` to `build_deep_agent` and the agent's terminal
   `AIMessage` is validated against your Pydantic schema. The model is

--- a/src/langgraph_kit/core/context_management/result_persistence.py
+++ b/src/langgraph_kit/core/context_management/result_persistence.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import AgentMiddleware
 
 from langgraph_kit.core.tools.result_retrieval import tool_results_namespace
+
+if TYPE_CHECKING:
+    from langgraph_kit.core.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -22,10 +25,17 @@ DEFAULT_PREVIEW_LENGTH = 300
 class ResultPersistenceMiddleware(AgentMiddleware):  # type: ignore[misc]
     """Persists large tool results to Store, replaces with compact preview + reference.
 
-    When a tool returns a result larger than `persist_threshold` chars:
+    When a tool returns a result larger than the effective threshold:
     1. Persists the full result to Store under ("tool_results", thread_id)
     2. Replaces the inline result with a preview + retrieval reference
     3. The agent can later retrieve the full result using the retrieve tool
+
+    The threshold is per-tool when ``ToolCapability.max_output_chars`` is
+    set (look-up via the optional ``tool_registry`` constructor arg), and
+    falls back to the middleware's ``persist_threshold`` otherwise. A
+    tool can opt out of persistence entirely by setting
+    ``offload_large_results=False`` on its capability — the result then
+    stays inline regardless of size.
 
     Namespacing by thread_id prevents cross-thread reads of persisted refs.
     """
@@ -34,10 +44,13 @@ class ResultPersistenceMiddleware(AgentMiddleware):  # type: ignore[misc]
         self,
         persist_threshold: int = DEFAULT_PERSIST_THRESHOLD,
         preview_length: int = DEFAULT_PREVIEW_LENGTH,
+        *,
+        tool_registry: ToolRegistry | None = None,
     ) -> None:
         super().__init__()
         self._threshold = persist_threshold
         self._preview_length = preview_length
+        self._tool_registry = tool_registry
 
     async def awrap_tool_call(self, request: Any, handler: Any) -> Any:
         """Execute tool, then persist and replace if result is large."""
@@ -45,7 +58,29 @@ class ResultPersistenceMiddleware(AgentMiddleware):  # type: ignore[misc]
 
         # Only process ToolMessage results with string content
         content = getattr(result, "content", None)
-        if not isinstance(content, str) or len(content) <= self._threshold:
+        if not isinstance(content, str):
+            return result
+
+        # Per-tool overrides on the capability, when a registry is wired in.
+        tool_name = request.tool_call.get("name", "unknown")
+        cap = (
+            self._tool_registry.find_by_tool_name(tool_name)
+            if self._tool_registry is not None
+            else None
+        )
+
+        # offload_large_results=False on the capability is an explicit
+        # opt-out: keep the result inline regardless of size.
+        if cap is not None and not cap.offload_large_results:
+            return result
+
+        # Effective threshold: per-tool override beats the middleware default.
+        effective_threshold = (
+            cap.max_output_chars
+            if cap is not None and cap.max_output_chars is not None
+            else self._threshold
+        )
+        if len(content) <= effective_threshold:
             return result
 
         # Persist to store
@@ -53,7 +88,6 @@ class ResultPersistenceMiddleware(AgentMiddleware):  # type: ignore[misc]
         if store is None:
             return result  # No store available, leave inline
 
-        tool_name = request.tool_call.get("name", "unknown")
         tool_call_id = request.tool_call.get("id", "")
         result_key = hashlib.sha256(f"{tool_call_id}:{tool_name}".encode()).hexdigest()[
             :16

--- a/src/langgraph_kit/core/coordinator.py
+++ b/src/langgraph_kit/core/coordinator.py
@@ -1,14 +1,11 @@
 """Coordinator mode — supervisor profile emphasizing orchestration over direct execution.
 
-.. note::
-    This module is **not wired into any shipped graph**. It defines
-    reusable prompt sections and a tool-surface narrowing helper for
-    callers that want to build a coordinator/delegation profile
-    themselves. See ``CoordinatorMode.get_conditions()`` for the
-    condition keys that must be passed into
-    ``SectionRegistry.get_active`` for the sections to appear. If the
-    kit later adds a shipped coordinator agent this note should be
-    removed.
+Wire into any deep agent by passing ``coordinator=True`` to
+:func:`langgraph_kit.graphs.build_deep_agent` — the kit then narrows
+the tool surface to ``ToolRisk.READ_ONLY``, merges the coordinator
+prompt sections, and activates the ``coordinator`` /
+``orchestration`` section conditions. Plugin-contributed tools still
+flow through, subject to the same read-only filter.
 """
 
 from __future__ import annotations

--- a/src/langgraph_kit/core/graph_builder/middleware.py
+++ b/src/langgraph_kit/core/graph_builder/middleware.py
@@ -13,6 +13,7 @@ from langgraph_kit.core.context_management.pressure_middleware import (
 from langgraph_kit.core.context_management.result_persistence import (
     ResultPersistenceMiddleware,
 )
+from langgraph_kit.core.hitl import AutoInterruptMiddleware
 from langgraph_kit.core.memory.extraction import AutoMemoryExtractor
 from langgraph_kit.core.memory.extraction_middleware import ExtractionMiddleware
 from langgraph_kit.core.memory.models import MemoryScope
@@ -33,6 +34,8 @@ from langgraph_kit.core.resilience import (
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
+    from langgraph_kit.core.tools.registry import ToolRegistry
+
 
 def build_middleware_stack(
     *,
@@ -43,6 +46,7 @@ def build_middleware_stack(
     stop_hooks: list[Any] | None = None,
     tool_search_loop_threshold: int = DEFAULT_LOOP_THRESHOLD,
     output_schema: type[BaseModel] | None = None,
+    tool_registry: ToolRegistry | None = None,
 ) -> tuple[list[Any], PressureMonitor]:
     """Build the standard middleware stack shared by all deep agents.
 
@@ -74,6 +78,12 @@ def build_middleware_stack(
             RuntimeStateMiddleware(),
             QueuedInputMiddleware(),
             ToolErrorMiddleware(max_retries=1),
+            # Auto-interrupt sits BEFORE the tool runs, so it has to be
+            # outermost on the tool-wrapping side after the error wrap
+            # (errors happen during execution; the interrupt prevents
+            # execution entirely). Tools without ``interrupt_before``
+            # set on their capability pass through unchanged.
+            AutoInterruptMiddleware(tool_registry=tool_registry),
             # Loop guard wraps tool calls BEFORE ResultPersistence so the
             # advisory appears in the full-text content rather than in
             # the persisted preview, and the model sees it on its next
@@ -83,7 +93,7 @@ def build_middleware_stack(
                 threshold=tool_search_loop_threshold,
             ),
             PressureMiddleware(pressure_monitor, llm=llm),
-            ResultPersistenceMiddleware(),
+            ResultPersistenceMiddleware(tool_registry=tool_registry),
             ExtractionMiddleware(
                 AutoMemoryExtractor(memory_mgr, llm), scope=MemoryScope.USER
             ),

--- a/src/langgraph_kit/core/hitl/__init__.py
+++ b/src/langgraph_kit/core/hitl/__init__.py
@@ -1,5 +1,6 @@
 """Human-in-the-loop — interrupt-based approval for tool calls."""
 
+from .auto_interrupt import AutoInterruptMiddleware
 from .models import (
     ActionRequest,
     HumanInterrupt,
@@ -12,6 +13,7 @@ from .tools import build_approve_action_tool
 
 __all__ = [
     "ActionRequest",
+    "AutoInterruptMiddleware",
     "HumanInterrupt",
     "HumanInterruptConfig",
     "HumanResponse",

--- a/src/langgraph_kit/core/hitl/auto_interrupt.py
+++ b/src/langgraph_kit/core/hitl/auto_interrupt.py
@@ -1,0 +1,125 @@
+"""AutoInterruptMiddleware — capability-driven HITL gating before tool calls.
+
+Pairs with ``ToolCapability.interrupt_before``: when a tool's
+capability is registered with ``interrupt_before=True``, this
+middleware pauses the graph via LangGraph's ``interrupt()`` *before*
+the tool's handler runs. The user's resume payload decides whether to
+proceed or skip the tool with an explanatory ``ToolMessage``.
+
+Coexists with the manual ``approve_action`` tool — both can be used
+together. Use ``interrupt_before`` for tools whose risk is intrinsic
+(e.g. ``delete_file``, ``git_push``); use ``approve_action`` when the
+agent should *decide* whether to ask, based on context.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import ToolMessage
+
+if TYPE_CHECKING:
+    from langgraph_kit.core.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _interpret_resume(response: Any) -> tuple[bool, str]:
+    """Map a HumanResponse-like payload to ``(approved, reason)``.
+
+    Mirrors the convention in ``hitl.tools._format_response`` but
+    returns a structured outcome the middleware can act on without
+    rendering text.
+    """
+    if isinstance(response, list):
+        response = response[0] if response else {}
+    if not isinstance(response, dict):
+        return (True, "")  # Unknown shape — fail open rather than block work.
+
+    rtype = response.get("type")
+    args = response.get("args")
+
+    if rtype == "accept":
+        return (True, "")
+    if rtype == "ignore":
+        return (False, "User chose to skip the action.")
+    if rtype == "response":
+        msg = args if isinstance(args, str) else str(args or "")
+        return (
+            False,
+            f"User rejected the action: {msg}" if msg else "User rejected the action.",
+        )
+    if rtype == "edit":
+        # We don't currently apply edits to tool args here — caller can
+        # use ``approve_action`` for edit-style flows. Treat as a reject
+        # with the edited intent surfaced as the reason so the agent can
+        # pivot rather than retry the original args.
+        return (False, f"User edited the action; original was rejected: {args!r}")
+
+    return (True, "")
+
+
+class AutoInterruptMiddleware(AgentMiddleware):  # type: ignore[misc]
+    """Auto-interrupt before tools whose capability declares
+    ``interrupt_before=True``.
+
+    Skips silently if no registry is wired in or the tool has no
+    capability registered (in which case the middleware can't know the
+    risk profile). Tools without ``interrupt_before`` set proceed
+    normally.
+    """
+
+    def __init__(self, *, tool_registry: ToolRegistry | None = None) -> None:
+        super().__init__()
+        self._tool_registry = tool_registry
+
+    async def awrap_tool_call(self, request: Any, handler: Any) -> Any:
+        if self._tool_registry is None:
+            return await handler(request)
+
+        tool_name = request.tool_call.get("name", "")
+        cap = self._tool_registry.find_by_tool_name(tool_name)
+        if cap is None or not cap.interrupt_before:
+            return await handler(request)
+
+        # Lazy import — only this module needs the langgraph runtime API.
+        from langgraph.types import (
+            interrupt,  # pyright: ignore[reportMissingModuleSource]
+        )
+
+        tool_args = request.tool_call.get("args", {}) or {}
+        logger.info(
+            "AutoInterruptMiddleware: pausing for HITL approval before %s",
+            tool_name,
+        )
+        response = interrupt(
+            {
+                "action_request": {"action": tool_name, "args": tool_args},
+                "config": {
+                    "allow_ignore": True,
+                    "allow_respond": True,
+                    "allow_accept": True,
+                    "allow_edit": False,
+                },
+                "description": (
+                    cap.description
+                    or f"The agent is about to call `{tool_name}`. Approve to proceed."
+                ),
+            }
+        )
+        approved, reason = _interpret_resume(response)
+        if approved:
+            return await handler(request)
+
+        # Reject path — return a ToolMessage so the agent can adjust
+        # rather than crashing the run. Match the failing-tool error
+        # shape so models that have seen those messages handle this
+        # gracefully.
+        tool_call_id = request.tool_call.get("id", "")
+        return ToolMessage(
+            content=f"Tool call rejected by user. {reason}".strip(),
+            tool_call_id=tool_call_id,
+            name=tool_name,
+        )

--- a/src/langgraph_kit/core/tools/capability.py
+++ b/src/langgraph_kit/core/tools/capability.py
@@ -19,15 +19,21 @@ class ToolRisk(StrEnum):
 class ToolCapability(BaseModel):
     """Rich tool capability with metadata beyond a simple callable.
 
-    .. note::
-        ``max_output_tokens``, ``offload_large_results``, and
-        ``interrupt_before`` are **advisory hints** — no kit middleware
-        currently enforces them. They're retained for callers that wire
-        their own enforcement. ``ResultPersistenceMiddleware`` uses its
-        own threshold constants (not ``offload_large_results``) and HITL
-        gating is triggered by tool name rather than by
-        ``interrupt_before``. If you set one of these fields, you're
-        responsible for acting on it.
+    Several fields are now *enforced* by bundled middleware:
+
+    - ``max_output_chars`` — honored by
+      :class:`ResultPersistenceMiddleware`; per-tool override of the
+      middleware's default character threshold.
+    - ``offload_large_results`` — honored by
+      :class:`ResultPersistenceMiddleware`; ``False`` opts the tool out
+      of persistence regardless of size.
+    - ``interrupt_before`` — honored by
+      :class:`AutoInterruptMiddleware`; ``True`` triggers HITL gating
+      before the tool runs.
+
+    ``max_output_tokens`` is retained as an advisory hint for callers
+    layering tokenizer-aware middleware (the bundled middleware caps in
+    characters to stay provider-agnostic, see ``max_output_chars``).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -41,7 +47,19 @@ class ToolCapability(BaseModel):
     prompt_guidance: str | None = None
     profiles: list[str] | None = None
     worker_types: list[str] | None = None
-    # Advisory hints — see class docstring. Not enforced by the kit.
+    # Advisory hint for caller-supplied tokenizer-aware middleware.
     max_output_tokens: int | None = None
-    offload_large_results: bool = False
+    # Enforced by ResultPersistenceMiddleware: per-tool override of the
+    # character threshold for "large enough to persist". None = use the
+    # middleware's default.
+    max_output_chars: int | None = None
+    # Enforced by ResultPersistenceMiddleware. True (default) = persist
+    # this tool's results when over threshold; False = always inline,
+    # regardless of size. Default flipped from False to True in 1.1: the
+    # previous default was a no-op (the field was advisory) so callers
+    # who set it to False explicitly now get the opt-out behaviour they
+    # were trying to express.
+    offload_large_results: bool = True
+    # Enforced by AutoInterruptMiddleware. True = HITL approval prompt
+    # before the tool runs.
     interrupt_before: bool = False

--- a/src/langgraph_kit/core/tools/registry.py
+++ b/src/langgraph_kit/core/tools/registry.py
@@ -35,6 +35,21 @@ class ToolRegistry:
     def get(self, tool_id: str) -> ToolCapability | None:
         return self._tools.get(tool_id)
 
+    def find_by_tool_name(self, name: str) -> ToolCapability | None:
+        """Look up a capability by the LLM-visible tool name.
+
+        Tool names (the function ``__name__``, e.g. ``save_memory``) are
+        what appear in ``tool_call["name"]``. Capability ``id`` values
+        are typically prefixed (e.g. ``memory.save_memory``) so the id
+        lookup ``.get()`` does not match. This helper closes that gap
+        for middleware that needs to consult a capability based on the
+        tool the model just called.
+        """
+        for cap in self._tools.values():
+            if cap.name == name:
+                return cap
+        return None
+
     def remove(self, tool_id: str) -> None:
         self._tools.pop(tool_id, None)
 

--- a/src/langgraph_kit/graphs/_builder.py
+++ b/src/langgraph_kit/graphs/_builder.py
@@ -158,6 +158,7 @@ def build_deep_agent(
     conditions: set[str] | None = None,
     recursion_limit: int = DEFAULT_RECURSION_LIMIT,
     output_schema: type[BaseModel] | None = None,
+    coordinator: bool = False,
 ) -> tuple[Any, Any]:
     """Build a deep agent with the standard skeleton.
 
@@ -310,6 +311,7 @@ def build_deep_agent(
         stop_hooks=stop_hooks,
         tool_search_loop_threshold=tool_search_loop_threshold,
         output_schema=output_schema,
+        tool_registry=tool_registry,
     )
 
     # --- Compose system prompt ---
@@ -366,12 +368,29 @@ def build_deep_agent(
     if plugin_registry is not None:
         merged_subagents.extend(plugin_registry.collect_workers())
 
+    # Coordinator profile narrows the tool surface to read-only and adds
+    # delegation prompt sections (CoordinatorMode.get_coordinator_tools()
+    # filters by ToolRisk.READ_ONLY, so plugin tools survive subject to
+    # the same risk filter as standard tools).
+    if coordinator:
+        from langgraph_kit.core.coordinator import CoordinatorMode
+
+        coord = CoordinatorMode(tool_registry)
+        compiled_tools = coord.get_coordinator_tools()
+        # Append coordinator prompt sections before re-rendering the
+        # system prompt so they're folded into the same composition pass.
+        section_registry.register_many(coord.get_coordinator_sections())
+        active_conditions |= coord.get_conditions()
+        system_prompt = composer.compose_sections_only(conditions=active_conditions)
+    else:
+        compiled_tools = tool_registry.compile_tools()
+
     # ``subagents`` is a list of dict-shaped specs (deepagents accepts both
     # the typed ``SubAgent`` dataclass and the dict form at runtime, but
     # the stub only types the dataclass path).
     graph = _create(
         model=llm,
-        tools=tool_registry.compile_tools(),
+        tools=compiled_tools,
         system_prompt=system_prompt,
         middleware=middleware,
         subagents=merged_subagents,  # pyright: ignore[reportArgumentType]

--- a/tests/test_orphaned_contracts_wired.py
+++ b/tests/test_orphaned_contracts_wired.py
@@ -1,0 +1,433 @@
+"""Coverage — issue #6 wiring up of orphaned ToolCapability fields.
+
+Three previously-advisory fields are now enforced by bundled middleware:
+
+- ``max_output_chars`` — per-tool override of the persistence threshold
+- ``offload_large_results`` — opt-out of persistence regardless of size
+- ``interrupt_before`` — auto-HITL pause before the tool runs
+
+Plus a wiring smoke test for ``coordinator=True`` on
+``build_deep_agent`` (the helper used to be unreachable from the
+public builder).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from langgraph_kit.core.context_management.result_persistence import (
+    ResultPersistenceMiddleware,
+)
+from langgraph_kit.core.hitl import AutoInterruptMiddleware
+from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
+from langgraph_kit.core.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Test fixtures: minimal stand-ins for the runtime objects the middlewares need
+# ---------------------------------------------------------------------------
+
+
+class _Runtime:
+    def __init__(
+        self, store: Any | None = None, thread_id: str = "test-thread"
+    ) -> None:
+        super().__init__()
+        self.store = store
+        self.config = {"configurable": {"thread_id": thread_id}}
+
+
+class _Request:
+    def __init__(
+        self, tool_name: str, *, runtime: _Runtime, args: dict[str, Any] | None = None
+    ) -> None:
+        super().__init__()
+        self.tool_call: dict[str, Any] = {
+            "id": "tc-1",
+            "name": tool_name,
+            "args": args or {},
+        }
+        self.runtime = runtime
+
+
+class _SpyStore:
+    """In-memory async-style store; records aput calls so tests can assert on them."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.puts: list[tuple[Any, str, dict[str, Any]]] = []
+
+    async def aput(
+        self, namespace: tuple[str, ...], key: str, value: dict[str, Any]
+    ) -> None:
+        self.puts.append((namespace, key, value))
+
+    async def adelete(self, namespace: tuple[str, ...], key: str) -> None:
+        # Used by middleware rollback path — irrelevant for these tests.
+        _ = namespace, key
+
+
+def _make_tool_message(content: str) -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id="tc-1", name="dummy")
+
+
+def _registry_with(*caps: ToolCapability) -> ToolRegistry:
+    reg = ToolRegistry()
+    for cap in caps:
+        reg.register(cap)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# (a) max_output_chars — per-tool threshold override
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_tool_max_output_chars_truncates_earlier_than_default() -> None:
+    """A tool with `max_output_chars=200` persists a 300-char result while
+    a tool without the override stays inline (because 300 < default 4000)."""
+    cap = ToolCapability(
+        id="chatty.read_file",
+        name="read_file",
+        description="reads a file",
+        fn=lambda: None,
+        max_output_chars=200,
+    )
+    store = _SpyStore()
+    mw = ResultPersistenceMiddleware(tool_registry=_registry_with(cap))
+
+    big = "x" * 300
+    runtime = _Runtime(store=store)
+    request = _Request("read_file", runtime=runtime)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return _make_tool_message(big)
+
+    result = await mw.awrap_tool_call(request, handler)
+    # The result should have been persisted (one aput call).
+    assert len(store.puts) == 1, f"expected one persistence write, got {store.puts!r}"
+    # The replacement content carries a [Full result persisted ... ref:] note.
+    assert "Full result persisted" in str(result.content)
+
+
+@pytest.mark.asyncio
+async def test_default_threshold_used_when_no_per_tool_override() -> None:
+    """Tool without ``max_output_chars`` falls back to the middleware default;
+    a 300-char result is well under that and should stay inline."""
+    cap = ToolCapability(
+        id="quiet.echo",
+        name="echo",
+        description="echoes",
+        fn=lambda: None,
+    )
+    store = _SpyStore()
+    mw = ResultPersistenceMiddleware(tool_registry=_registry_with(cap))
+
+    runtime = _Runtime(store=store)
+    request = _Request("echo", runtime=runtime)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return _make_tool_message("x" * 300)
+
+    result = await mw.awrap_tool_call(request, handler)
+    assert store.puts == []
+    assert result.content == "x" * 300
+
+
+@pytest.mark.asyncio
+async def test_no_registry_falls_back_to_default_threshold() -> None:
+    """When no registry is wired, behavior matches pre-change default."""
+    store = _SpyStore()
+    mw = ResultPersistenceMiddleware()
+
+    runtime = _Runtime(store=store)
+    request = _Request("echo", runtime=runtime)
+
+    async def handler(_req: Any) -> ToolMessage:
+        # Just over the 4000-char default → should persist.
+        return _make_tool_message("x" * 4001)
+
+    result = await mw.awrap_tool_call(request, handler)
+    assert len(store.puts) == 1
+    assert "Full result persisted" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
+# (b) offload_large_results — opt-out of persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_offload_false_keeps_result_inline_regardless_of_size() -> None:
+    """A tool with ``offload_large_results=False`` should never persist."""
+    cap = ToolCapability(
+        id="opt_out.tool",
+        name="tool_a",
+        description="opted out",
+        fn=lambda: None,
+        offload_large_results=False,
+    )
+    store = _SpyStore()
+    mw = ResultPersistenceMiddleware(tool_registry=_registry_with(cap))
+
+    big = "x" * 10_000  # well over default 4000 threshold
+    runtime = _Runtime(store=store)
+    request = _Request("tool_a", runtime=runtime)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return _make_tool_message(big)
+
+    result = await mw.awrap_tool_call(request, handler)
+    assert store.puts == []
+    assert result.content == big
+
+
+@pytest.mark.asyncio
+async def test_offload_true_persists_when_over_threshold() -> None:
+    cap = ToolCapability(
+        id="opted_in.tool",
+        name="tool_b",
+        description="opted in",
+        fn=lambda: None,
+        offload_large_results=True,
+    )
+    store = _SpyStore()
+    mw = ResultPersistenceMiddleware(tool_registry=_registry_with(cap))
+
+    runtime = _Runtime(store=store)
+    request = _Request("tool_b", runtime=runtime)
+
+    async def handler(_req: Any) -> ToolMessage:
+        return _make_tool_message("x" * 5000)
+
+    result = await mw.awrap_tool_call(request, handler)
+    assert len(store.puts) == 1
+    assert "Full result persisted" in str(result.content)
+
+
+def test_default_offload_large_results_is_true() -> None:
+    """Default flipped from False to True in #6 to honor the field for
+    persisted-by-default tools. Documented as a Changed entry."""
+    cap = ToolCapability(
+        id="default.tool",
+        name="default_tool",
+        description="defaults",
+        fn=lambda: None,
+    )
+    assert cap.offload_large_results is True
+
+
+# ---------------------------------------------------------------------------
+# (c) AutoInterruptMiddleware — capability-driven HITL gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_interrupt_passes_through_when_flag_unset() -> None:
+    cap = ToolCapability(
+        id="safe.tool",
+        name="safe_tool",
+        description="harmless",
+        fn=lambda: None,
+        interrupt_before=False,
+    )
+    mw = AutoInterruptMiddleware(tool_registry=_registry_with(cap))
+
+    handler_called = False
+
+    async def handler(_req: Any) -> ToolMessage:
+        nonlocal handler_called
+        handler_called = True
+        return _make_tool_message("ok")
+
+    runtime = _Runtime()
+    request = _Request("safe_tool", runtime=runtime)
+    result = await mw.awrap_tool_call(request, handler)
+    assert handler_called is True
+    assert result.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_auto_interrupt_passes_through_when_no_registry() -> None:
+    """No registry means we can't know the risk profile; fail open."""
+    mw = AutoInterruptMiddleware(tool_registry=None)
+
+    handler_called = False
+
+    async def handler(_req: Any) -> ToolMessage:
+        nonlocal handler_called
+        handler_called = True
+        return _make_tool_message("ok")
+
+    runtime = _Runtime()
+    request = _Request("any_tool", runtime=runtime)
+    await mw.awrap_tool_call(request, handler)
+    assert handler_called is True
+
+
+@pytest.mark.asyncio
+async def test_auto_interrupt_pauses_and_proceeds_on_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``interrupt_before=True`` and the user accepts, the tool runs."""
+    cap = ToolCapability(
+        id="risky.delete",
+        name="delete_thing",
+        description="deletes a thing",
+        fn=lambda: None,
+        risk=ToolRisk.DESTRUCTIVE,
+        interrupt_before=True,
+    )
+    mw = AutoInterruptMiddleware(tool_registry=_registry_with(cap))
+
+    captured: list[Any] = []
+
+    def fake_interrupt(payload: Any) -> Any:
+        captured.append(payload)
+        return {"type": "accept"}
+
+    import langgraph.types as lg_types
+
+    monkeypatch.setattr(lg_types, "interrupt", fake_interrupt)
+
+    handler_called = False
+
+    async def handler(_req: Any) -> ToolMessage:
+        nonlocal handler_called
+        handler_called = True
+        return _make_tool_message("done")
+
+    runtime = _Runtime()
+    request = _Request("delete_thing", runtime=runtime, args={"path": "/some/path"})
+    result = await mw.awrap_tool_call(request, handler)
+
+    assert len(captured) == 1
+    payload = captured[0]
+    assert payload["action_request"]["action"] == "delete_thing"
+    assert payload["action_request"]["args"] == {"path": "/some/path"}
+    assert handler_called is True
+    assert result.content == "done"
+
+
+@pytest.mark.asyncio
+async def test_auto_interrupt_rejects_with_tool_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """User rejection returns a ToolMessage explaining the refusal so the
+    agent can adjust rather than crash."""
+    cap = ToolCapability(
+        id="risky.rm",
+        name="rm",
+        description="removes",
+        fn=lambda: None,
+        interrupt_before=True,
+    )
+    mw = AutoInterruptMiddleware(tool_registry=_registry_with(cap))
+
+    def fake_interrupt(_payload: Any) -> Any:
+        return {"type": "response", "args": "no — wrong path"}
+
+    import langgraph.types as lg_types
+
+    monkeypatch.setattr(lg_types, "interrupt", fake_interrupt)
+
+    handler_called = False
+
+    async def handler(_req: Any) -> ToolMessage:
+        nonlocal handler_called
+        handler_called = True
+        return _make_tool_message("oops")
+
+    runtime = _Runtime()
+    request = _Request("rm", runtime=runtime)
+    result = await mw.awrap_tool_call(request, handler)
+
+    assert handler_called is False
+    assert isinstance(result, ToolMessage)
+    assert "rejected" in str(result.content).lower()
+    assert "wrong path" in str(result.content)
+
+
+@pytest.mark.asyncio
+async def test_auto_interrupt_ignore_path_returns_tool_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cap = ToolCapability(
+        id="risky.git_push",
+        name="git_push",
+        description="pushes",
+        fn=lambda: None,
+        interrupt_before=True,
+    )
+    mw = AutoInterruptMiddleware(tool_registry=_registry_with(cap))
+
+    def fake_interrupt(_payload: Any) -> Any:
+        return {"type": "ignore"}
+
+    import langgraph.types as lg_types
+
+    monkeypatch.setattr(lg_types, "interrupt", fake_interrupt)
+
+    handler_called = False
+
+    async def handler(_req: Any) -> ToolMessage:
+        nonlocal handler_called
+        handler_called = True
+        return _make_tool_message("pushed")
+
+    runtime = _Runtime()
+    request = _Request("git_push", runtime=runtime)
+    result = await mw.awrap_tool_call(request, handler)
+    assert handler_called is False
+    assert "skip" in str(result.content).lower()
+
+
+# ---------------------------------------------------------------------------
+# (e) coordinator=True wires CoordinatorMode into build_deep_agent
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_get_coordinator_tools_filters_by_risk() -> None:
+    """The narrowing helper used by ``coordinator=True`` returns only
+    ``risk=READ_ONLY`` tools (mutating + destructive are filtered)."""
+    from langgraph_kit.core.coordinator import CoordinatorMode
+
+    def _safe_fn() -> str:
+        return "safe"
+
+    def _danger_fn() -> str:
+        return "danger"
+
+    safe = ToolCapability(
+        id="r.search",
+        name="search",
+        description="",
+        fn=_safe_fn,
+        risk=ToolRisk.READ_ONLY,
+    )
+    danger = ToolCapability(
+        id="r.delete",
+        name="delete",
+        description="",
+        fn=_danger_fn,
+        risk=ToolRisk.DESTRUCTIVE,
+    )
+    reg = _registry_with(safe, danger)
+    coord = CoordinatorMode(reg)
+    tools = coord.get_coordinator_tools()
+    # ``compile_tools`` returns the underlying ``cap.fn`` callables. The
+    # READ_ONLY filter must keep ``_safe_fn`` and drop ``_danger_fn``.
+    assert _safe_fn in tools
+    assert _danger_fn not in tools
+
+
+def test_coordinator_conditions_match_section_definitions() -> None:
+    from langgraph_kit.core.coordinator import COORDINATOR_SECTIONS, CoordinatorMode
+
+    conditions = CoordinatorMode.get_conditions()
+    section_conditions = {s.condition for s in COORDINATOR_SECTIONS if s.condition}
+    # Every coordinator section must be covered by the activation set.
+    assert section_conditions <= conditions

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -47,7 +47,12 @@ class TestToolCapability:
         assert cap.profiles is None
         assert cap.worker_types is None
         assert cap.max_output_tokens is None
-        assert cap.offload_large_results is False
+        assert cap.max_output_chars is None
+        # Default flipped from False to True in #6 — see the
+        # ResultPersistenceMiddleware wiring. Pre-flip callers who
+        # relied on the silent no-op behavior get the documented
+        # default-True behavior now.
+        assert cap.offload_large_results is True
         assert cap.interrupt_before is False
 
     def test_capability_with_all_fields(self) -> None:


### PR DESCRIPTION
## Summary

Three `ToolCapability` fields that were previously advisory are now enforced by bundled middleware, and the `CoordinatorMode` helper is reachable from `build_deep_agent`. Sub-task `(d)` (`SkillMetadata.allowed_tools`) is deferred to #7 because re-adding the field without active-skill plumbing reintroduces the original dead-contract problem.

- **(a)** New `max_output_chars` field; `ResultPersistenceMiddleware` honours it as a per-tool threshold override. Legacy `max_output_tokens` retained as an advisory hint for caller-supplied tokenizer middleware.
- **(b)** `offload_large_results` now controls persistence opt-out. **Default flipped from `False` to `True`** (documented in CHANGELOG `### Changed`).
- **(c)** New `AutoInterruptMiddleware` in `core.hitl.auto_interrupt` auto-pauses for HITL approval before any tool with `interrupt_before=True`. Accept → run; ignore/response/edit → `ToolMessage` with the rejection reason.
- **(e)** New `coordinator=True` kwarg on `build_deep_agent`: narrows tools to `ToolRisk.READ_ONLY`, merges coordinator prompt sections, activates the `coordinator` / `orchestration` section conditions.

Plumbing: `ToolRegistry.find_by_tool_name(name)` helper and a new `tool_registry=` kwarg on `build_middleware_stack` thread the registry from the builder to the middlewares that need it.

## Test plan

- [x] 13 new tests in `tests/test_orphaned_contracts_wired.py` covering per-tool max-chars, default-threshold fallback, no-registry path, offload-False opt-out, offload-True over-threshold persistence, default-True flip, `AutoInterruptMiddleware` accept / ignore / response / no-flag / no-registry paths, and `CoordinatorMode` risk-filter + condition-coverage smoke tests.
- [x] `test_capability_defaults` updated for the `offload_large_results` flip.
- [x] Full suite: 927 passed (was 914).
- [x] ruff / basedpyright / pre-commit clean.

## Plan comment

Scope contract: https://github.com/allada-homelab/langgraph-kit/issues/6#issuecomment-4317238834

Fixes #6