### PR TITLE
Add CI-friendly exits to python -m langgraph_kit.evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **CI-friendly exits for `python -m langgraph_kit.evals`.** Four new
+  flags: `--fail-under N` exits non-zero when the overall pass rate is
+  below N; `--baseline FILE` compares against a stored slim JSON
+  report and fails on regression; `--baseline-tolerance` allows a
+  configurable drop; `--ci-json PATH` writes a slim, schema-versioned
+  JSON document suitable for CI artifact upload and as input to a
+  future `--baseline` run. Helpers `compute_overall_pass_rate`,
+  `report_to_ci_json`, and `check_ci_thresholds` are exported from
+  `langgraph_kit.evals.report` for in-process use. Fixes
+  [#14](https://github.com/allada-homelab/langgraph-kit/issues/14).
+
 - **SSE heartbeats and event ids in `stream_agent_events`.** Every emitted
   chunk now carries an `id: <n>` line with a per-stream monotonically-
   increasing sequence number, and a configurable

--- a/src/langgraph_kit/evals/__main__.py
+++ b/src/langgraph_kit/evals/__main__.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import sys
 from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -65,10 +68,51 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Skip model-graded metrics (rule-based only)",
     )
+    # --- CI integration flags (issue #14) ---
+    parser.add_argument(
+        "--fail-under",
+        type=float,
+        default=None,
+        help=(
+            "Exit non-zero when the overall pass rate (mean across "
+            "metrics that report one) is below this threshold. "
+            "Range: 0.0 to 1.0."
+        ),
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Path to a previous --ci-json output to compare against. "
+            "Exits non-zero when this run's pass_rate drops by more "
+            "than --baseline-tolerance vs the baseline's pass_rate."
+        ),
+    )
+    parser.add_argument(
+        "--baseline-tolerance",
+        type=float,
+        default=0.0,
+        help=(
+            "Allowed pass_rate drop vs the baseline before failing "
+            "(default: 0.0 = any regression fails)."
+        ),
+    )
+    parser.add_argument(
+        "--ci-json",
+        type=Path,
+        default=None,
+        help=(
+            "Write a slim, schema-versioned JSON report to this path. "
+            "Suitable for CI artifact upload and as input to a future "
+            "--baseline run. Distinct from --report-file which writes "
+            "the full EvalReport."
+        ),
+    )
     return parser.parse_args()
 
 
-async def _main() -> None:
+async def _main() -> int:
     args = _parse_args()
 
     # --- Initialize Langfuse ---
@@ -76,7 +120,7 @@ async def _main() -> None:
         from langfuse import Langfuse
     except ImportError:
         logger.error("langfuse package not installed. Run: uv sync")
-        sys.exit(1)
+        return 1
 
     langfuse = Langfuse()
 
@@ -119,7 +163,7 @@ async def _main() -> None:
         all_metrics = [m for m in all_metrics if m.name in args.metric]
         if not all_metrics:
             logger.error("No matching metrics found for: %s", args.metric)
-            sys.exit(1)
+            return 1
 
     logger.info(
         "Running %d metric(s): %s",
@@ -128,7 +172,12 @@ async def _main() -> None:
     )
 
     # --- Run ---
-    from langgraph_kit.evals.report import print_console_report, write_json_report
+    from langgraph_kit.evals.report import (
+        check_ci_thresholds,
+        print_console_report,
+        report_to_ci_json,
+        write_json_report,
+    )
     from langgraph_kit.evals.runner import EvalRunner
 
     runner = EvalRunner(langfuse=langfuse, metrics=all_metrics, llm=llm)
@@ -148,6 +197,37 @@ async def _main() -> None:
     if args.report_file or not args.dry_run:
         write_json_report(report, report_path)
 
