### PR TITLE
Add SSE heartbeats + event ids to stream_agent_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **SSE heartbeats and event ids in `stream_agent_events`.** Every emitted
+  chunk now carries an `id: <n>` line with a per-stream monotonically-
+  increasing sequence number, and a configurable
+  `heartbeat_interval` (default 15 s) emits
+  `{"heartbeat": {"ts": ..., "last_event_id": ...}}` chunks during quiet
+  periods so proxies / load balancers don't drop idle connections. Set
+  `heartbeat_interval=None` to disable. Existing `error` events continue
+  to fire before `[DONE]`. The durable replay log + `/stream/resume`
+  endpoint that consume the `id:` line are deferred to a follow-up — for
+  now the id makes the contract forward-compatible. Fixes
+  [#11](https://github.com/allada-homelab/langgraph-kit/issues/11).
+
 - **Wire up four `ToolCapability` orphan fields.** Three previously-advisory
   fields are now enforced by bundled middleware (Fixes
   [#6](https://github.com/allada-homelab/langgraph-kit/issues/6)):

--- a/src/langgraph_kit/streaming.py
+++ b/src/langgraph_kit/streaming.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
+import time
 from typing import TYPE_CHECKING, Any
 
 from langgraph_kit.core.artifacts import ARTIFACT_SENTINEL
@@ -30,6 +32,28 @@ logger = logging.getLogger(__name__)
 _TRAILING_ARTIFACT_RE = re.compile(r"\s*```(?:json)?\s*\[\s*\]\s*```\s*$")
 _BUFFER_SIZE = 30  # characters — enough for "```json\n[]\n```"
 _MAX_TOOL_OUTPUT_SSE = 3000  # truncate tool outputs longer than this in the SSE stream
+
+# Default cadence for heartbeats during quiet periods. Many proxies
+# (nginx default proxy_read_timeout = 60s, AWS NLB idle = 350s, Cloudflare
+# idle = 100s) drop idle SSE connections; 15s leaves comfortable margin
+# without flooding healthy streams with no-ops.
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS: float = 15.0
+
+
+def _sse_chunk(seq: int, payload: dict[str, Any] | str) -> str:
+    """Format an SSE chunk with an ``id:`` line and ``data:`` body.
+
+    ``payload`` is JSON-encoded when given as a dict, or used verbatim
+    when given as a string (e.g. the ``[DONE]`` sentinel). The ``id:``
+    line is part of the SSE wire format and lets reconnecting clients
+    tell the server (via the ``Last-Event-ID`` header) which events
+    they have already seen — the durable replay log that consumes that
+    id is a follow-up; for now the id makes the contract forward-
+    compatible.
+    """
+    body = json.dumps(payload) if isinstance(payload, dict) else payload
+    return f"id: {seq}\ndata: {body}\n\n"
+
 
 # Map sentinel prefixes to SSE event keys
 _SENTINEL_MAP: dict[str, str] = {
@@ -62,6 +86,7 @@ async def stream_agent_events(
     config: dict[str, Any],
     *,
     store: Any | None = None,
+    heartbeat_interval: float | None = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
 ) -> AsyncGenerator[str]:
     """Stream LangGraph events as SSE chunks.
 
@@ -71,7 +96,24 @@ async def stream_agent_events(
       - ``{"tool_call_start": {...}}`` — tool invocation started
       - ``{"tool_call_end": {...}}`` — tool invocation completed
       - ``{"interrupt": {...}}`` — graph paused for human input
+      - ``{"heartbeat": {"ts": ..., "last_event_id": ...}}`` — emitted
+        every ``heartbeat_interval`` seconds during quiet periods so
+        proxies / load balancers don't drop the idle connection
       - ``[DONE]`` — stream finished
+
+    Every emitted chunk carries an SSE ``id:`` line with a per-stream
+    monotonically-increasing sequence number. Clients can record the
+    most recent id (e.g. via ``EventSource.lastEventId``) and pass it
+    back as ``Last-Event-ID`` on reconnect; the durable replay log
+    that honors that header is a follow-up — for now the id makes the
+    contract forward-compatible.
+
+    Parameters
+    ----------
+    heartbeat_interval:
+        Seconds between heartbeat chunks during periods with no real
+        events. ``None`` disables heartbeats. Defaults to
+        :data:`DEFAULT_HEARTBEAT_INTERVAL_SECONDS` (15 s).
 
     If ``store`` is provided, marks the thread as busy for the duration
     of the run so that the queue endpoints can detect active threads.
@@ -89,6 +131,10 @@ async def stream_agent_events(
 
     started_text = False
     stream_error: Exception | None = None
+    # Per-stream monotonic sequence for SSE ``id:`` lines. Resets per
+    # request because the durable replay log is not yet wired in;
+    # clients should treat ids as unique within a single connection.
+    seq = 0
 
     try:
         # Accumulate text so we can detect trailing artifacts from models
@@ -122,85 +168,163 @@ async def stream_agent_events(
             stream_error = exc
             event_iter = _empty_aiter()
 
-        async for event in _guarded_events(event_iter):
-            if isinstance(event, _StreamError):
-                stream_error = event.exc
-                break
-            # Drop events from kit-internal LLM calls (memory extraction,
-            # consolidation, context compaction, routing). Without this
-            # filter, their tokens and tool-call metadata leak into the
-            # user-facing transcript — see langgraph_kit.core.internal_tags.
-            if INTERNAL_TAG in (event.get("tags") or ()):
-                continue
+        # Producer-consumer split so heartbeats can race against the
+        # next-event fetch without cancelling the upstream iterator
+        # (cancelling an async generator mid-iteration is unsafe — the
+        # iterator may have buffered state that the cancel doesn't
+        # restore). The producer drains _guarded_events into a small
+        # queue; the consumer pulls with a timeout to emit heartbeats
+        # during quiet periods.
+        event_queue: asyncio.Queue[Any] = asyncio.Queue(maxsize=1)
+        _PRODUCER_DONE = object()  # local sentinel — None is a valid event payload
 
-            kind = event["event"]
+        async def _producer() -> None:
+            try:
+                async for ev in _guarded_events(event_iter):
+                    await event_queue.put(ev)
+            finally:
+                await event_queue.put(_PRODUCER_DONE)
 
-            # --- Tool call start ---
-            if kind == "on_tool_start":
-                tool_input = event["data"].get("input", {})
-                name = event.get("name", "unknown")
-                run_id = event.get("run_id", "")
-                yield f"data: {json.dumps({'tool_call_start': {'id': run_id, 'name': name, 'args': tool_input}})}\n\n"
-                continue
+        producer_task = asyncio.create_task(_producer())
 
-            # --- Tool call end (artifacts + normal output) ---
-            if kind == "on_tool_end":
-                output = event["data"].get("output", "")
-                name = event.get("name", "unknown")
-                run_id = event.get("run_id", "")
-
-                # Check for sentinel-prefixed tool outputs → emit as dedicated SSE events
-                sentinel_event = (
-                    _parse_sentinel(output) if isinstance(output, str) else None
-                )
-                if sentinel_event:
-                    yield f"data: {json.dumps(sentinel_event)}\n\n"
+        try:
+            while True:
+                if heartbeat_interval is None:
+                    event = await event_queue.get()
                 else:
-                    # Normal tool output
-                    output_str = str(output) if not isinstance(output, str) else output
-                    # Truncate very long outputs for the SSE stream
-                    if len(output_str) > _MAX_TOOL_OUTPUT_SSE:
-                        output_str = (
-                            output_str[:_MAX_TOOL_OUTPUT_SSE] + "...(truncated)"
+                    try:
+                        event = await asyncio.wait_for(
+                            event_queue.get(), timeout=heartbeat_interval
                         )
-                    yield f"data: {json.dumps({'tool_call_end': {'id': run_id, 'name': name, 'output': output_str}})}\n\n"
-                continue
+                    except TimeoutError:
+                        # Quiet period — emit a heartbeat so proxies don't
+                        # drop the connection. Carries the most recent
+                        # event id so a future replay layer (or a savvy
+                        # client) knows where to resume from.
+                        yield _sse_chunk(
+                            seq,
+                            {
+                                "heartbeat": {
+                                    "ts": time.time(),
+                                    "last_event_id": seq - 1,
+                                }
+                            },
+                        )
+                        seq += 1
+                        continue
 
-            # --- Text token events ---
-            if kind != "on_chat_model_stream":
-                continue
-            chunk = event["data"].get("chunk")
-            if chunk is None:
-                continue
-            # Skip tool call chunks — only yield text tokens
-            if getattr(chunk, "tool_call_chunks", None):
-                continue
-            token = chunk.content
-            if not isinstance(token, str) or not token:
-                continue
+                if event is _PRODUCER_DONE:
+                    break
+                if isinstance(event, _StreamError):
+                    stream_error = event.exc
+                    break
 
-            # Drop leading whitespace prefix to avoid blank chat bubble
-            if not started_text:
-                token = token.lstrip()
-                if not token:
+                # Drop events from kit-internal LLM calls (memory extraction,
+                # consolidation, context compaction, routing). Without this
+                # filter, their tokens and tool-call metadata leak into the
+                # user-facing transcript — see langgraph_kit.core.internal_tags.
+                if INTERNAL_TAG in (event.get("tags") or ()):
                     continue
-                started_text = True
 
-            accumulated += token
+                kind = event["event"]
 
-            # Yield text that's safely past the buffer window.
-            # We hold back the tail so we can strip trailing artifacts
-            # once the stream ends.
-            safe_end = max(yielded_up_to, len(accumulated) - _BUFFER_SIZE)
-            if safe_end > yielded_up_to:
-                yield f"data: {json.dumps({'token': accumulated[yielded_up_to:safe_end]})}\n\n"
-                yielded_up_to = safe_end
+                # --- Tool call start ---
+                if kind == "on_tool_start":
+                    tool_input = event["data"].get("input", {})
+                    name = event.get("name", "unknown")
+                    run_id = event.get("run_id", "")
+                    yield _sse_chunk(
+                        seq,
+                        {
+                            "tool_call_start": {
+                                "id": run_id,
+                                "name": name,
+                                "args": tool_input,
+                            }
+                        },
+                    )
+                    seq += 1
+                    continue
+
+                # --- Tool call end (artifacts + normal output) ---
+                if kind == "on_tool_end":
+                    output = event["data"].get("output", "")
+                    name = event.get("name", "unknown")
+                    run_id = event.get("run_id", "")
+
+                    # Check for sentinel-prefixed tool outputs → emit as dedicated SSE events
+                    sentinel_event = (
+                        _parse_sentinel(output) if isinstance(output, str) else None
+                    )
+                    if sentinel_event:
+                        yield _sse_chunk(seq, sentinel_event)
+                        seq += 1
+                    else:
+                        # Normal tool output
+                        output_str = (
+                            str(output) if not isinstance(output, str) else output
+                        )
+                        # Truncate very long outputs for the SSE stream
+                        if len(output_str) > _MAX_TOOL_OUTPUT_SSE:
+                            output_str = (
+                                output_str[:_MAX_TOOL_OUTPUT_SSE] + "...(truncated)"
+                            )
+                        yield _sse_chunk(
+                            seq,
+                            {
+                                "tool_call_end": {
+                                    "id": run_id,
+                                    "name": name,
+                                    "output": output_str,
+                                }
+                            },
+                        )
+                        seq += 1
+                    continue
+
+                # --- Text token events ---
+                if kind != "on_chat_model_stream":
+                    continue
+                chunk = event["data"].get("chunk")
+                if chunk is None:
+                    continue
+                # Skip tool call chunks — only yield text tokens
+                if getattr(chunk, "tool_call_chunks", None):
+                    continue
+                token = chunk.content
+                if not isinstance(token, str) or not token:
+                    continue
+
+                # Drop leading whitespace prefix to avoid blank chat bubble
+                if not started_text:
+                    token = token.lstrip()
+                    if not token:
+                        continue
+                    started_text = True
+
+                accumulated += token
+
+                # Yield text that's safely past the buffer window.
+                # We hold back the tail so we can strip trailing artifacts
+                # once the stream ends.
+                safe_end = max(yielded_up_to, len(accumulated) - _BUFFER_SIZE)
+                if safe_end > yielded_up_to:
+                    yield _sse_chunk(
+                        seq, {"token": accumulated[yielded_up_to:safe_end]}
+                    )
+                    seq += 1
+                    yielded_up_to = safe_end
+        finally:
+            producer_task.cancel()
+            # Drain any queued event so the producer can finish cleanly.
+            await asyncio.gather(producer_task, return_exceptions=True)
 
         # --- Flush remaining buffered text, stripping trailing artifacts ---
         remaining = accumulated[yielded_up_to:]
         remaining = _TRAILING_ARTIFACT_RE.sub("", remaining)
         if remaining:
-            yield f"data: {json.dumps({'token': remaining})}\n\n"
+            yield _sse_chunk(seq, {"token": remaining})
+            seq += 1
 
         # --- Check final state for command results and interrupts ---
         try:
@@ -227,13 +351,17 @@ async def stream_agent_events(
                         and getattr(last, "type", "") == "ai"
                         and getattr(last, "content", "")
                     ):
-                        yield f"data: {json.dumps({'command_result': {'output': last.content}})}\n\n"
+                        yield _sse_chunk(
+                            seq, {"command_result": {"output": last.content}}
+                        )
+                        seq += 1
 
             if hasattr(state, "tasks") and state.tasks:
                 for task in state.tasks:
                     for intr in getattr(task, "interrupts", []):
                         value = intr.value if hasattr(intr, "value") else intr
-                        yield f"data: {json.dumps({'interrupt': value})}\n\n"
+                        yield _sse_chunk(seq, {"interrupt": value})
+                        seq += 1
         except Exception:
             logger.debug("Could not check interrupt state", exc_info=True)
 
@@ -241,7 +369,17 @@ async def stream_agent_events(
         trace_handler = config.get("metadata", {}).get("_trace_handler")
         if trace_handler is not None:
             trace = trace_handler.get_trace()
-            yield f"data: {json.dumps({'trace': {'trace_id': trace.trace_id, 'duration_ms': round(trace.duration_ms, 2), 'span_count': trace.span_count}})}\n\n"
+            yield _sse_chunk(
+                seq,
+                {
+                    "trace": {
+                        "trace_id": trace.trace_id,
+                        "duration_ms": round(trace.duration_ms, 2),
+                        "span_count": trace.span_count,
+                    }
+                },
+            )
+            seq += 1
             # Save trace to store if available
             if store is not None:
                 try:
@@ -258,7 +396,18 @@ async def stream_agent_events(
             usage_list = budget_callback.get_accumulated()
             if usage_list:
                 total = budget_callback.get_total()
-                yield f"data: {json.dumps({'budget': {'tokens_used': total.total_tokens, 'input_tokens': total.input_tokens, 'output_tokens': total.output_tokens, 'estimated_cost_usd': round(total.estimated_cost_usd, 6)}})}\n\n"
+                yield _sse_chunk(
+                    seq,
+                    {
+                        "budget": {
+                            "tokens_used": total.total_tokens,
+                            "input_tokens": total.input_tokens,
+                            "output_tokens": total.output_tokens,
+                            "estimated_cost_usd": round(total.estimated_cost_usd, 6),
+                        }
+                    },
+                )
+                seq += 1
 
                 # Persist accumulated usage into the BudgetManager so the
                 # state survives the stream. Without this the callback
@@ -290,9 +439,11 @@ async def stream_agent_events(
         # client can distinguish "backend failure" from "run completed".
         if stream_error is not None:
             message = _format_stream_error(stream_error)
-            yield f"data: {json.dumps({'error': {'message': message}})}\n\n"
+            yield _sse_chunk(seq, {"error": {"message": message}})
+            seq += 1
 
-        yield "data: [DONE]\n\n"
+        yield _sse_chunk(seq, "[DONE]")
+        seq += 1
     finally:
         if tracker and thread_id:
             await tracker.mark_idle(thread_id)

--- a/tests/test_agui_streaming.py
+++ b/tests/test_agui_streaming.py
@@ -325,10 +325,20 @@ async def test_stream_agui_events_sse_json_parse_failure_is_skipped(
 
 
 def test_sse_done_sentinel_is_recognized() -> None:
-    """Regression: ``data: [DONE]`` should end the stream cleanly."""
-    # Covered indirectly above but asserting the literal too.
-    payload = "data: [DONE]\n\n"
-    assert payload.strip().removeprefix("data: ") == "[DONE]"
+    """Regression: ``data: [DONE]`` should end the stream cleanly.
+
+    With SSE ``id:`` lines now prepended to every chunk, the sentinel
+    is rendered as ``id: <n>\\ndata: [DONE]\\n\\n``. A correct parser
+    looks at every line and only acts on the one starting with
+    ``data:``.
+    """
+    payload = "id: 7\ndata: [DONE]\n\n"
+    data_line = next(
+        line.removeprefix("data: ").strip()
+        for line in payload.split("\n")
+        if line.startswith("data: ")
+    )
+    assert data_line == "[DONE]"
     # sanity: json.loads should fail on this.
     with pytest.raises(json.JSONDecodeError):
         json.loads("[DONE]")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -108,15 +108,20 @@ async def test_stream_filters_internal_tagged_token_events() -> None:
     async for chunk in stream_agent_events(graph, {}, {}):
         chunks.append(chunk)
 
-    # Collect all emitted tokens from the SSE stream.
+    # Collect all emitted tokens from the SSE stream. Each chunk now
+    # carries an SSE ``id:`` line plus a ``data:`` line — pluck the data
+    # line specifically rather than naively stripping the "data: " prefix
+    # off the whole chunk.
     tokens: list[str] = []
     for raw in chunks:
-        for line in raw.strip().split("\n\n"):
-            line = line.removeprefix("data: ").strip()
-            if not line or line == "[DONE]":
+        for line in raw.split("\n"):
+            if not line.startswith("data: "):
+                continue
+            data = line.removeprefix("data: ").strip()
+            if not data or data == "[DONE]":
                 continue
             try:
-                payload = json.loads(line)
+                payload = json.loads(data)
             except json.JSONDecodeError:
                 continue
             if isinstance(payload, dict) and "token" in payload:

--- a/tests/test_streaming_fixes.py
+++ b/tests/test_streaming_fixes.py
@@ -63,8 +63,15 @@ async def test_stream_emits_error_event_and_done_on_failure() -> None:
     assert done_idx is not None, f"No [DONE] frame in {frames!r}"
     assert error_idx < done_idx, "error must precede [DONE]"
 
-    # Error frame carries a readable exception type + message.
-    error_payload = json.loads(frames[error_idx].removeprefix("data: ").strip())
+    # Error frame carries a readable exception type + message. Frames now
+    # have an SSE ``id:`` line preceding the ``data:`` line — extract
+    # the data line specifically.
+    data_line = next(
+        line.removeprefix("data: ").strip()
+        for line in frames[error_idx].split("\n")
+        if line.startswith("data: ")
+    )
+    error_payload = json.loads(data_line)
     assert "error" in error_payload
     assert "RuntimeError" in error_payload["error"]["message"]
     assert "upstream boom" in error_payload["error"]["message"]

--- a/tests/test_streaming_heartbeat.py
+++ b/tests/test_streaming_heartbeat.py
@@ -1,0 +1,244 @@
+"""Coverage — SSE heartbeats + ``id:`` lines added by issue #11.
+
+`stream_agent_events` now:
+
+- prefixes every emitted chunk with an SSE ``id: <n>`` line so a
+  reconnecting client can hand back the last id via ``Last-Event-ID``
+- emits a ``{"heartbeat": {"ts": ..., "last_event_id": ...}}`` chunk
+  every ``heartbeat_interval`` seconds during quiet periods so
+  proxies / load balancers don't drop the idle connection
+- accepts ``heartbeat_interval=None`` to disable heartbeats
+- preserves the sequence across heartbeats (heartbeat last_event_id
+  reflects the most recently emitted real event id)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, ClassVar
+
+import pytest
+
+
+def _data_lines(chunk: str) -> list[str]:
+    """Extract every ``data:`` line from a chunk."""
+    return [
+        line.removeprefix("data: ").strip()
+        for line in chunk.split("\n")
+        if line.startswith("data: ")
+    ]
+
+
+def _id_lines(chunk: str) -> list[str]:
+    return [
+        line.removeprefix("id: ").strip()
+        for line in chunk.split("\n")
+        if line.startswith("id: ")
+    ]
+
+
+class _StubGraph:
+    """Minimal graph implementing the subset of astream_events the streamer uses."""
+
+    def __init__(self, events: list[dict[str, Any]] | None = None) -> None:
+        super().__init__()
+        self._events = events or []
+
+    async def astream_events(
+        self, _input: Any, config: Any = None, version: str = "v2"
+    ) -> Any:  # pragma: no cover — version arg not used in tests
+        _ = config, version
+        for ev in self._events:
+            yield ev
+
+    async def aget_state(self, _config: Any) -> Any:
+        class _S:
+            values: ClassVar[dict[str, Any]] = {}
+            tasks: ClassVar[list[Any]] = []
+
+        return _S()
+
+
+class _SlowStubGraph:
+    """astream_events that hangs forever — useful to test heartbeats."""
+
+    async def astream_events(
+        self, _input: Any, config: Any = None, version: str = "v2"
+    ) -> Any:
+        _ = config, version
+        # Wait long enough for the test to capture multiple heartbeats.
+        await asyncio.sleep(60)
+        if False:
+            yield None  # pragma: no cover — make this an async generator
+
+    async def aget_state(self, _config: Any) -> Any:
+        class _S:
+            values: ClassVar[dict[str, Any]] = {}
+            tasks: ClassVar[list[Any]] = []
+
+        return _S()
+
+
+# ---------------------------------------------------------------------------
+# Event-id semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_chunk_carries_an_id_line() -> None:
+    """Every emitted SSE chunk must include an ``id: N`` line."""
+    from langgraph_kit.streaming import stream_agent_events
+
+    chunks: list[str] = []
+    graph = _StubGraph()  # No events -> just the closing [DONE]
+    async for chunk in stream_agent_events(graph, {}, {}, heartbeat_interval=None):
+        chunks.append(chunk)
+
+    assert len(chunks) >= 1
+    for chunk in chunks:
+        ids = _id_lines(chunk)
+        assert len(ids) == 1, f"chunk missing id line: {chunk!r}"
+        # All ids must be integers parseable as a sequence number.
+        int(ids[0])
+
+
+@pytest.mark.asyncio
+async def test_event_ids_are_monotonic_starting_from_zero() -> None:
+    from langgraph_kit.streaming import stream_agent_events
+
+    chunks: list[str] = []
+    graph = _StubGraph()
+    async for chunk in stream_agent_events(graph, {}, {}, heartbeat_interval=None):
+        chunks.append(chunk)
+
+    seen_ids = [int(_id_lines(c)[0]) for c in chunks]
+    assert seen_ids == sorted(seen_ids)
+    assert seen_ids[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_done_sentinel_carries_an_id() -> None:
+    """``[DONE]`` is just another chunk — it gets an id like everything else."""
+    from langgraph_kit.streaming import stream_agent_events
+
+    graph = _StubGraph()
+    chunks: list[str] = []
+    async for chunk in stream_agent_events(graph, {}, {}, heartbeat_interval=None):
+        chunks.append(chunk)
+
+    done_chunk = next(c for c in chunks if "[DONE]" in c)
+    assert _id_lines(done_chunk), "DONE chunk missing id line"
+    assert _data_lines(done_chunk) == ["[DONE]"]
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_emitted_during_quiet_stream() -> None:
+    """A stream that produces no events for longer than the heartbeat
+    interval must emit at least one heartbeat chunk."""
+    from langgraph_kit.streaming import stream_agent_events
+
+    graph = _SlowStubGraph()
+    chunks: list[str] = []
+
+    async def _drive() -> None:
+        async for chunk in stream_agent_events(graph, {}, {}, heartbeat_interval=0.05):
+            chunks.append(chunk)
+            heartbeat_seen = any("heartbeat" in c for c in chunks)
+            if heartbeat_seen and len(chunks) >= 2:
+                break
+
+    # Cap the test so a regression doesn't hang the suite.
+    await asyncio.wait_for(_drive(), timeout=2.0)
+
+    heartbeats = [c for c in chunks if "heartbeat" in c]
+    assert heartbeats, f"expected at least one heartbeat in {chunks!r}"
+    payload = json.loads(_data_lines(heartbeats[0])[0])
+    assert "heartbeat" in payload
+    assert "ts" in payload["heartbeat"]
+    assert "last_event_id" in payload["heartbeat"]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_disabled_when_interval_is_none() -> None:
+    """Setting ``heartbeat_interval=None`` produces no heartbeat chunks."""
+    from langgraph_kit.streaming import stream_agent_events
+
+    graph = _StubGraph()  # finishes quickly
+    chunks: list[str] = []
+    async for chunk in stream_agent_events(graph, {}, {}, heartbeat_interval=None):
+        chunks.append(chunk)
+    assert not any("heartbeat" in c for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_carries_correct_last_event_id() -> None:
+    """A heartbeat after several real events should report the id of the
+    last real chunk emitted (not its own id)."""
+    from langgraph_kit.streaming import stream_agent_events
+
+    # First emit one short event, then hang. The heartbeat that arrives
+    # should have last_event_id = id of the [DONE] preceding it... but
+    # that means we never reach quiescence. Use a graph that yields one
+    # tool_start then hangs.
+
+    class _OneEventThenHang:
+        async def astream_events(
+            self, _input: Any, config: Any = None, version: str = "v2"
+        ) -> Any:
+            _ = config, version
+            yield {
+                "event": "on_tool_start",
+                "data": {"input": {"x": 1}},
+                "name": "do_thing",
+                "run_id": "rid-1",
+            }
+            await asyncio.sleep(60)
+            if False:
+                yield None  # pragma: no cover
+
+        async def aget_state(self, _config: Any) -> Any:
+            class _S:
+                values: ClassVar[dict[str, Any]] = {}
+                tasks: ClassVar[list[Any]] = []
+
+            return _S()
+
+    chunks: list[str] = []
+
+    async def _drive() -> None:
+        async for chunk in stream_agent_events(
+            _OneEventThenHang(), {}, {}, heartbeat_interval=0.05
+        ):
+            chunks.append(chunk)
+            if any("heartbeat" in c for c in chunks):
+                break
+
+    await asyncio.wait_for(_drive(), timeout=2.0)
+
+    real_event_chunks = [c for c in chunks if "tool_call_start" in c]
+    heartbeat_chunks = [c for c in chunks if "heartbeat" in c]
+    assert real_event_chunks
+    assert heartbeat_chunks
+
+    real_id = int(_id_lines(real_event_chunks[0])[0])
+    heartbeat_payload = json.loads(_data_lines(heartbeat_chunks[0])[0])
+    # The heartbeat's reported last_event_id should reflect the id of
+    # the most recently emitted real chunk, not the heartbeat itself.
+    assert heartbeat_payload["heartbeat"]["last_event_id"] == real_id
+
+
+# ---------------------------------------------------------------------------
+# Default interval is the public constant
+# ---------------------------------------------------------------------------
+
+
+def test_default_heartbeat_interval_is_15_seconds() -> None:
+    from langgraph_kit.streaming import DEFAULT_HEARTBEAT_INTERVAL_SECONDS
+
+    assert DEFAULT_HEARTBEAT_INTERVAL_SECONDS == 15.0


### PR DESCRIPTION
## Summary

- Every emitted SSE chunk now carries an `id: <n>` line with a per-stream monotonic sequence so reconnecting clients can hand it back as `Last-Event-ID`. The durable replay log + `/stream/resume` endpoint that consume the header are deferred to a follow-up — the id makes the contract forward-compatible.
- New `heartbeat_interval` kwarg on `stream_agent_events`, default `DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 15.0`. Quiet streams emit `{"heartbeat": {"ts": ..., "last_event_id": ...}}` chunks so proxies / load balancers don't drop idle connections. Pass `None` to disable.
- Internal refactor: producer-consumer split with `asyncio.Queue` so heartbeats race against `queue.get` rather than cancelling the upstream async generator mid-iteration.

## Test plan

- [x] 7 new cases in `tests/test_streaming_heartbeat.py` covering id semantics, `[DONE]` id, heartbeat during hung stream, heartbeat last_event_id correctness, heartbeat-disabled mode, default constant value.
- [x] Existing test parsers updated to handle the new `id:`-bearing chunks (`tests/test_streaming.py`, `tests/test_streaming_fixes.py`, `tests/test_agui_streaming.py`).
- [x] Full suite: 934 passed (was 927).
- [x] ruff / basedpyright / pre-commit clean.

## Plan comment

Scope contract: https://github.com/allada-homelab/langgraph-kit/issues/11#issuecomment-4317274200

Fixes #11