+    # --- CI integration: slim JSON + thresholds + baseline ---
+    if args.ci_json is not None:
+        ci_payload = report_to_ci_json(report)
+        args.ci_json.parent.mkdir(parents=True, exist_ok=True)
+        args.ci_json.write_text(json.dumps(ci_payload, indent=2), encoding="utf-8")
+        logger.info("CI JSON written to %s", args.ci_json)
+
+    baseline_payload: dict[str, Any] | None = None
+    if args.baseline is not None:
+        try:
+            baseline_payload = json.loads(args.baseline.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            logger.error("Baseline file not found: %s", args.baseline)
+            return 1
+        except json.JSONDecodeError as e:
+            logger.error("Baseline file is not valid JSON: %s (%s)", args.baseline, e)
+            return 1
+
+    failures = check_ci_thresholds(
+        report,
+        fail_under=args.fail_under,
+        baseline=baseline_payload,
+        baseline_tolerance=args.baseline_tolerance,
+    )
+    if failures:
+        for reason in failures:
+            sys.stderr.write(f"FAIL: {reason}\n")
+        return 1
+
+    return 0
+
 
 if __name__ == "__main__":
-    asyncio.run(_main())
+    sys.exit(asyncio.run(_main()))

--- a/src/langgraph_kit/evals/report.py
+++ b/src/langgraph_kit/evals/report.py
@@ -6,11 +6,17 @@ import json
 import logging
 import sys
 from pathlib import Path
+from typing import Any
 
 from langgraph_kit.evals.models import EvalReport
 from langgraph_kit.evals.runner import DEFAULT_PASS_THRESHOLD
 
 logger = logging.getLogger(__name__)
+
+# Bumped when the ci_json schema changes incompatibly. Consumers (CI
+# pipelines, baselines stored in artifacts) should refuse to compare
+# different major versions.
+CI_JSON_SCHEMA_VERSION: int = 1
 
 
 def write_json_report(report: EvalReport, path: str | Path) -> None:
@@ -22,6 +28,95 @@ def write_json_report(report: EvalReport, path: str | Path) -> None:
         encoding="utf-8",
     )
     logger.info("Report written to %s", output)
+
+
+def compute_overall_pass_rate(report: EvalReport) -> float | None:
+    """Mean of per-metric pass rates, restricted to metrics that report one.
+
+    Counts each metric equally regardless of trace count — that's the
+    contract `--fail-under` thresholds against. Metrics with no
+    ``pass_rate`` (e.g. pure NUMERIC mean-only metrics) are excluded
+    from the average. Returns ``None`` if no metric reports a pass
+    rate, in which case CI thresholds short-circuit (no number to
+    threshold against = no automated failure).
+    """
+    rates = [s.pass_rate for s in report.metrics.values() if s.pass_rate is not None]
+    if not rates:
+        return None
+    return sum(rates) / len(rates)
+
+
+def report_to_ci_json(report: EvalReport) -> dict[str, Any]:
+    """Render a slim, stable JSON shape for CI consumers + baselines.
+
+    Distinct from the full ``model_dump()`` written by
+    :func:`write_json_report`: the CI shape is intentionally narrow so
+    a stored baseline can survive minor changes to the full report
+    without breaking regression checks. Carries
+    :data:`CI_JSON_SCHEMA_VERSION` so consumers can refuse to compare
+    incompatible versions.
+    """
+    return {
+        "schema_version": CI_JSON_SCHEMA_VERSION,
+        "timestamp": report.timestamp,
+        "total_traces": report.total_traces,
+        "pass_rate": compute_overall_pass_rate(report),
+        "metrics": {
+            name: {
+                "pass_rate": summary.pass_rate,
+                "mean": summary.mean,
+                "count": summary.count,
+            }
+            for name, summary in report.metrics.items()
+        },
+    }
+
+
+def check_ci_thresholds(
+    report: EvalReport,
+    *,
+    fail_under: float | None,
+    baseline: dict[str, Any] | None,
+    baseline_tolerance: float,
+) -> list[str]:
+    """Return a list of CI-failure reasons; an empty list means the run passes.
+
+    Two checks, each only active when their argument is supplied:
+
+    - **`fail_under`**: overall ``pass_rate`` must be at least this value.
+      Skipped (no failure) when the report has no pass-rate-bearing
+      metrics — there's nothing to threshold against.
+    - **`baseline`**: ``pass_rate`` must not have dropped versus the
+      stored baseline by more than ``baseline_tolerance``. Schema
+      version of the baseline is checked first; mismatch is itself a
+      failure so a stale baseline can't silently pass.
+    """
+    failures: list[str] = []
+    overall = compute_overall_pass_rate(report)
+
+    if fail_under is not None and overall is not None and overall < fail_under:
+        failures.append(f"pass_rate {overall:.3f} < --fail-under {fail_under:.3f}")
+
+    if baseline is not None:
+        base_version = baseline.get("schema_version")
+        if base_version != CI_JSON_SCHEMA_VERSION:
+            failures.append(
+                f"baseline schema_version {base_version!r} != current "
+                f"{CI_JSON_SCHEMA_VERSION!r}; refusing to compare"
+            )
+        else:
+            base_rate = baseline.get("pass_rate")
+            if (
+                isinstance(base_rate, (int, float))
+                and overall is not None
+                and overall + baseline_tolerance < base_rate
+            ):
+                failures.append(
+                    f"pass_rate dropped from {base_rate:.3f} to {overall:.3f}"
+                    f" (tolerance {baseline_tolerance:.3f})"
+                )
+
+    return failures
 
 
 def _out(text: str) -> None:

--- a/tests/test_evals_ci_thresholds.py
+++ b/tests/test_evals_ci_thresholds.py
@@ -1,0 +1,195 @@
+"""Coverage — CI threshold + baseline + ci-json helpers added by issue #14.
+
+The `python -m langgraph_kit.evals` CLI now exits non-zero when:
+
+- the overall pass rate (mean across pass-rate-bearing metrics) is
+  below ``--fail-under``
+- pass rate has dropped below the stored ``--baseline`` by more than
+  ``--baseline-tolerance``
+- the baseline file's ``schema_version`` doesn't match the current
+  format
+
+The slim ``--ci-json`` output is intentionally separate from the full
+``write_json_report`` output: a future change to the full report's
+shape shouldn't invalidate stored baselines.
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.evals.models import EvalReport, MetricSummary
+from langgraph_kit.evals.report import (
+    CI_JSON_SCHEMA_VERSION,
+    check_ci_thresholds,
+    compute_overall_pass_rate,
+    report_to_ci_json,
+)
+
+
+def _report(*pass_rates: float | None) -> EvalReport:
+    """Build a minimal EvalReport with N metrics, each carrying a fixed pass_rate."""
+    metrics: dict[str, MetricSummary] = {}
+    for i, rate in enumerate(pass_rates):
+        metrics[f"metric_{i}"] = MetricSummary(
+            name=f"metric_{i}",
+            data_type="BOOLEAN",
+            count=10,
+            mean=rate,
+            pass_rate=rate,
+        )
+    return EvalReport(
+        timestamp="2026-04-25T00:00:00Z",
+        total_traces=10,
+        metrics=metrics,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_overall_pass_rate
+# ---------------------------------------------------------------------------
+
+
+def test_overall_pass_rate_is_mean_of_metric_pass_rates() -> None:
+    report = _report(0.8, 0.6, 1.0)
+    overall = compute_overall_pass_rate(report)
+    assert overall is not None
+    assert abs(overall - 0.8) < 1e-9
+
+
+def test_overall_pass_rate_skips_metrics_without_a_pass_rate() -> None:
+    """Metrics that don't report pass_rate (NUMERIC means) shouldn't drag
+    the overall down, nor be counted as 0."""
+    report = _report(0.8, None, 1.0)
+    overall = compute_overall_pass_rate(report)
+    assert overall is not None
+    assert abs(overall - 0.9) < 1e-9
+
+
+def test_overall_pass_rate_returns_none_when_no_metric_reports() -> None:
+    """No pass_rate-bearing metrics → no overall to threshold against."""
+    report = _report(None, None)
+    assert compute_overall_pass_rate(report) is None
+
+
+# ---------------------------------------------------------------------------
+# report_to_ci_json
+# ---------------------------------------------------------------------------
+
+
+def test_ci_json_carries_schema_version_and_overall_pass_rate() -> None:
+    payload = report_to_ci_json(_report(0.8, 1.0))
+    assert payload["schema_version"] == CI_JSON_SCHEMA_VERSION
+    assert payload["pass_rate"] is not None
+    assert "metric_0" in payload["metrics"]
+    assert payload["metrics"]["metric_0"]["pass_rate"] == 0.8
+
+
+def test_ci_json_handles_empty_metrics() -> None:
+    payload = report_to_ci_json(_report())
+    assert payload["pass_rate"] is None
+    assert payload["metrics"] == {}
+
+
+# ---------------------------------------------------------------------------
+# check_ci_thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_passes_under_threshold_returns_failure() -> None:
+    failures = check_ci_thresholds(
+        _report(0.5),
+        fail_under=0.7,
+        baseline=None,
+        baseline_tolerance=0.0,
+    )
+    assert len(failures) == 1
+    assert "fail-under" in failures[0].lower()
+
+
+def test_at_threshold_passes() -> None:
+    """``--fail-under 0.7`` against a 0.7 pass_rate should not fail
+    (strict less-than, not less-than-or-equal)."""
+    failures = check_ci_thresholds(
+        _report(0.7),
+        fail_under=0.7,
+        baseline=None,
+        baseline_tolerance=0.0,
+    )
+    assert failures == []
+
+
+def test_no_metrics_with_pass_rate_skips_fail_under() -> None:
+    """When there's no overall pass_rate, --fail-under has nothing to
+    threshold against → don't fail the build."""
+    failures = check_ci_thresholds(
+        _report(None, None),
+        fail_under=0.99,
+        baseline=None,
+        baseline_tolerance=0.0,
+    )
+    assert failures == []
+
+
+def test_baseline_regression_fails() -> None:
+    failures = check_ci_thresholds(
+        _report(0.6),
+        fail_under=None,
+        baseline={"schema_version": CI_JSON_SCHEMA_VERSION, "pass_rate": 0.9},
+        baseline_tolerance=0.0,
+    )
+    assert len(failures) == 1
+    assert "dropped" in failures[0].lower()
+
+
+def test_baseline_within_tolerance_passes() -> None:
+    failures = check_ci_thresholds(
+        _report(0.85),
+        fail_under=None,
+        baseline={"schema_version": CI_JSON_SCHEMA_VERSION, "pass_rate": 0.9},
+        baseline_tolerance=0.1,
+    )
+    assert failures == []
+
+
+def test_baseline_improvement_passes() -> None:
+    failures = check_ci_thresholds(
+        _report(0.95),
+        fail_under=None,
+        baseline={"schema_version": CI_JSON_SCHEMA_VERSION, "pass_rate": 0.9},
+        baseline_tolerance=0.0,
+    )
+    assert failures == []
+
+
+def test_baseline_schema_mismatch_fails() -> None:
+    """A baseline from an older schema version should be refused
+    rather than silently compared — otherwise a CI pipeline can stop
+    catching regressions when the schema bumps."""
+    failures = check_ci_thresholds(
+        _report(0.5),
+        fail_under=None,
+        baseline={"schema_version": 0, "pass_rate": 0.9},
+        baseline_tolerance=0.0,
+    )
+    assert len(failures) == 1
+    assert "schema" in failures[0].lower()
+
+
+def test_both_checks_can_fail_simultaneously() -> None:
+    failures = check_ci_thresholds(
+        _report(0.4),
+        fail_under=0.8,
+        baseline={"schema_version": CI_JSON_SCHEMA_VERSION, "pass_rate": 0.9},
+        baseline_tolerance=0.0,
+    )
+    assert len(failures) == 2
+
+
+def test_no_args_means_no_failures() -> None:
+    """Without --fail-under and --baseline, the CI checks are no-ops."""
+    failures = check_ci_thresholds(
+        _report(0.0),
+        fail_under=None,
+        baseline=None,
+        baseline_tolerance=0.0,
+    )
+    assert failures == []


### PR DESCRIPTION
## Summary

- Four new opt-in CLI flags: `--fail-under N`, `--baseline FILE`, `--baseline-tolerance`, `--ci-json PATH`. Together they let CI pipelines gate on overall pass rate and detect regressions vs a stored baseline.
- New helpers in `langgraph_kit.evals.report`: `compute_overall_pass_rate`, `report_to_ci_json`, `check_ci_thresholds`. Also exposes `CI_JSON_SCHEMA_VERSION = 1` for consumers that want to refuse incompatible baselines.
- `_main()` now returns an int exit code; `__main__` wraps with `sys.exit(asyncio.run(_main()))`.

## Test plan

- [x] 14 cases in `tests/test_evals_ci_thresholds.py` covering overall pass-rate computation, CI JSON shape + schema version, and the threshold checker (under/at threshold, no metric reports, baseline regression / within-tolerance / improvement, schema mismatch, both checks failing simultaneously, no-args no-op).
- [x] Full suite: 948 passed (was 934).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #14