### PR TITLE
Add RAG primitives — foundation layer (ingestion + retrieval + search tool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **RAG primitives — foundation layer.** New `langgraph_kit.core.rag`
+  module: `Document`, default `word_chunker` (3.2k chars / 200-char
+  overlap, no mid-word splits), `RetrievalIndex` with
+  ingest/search/delete on top of any LangGraph `Store`, and
+  `build_search_knowledge_tool(index)` factory that wraps the index as
+  an agent-facing `search_knowledge` tool. Embedding function is
+  caller-supplied (same convention as semantic memory search from #8)
+  — no new heavyweight dependencies. Cosine helper extracted to
+  `langgraph_kit.core._vector_math` for reuse across memory and RAG.
+  Citation verification + grounding-eval rubric are deferred to a
+  follow-up. Fixes
+  [#16](https://github.com/allada-homelab/langgraph-kit/issues/16).
+
 - **CI-friendly exits for `python -m langgraph_kit.evals`.** Four new
   flags: `--fail-under N` exits non-zero when the overall pass rate is
   below N; `--baseline FILE` compares against a stored slim JSON

--- a/src/langgraph_kit/core/_vector_math.py
+++ b/src/langgraph_kit/core/_vector_math.py
@@ -1,0 +1,57 @@
+"""Tiny vector helpers shared by the memory and RAG indexes.
+
+Lives at ``langgraph_kit.core._vector_math`` (underscore-prefixed to mark
+it as kit-internal — public callers should not depend on its surface).
+The helpers are dependency-free so adding embeddings doesn't pull in
+numpy or scipy on installs that haven't opted into RAG / semantic
+memory.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity between two equal-length numeric vectors.
+
+    Returns 0.0 (rather than raising) on length mismatch or when either
+    vector has zero magnitude — those degenerate cases mean "no
+    meaningful similarity to score" and ranking on them would be
+    misleading.
+    """
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b, strict=True):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def top_k_by_score(
+    scored: Iterable[tuple[float, object]],
+    k: int,
+    *,
+    drop_zero: bool = True,
+) -> list[tuple[float, object]]:
+    """Return the top-``k`` ``(score, payload)`` tuples by descending score.
+
+    ``drop_zero`` filters out exact-zero scores before ranking — handy
+    for cosine-similarity pipelines where 0.0 reliably signals
+    "completely orthogonal" rather than "tied for last".
+    """
+    items = list(scored)
+    if drop_zero:
+        items = [(s, p) for s, p in items if s > 0.0]
+    items.sort(key=lambda pair: pair[0], reverse=True)
+    return items[:k]

--- a/src/langgraph_kit/core/memory/persistent.py
+++ b/src/langgraph_kit/core/memory/persistent.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import logging
-import math
 import re
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from langgraph_kit.core._vector_math import cosine_similarity
 from langgraph_kit.core.memory.models import (
     MemoryRecord,
     MemoryScope,
@@ -42,16 +42,7 @@ def _tokenize(text: str) -> set[str]:
     return {m.group(0).lower() for m in _TOKEN_RE.finditer(text)}
 
 
-def _cosine(a: list[float], b: list[float]) -> float:
-    """Cosine similarity. Returns 0.0 if either vector is the zero vector."""
-    if not a or not b or len(a) != len(b):
-        return 0.0
-    dot = sum(x * y for x, y in zip(a, b, strict=True))
-    na = math.sqrt(sum(x * x for x in a))
-    nb = math.sqrt(sum(y * y for y in b))
-    if na == 0.0 or nb == 0.0:
-        return 0.0
-    return dot / (na * nb)
+_cosine = cosine_similarity
 
 
 class PersistentMemoryManager:

--- a/src/langgraph_kit/core/rag/__init__.py
+++ b/src/langgraph_kit/core/rag/__init__.py
@@ -1,0 +1,29 @@
+"""RAG primitives: document ingestion, retrieval index, and search-knowledge tool.
+
+Foundation layer for issue #16 — chunking + embedding + vector search
+on top of any LangGraph ``BaseStore``. Provider-agnostic: the embedding
+function is supplied by the caller (same convention as the opt-in
+semantic memory search added in #8). No new heavyweight dependencies.
+
+Citation verification and the grounding-eval rubric are tracked
+separately in a follow-up issue.
+"""
+
+from .ingest import (
+    DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+    Document,
+    word_chunker,
+)
+from .retrieval import RetrievalIndex, RetrievedChunk
+from .search_tool import build_search_knowledge_tool
+
+__all__ = [
+    "DEFAULT_CHUNK_OVERLAP",
+    "DEFAULT_CHUNK_SIZE",
+    "Document",
+    "RetrievalIndex",
+    "RetrievedChunk",
+    "build_search_knowledge_tool",
+    "word_chunker",
+]

--- a/src/langgraph_kit/core/rag/ingest.py
+++ b/src/langgraph_kit/core/rag/ingest.py
@@ -1,0 +1,92 @@
+"""Document model and the default word-based chunker.
+
+Kept minimal on purpose — heavier chunkers (code-aware, structural,
+semantic) belong in an extras module so the kit base install stays
+dependency-free.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# Default targets ~3.2k chars per chunk with 200-char overlap. The 800
+# "tokens" is approximate — we operate in characters so we don't depend
+# on any specific tokenizer. 3.2k chars is roughly 800 tokens for
+# English prose at the LLaMA / GPT-3.5 ratio (~4 chars per token).
+DEFAULT_CHUNK_SIZE: int = 3200
+DEFAULT_CHUNK_OVERLAP: int = 200
+
+# Pluggable chunker contract — takes raw text and returns ordered chunks.
+Chunker = Callable[[str], list[str]]
+
+
+class Document(BaseModel):
+    """A document to be ingested into a :class:`RetrievalIndex`."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    text: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+def word_chunker(
+    text: str,
+    *,
+    chunk_size: int = DEFAULT_CHUNK_SIZE,
+    chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+) -> list[str]:
+    """Split *text* into overlapping chunks at word boundaries.
+
+    Tokenises whitespace-separated words and greedily packs them into
+    chunks of approximately ``chunk_size`` characters. Each subsequent
+    chunk re-includes enough trailing words from the previous chunk to
+    cover ``chunk_overlap`` characters. Words are never split, so a
+    very long single word lands in its own oversized chunk rather than
+    breaking mid-token.
+    """
+    if chunk_overlap >= chunk_size:
+        msg = "chunk_overlap must be smaller than chunk_size"
+        raise ValueError(msg)
+
+    text = text.strip()
+    if not text:
+        return []
+    if len(text) <= chunk_size:
+        return [text]
+
+    words = text.split()
+    if not words:
+        return []
+
+    chunks: list[str] = []
+    current: list[str] = []
+    current_chars = 0
+    for word in words:
+        # +1 accounts for the joining space we'd add when assembling.
+        delta = len(word) + (1 if current else 0)
+        if current_chars + delta > chunk_size and current:
+            chunks.append(" ".join(current))
+            # Build overlap from the tail of the just-flushed chunk.
+            overlap_words: list[str] = []
+            overlap_chars = 0
+            for w in reversed(current):
+                w_delta = len(w) + (1 if overlap_words else 0)
+                if overlap_chars + w_delta > chunk_overlap:
+                    break
+                overlap_words.insert(0, w)
+                overlap_chars += w_delta
+            current = overlap_words
+            current_chars = overlap_chars
+
+        if current:
+            current_chars += 1  # joining space
+        current.append(word)
+        current_chars += len(word)
+
+    if current:
+        chunks.append(" ".join(current))
+
+    return chunks

--- a/src/langgraph_kit/core/rag/retrieval.py
+++ b/src/langgraph_kit/core/rag/retrieval.py
@@ -1,0 +1,226 @@
+"""Vector-similarity retrieval over a LangGraph ``BaseStore``.
+
+The :class:`RetrievalIndex` writes chunks and embeddings to two
+parallel namespaces and ranks queries by cosine similarity. Storage
+contract:
+
+- ``("rag", index_name, "chunks")`` keyed by ``chunk_id`` →
+  ``{"text": str, "doc_id": str, "metadata": dict, "position": int}``
+- ``("rag", index_name, "embeddings")`` keyed by ``chunk_id`` →
+  ``{"vector": list[float], "doc_id": str}``
+- ``("rag", index_name, "doc_chunks")`` keyed by ``doc_id`` →
+  ``{"chunk_ids": list[str]}`` — used for fast delete/replace.
+
+Splitting chunks and embeddings keeps the chunk payload light when
+read by tools (no ~6 KB vector tax on every retrieval) and lets the
+vector index be rebuilt without reingesting source text.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from langgraph_kit.core._vector_math import cosine_similarity, top_k_by_score
+
+from .ingest import (
+    DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+    Chunker,
+    Document,
+    word_chunker,
+)
+
+logger = logging.getLogger(__name__)
+
+# Same shape as the memory module's EmbeddingFn so a single embedder
+# can back both. Kept as a re-imported type alias rather than imported
+# from memory to keep RAG / memory decoupled — they share an *interface*,
+# not an implementation.
+EmbeddingFn = Callable[[list[str]], Awaitable[list[list[float]]]]
+
+
+def _chunk_namespace(index_name: str) -> tuple[str, ...]:
+    return ("rag", index_name, "chunks")
+
+
+def _embedding_namespace(index_name: str) -> tuple[str, ...]:
+    return ("rag", index_name, "embeddings")
+
+
+def _doc_chunks_namespace(index_name: str) -> tuple[str, ...]:
+    return ("rag", index_name, "doc_chunks")
+
+
+class RetrievedChunk(BaseModel):
+    """A chunk returned by :meth:`RetrievalIndex.asearch`."""
+
+    chunk_id: str
+    doc_id: str
+    text: str
+    score: float
+    position: int = 0
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RetrievalIndex:
+    """Document index backed by a LangGraph Store and a caller-supplied embedder.
+
+    The chunker and embedding function are explicit — no provider lock
+    in. Re-ingesting the same ``doc_id`` replaces all of its chunks,
+    so updates are write-through. Deletes are scoped to a single
+    document; per-namespace clears require iterating doc_chunks.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        store: Any,
+        embedding_fn: EmbeddingFn,
+        *,
+        chunker: Chunker | None = None,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+    ) -> None:
+        super().__init__()
+        self._name = name
+        self._store = store
+        self._embedding_fn = embedding_fn
+        self._chunker = chunker or (
+            lambda text: word_chunker(
+                text, chunk_size=chunk_size, chunk_overlap=chunk_overlap
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    async def aput_document(self, document: Document) -> int:
+        """Ingest *document*, returning the number of chunks created.
+
+        If the document id already exists in the index, its previous
+        chunks (and embeddings) are removed first so the call is idempotent.
+        """
+        await self.adelete_document(document.id)
+
+        chunks = self._chunker(document.text)
+        if not chunks:
+            return 0
+
+        vectors = await self._embedding_fn(chunks)
+        if len(vectors) != len(chunks):
+            msg = (
+                f"embedding_fn returned {len(vectors)} vectors for "
+                f"{len(chunks)} chunks; expected one per chunk"
+            )
+            raise ValueError(msg)
+
+        chunk_ids: list[str] = []
+        for position, (chunk, vector) in enumerate(zip(chunks, vectors, strict=True)):
+            chunk_id = f"{document.id}:{position}"
+            chunk_ids.append(chunk_id)
+            await self._store.aput(
+                _chunk_namespace(self._name),
+                chunk_id,
+                {
+                    "text": chunk,
+                    "doc_id": document.id,
+                    "position": position,
+                    "metadata": dict(document.metadata),
+                },
+            )
+            await self._store.aput(
+                _embedding_namespace(self._name),
+                chunk_id,
+                {"vector": list(vector), "doc_id": document.id},
+            )
+
+        await self._store.aput(
+            _doc_chunks_namespace(self._name),
+            document.id,
+            {"chunk_ids": chunk_ids},
+        )
+        return len(chunk_ids)
+
+    async def adelete_document(self, doc_id: str) -> int:
+        """Remove *doc_id* and all its chunks/embeddings. Returns count deleted."""
+        item = await self._store.aget(_doc_chunks_namespace(self._name), doc_id)
+        if item is None:
+            return 0
+        chunk_ids = list((item.value or {}).get("chunk_ids", []))
+        for chunk_id in chunk_ids:
+            try:
+                await self._store.adelete(_chunk_namespace(self._name), chunk_id)
+            except Exception:
+                logger.exception(
+                    "Failed to delete chunk %s for doc %s", chunk_id, doc_id
+                )
+            try:
+                await self._store.adelete(_embedding_namespace(self._name), chunk_id)
+            except Exception:
+                logger.exception(
+                    "Failed to delete embedding %s for doc %s", chunk_id, doc_id
+                )
+        try:
+            await self._store.adelete(_doc_chunks_namespace(self._name), doc_id)
+        except Exception:
+            logger.exception("Failed to delete doc_chunks index entry %s", doc_id)
+        return len(chunk_ids)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def asearch(self, query: str, top_k: int = 5) -> list[RetrievedChunk]:
+        """Return the top-K chunks closest to *query* by cosine similarity."""
+        if not query.strip() or top_k <= 0:
+            return []
+
+        q_vectors = await self._embedding_fn([query])
+        if not q_vectors:
+            return []
+        q_vec = list(q_vectors[0])
+
+        embedding_items: list[Any] = await self._store.asearch(
+            _embedding_namespace(self._name), limit=10_000
+        )
+
+        scored: list[tuple[float, str]] = []
+        for item in embedding_items:
+            vec = (item.value or {}).get("vector") or []
+            scored.append((cosine_similarity(q_vec, vec), item.key))
+
+        ranked = top_k_by_score(scored, k=top_k, drop_zero=True)
+
+        results: list[RetrievedChunk] = []
+        for score, chunk_id_obj in ranked:  # pyright: ignore[reportGeneralTypeIssues]
+            if not isinstance(chunk_id_obj, str):
+                # top_k_by_score is generic on payload type; we only
+                # ever push str keys, so this is a defensive narrow
+                # rather than a real branch.
+                continue
+            chunk_item = await self._store.aget(
+                _chunk_namespace(self._name), chunk_id_obj
+            )
+            if chunk_item is None:
+                # Embedding without a backing chunk — orphaned. Skip and
+                # let the next ingest cycle clean up; not fatal for the
+                # current query.
+                continue
+            payload = chunk_item.value or {}
+            chunk_id = chunk_id_obj
+            results.append(
+                RetrievedChunk(
+                    chunk_id=chunk_id,
+                    doc_id=payload.get("doc_id", ""),
+                    text=payload.get("text", ""),
+                    score=float(score),
+                    position=int(payload.get("position", 0)),
+                    metadata=dict(payload.get("metadata") or {}),
+                )
+            )
+        return results

--- a/src/langgraph_kit/core/rag/search_tool.py
+++ b/src/langgraph_kit/core/rag/search_tool.py
@@ -1,0 +1,70 @@
+"""Factory for the ``search_knowledge`` agent tool.
+
+Builds a :class:`ToolCapability` that wraps a :class:`RetrievalIndex`.
+The resulting tool is what the LLM calls (``search_knowledge`` returns
+a formatted block of ranked chunks); the index itself is the persistent
+state.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
+
+from .retrieval import RetrievalIndex
+
+logger = logging.getLogger(__name__)
+
+
+_PROMPT_GUIDANCE = (
+    "Use search_knowledge to find supporting passages from the configured "
+    "knowledge base before answering knowledge-grounded questions. The tool "
+    "returns ranked chunks; cite them in your answer using add_citation."
+)
+
+
+def build_search_knowledge_tool(
+    index: RetrievalIndex,
+    *,
+    default_top_k: int = 5,
+    tool_id: str = "rag.search_knowledge",
+    description: str = "Search the configured knowledge base for relevant passages.",
+) -> ToolCapability:
+    """Wrap a :class:`RetrievalIndex` as an agent tool.
+
+    The tool function name is always ``search_knowledge`` so prompts
+    referencing it stay consistent across agents; the registry id can be
+    customised when multiple indexes coexist.
+    """
+
+    async def search_knowledge(query: str, top_k: int | None = None) -> str:
+        """Search the knowledge base for passages relevant to ``query``.
+
+        Args:
+            query: Natural-language search query.
+            top_k: Optional override for the number of chunks returned.
+        """
+        k = top_k or default_top_k
+        chunks = await index.asearch(query=query, top_k=k)
+        if not chunks:
+            return "No matching passages found in the knowledge base."
+
+        lines = [f"Found {len(chunks)} relevant passage(s):\n"]
+        for chunk in chunks:
+            preview = chunk.text if len(chunk.text) <= 800 else chunk.text[:800] + "..."
+            lines.append(
+                f"- [{chunk.chunk_id}] (score={chunk.score:.3f}, doc={chunk.doc_id})"
+            )
+            lines.append(f"  {preview}")
+        return "\n".join(lines)
+
+    return ToolCapability(
+        id=tool_id,
+        name="search_knowledge",
+        description=description,
+        fn=search_knowledge,
+        tags=["rag", "retrieval"],
+        risk=ToolRisk.READ_ONLY,
+        prompt_guidance=_PROMPT_GUIDANCE,
+    )

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,242 @@
+"""Coverage — RAG ingestion, RetrievalIndex round trip, and search_knowledge tool.
+
+Issue #16 lands the foundation: chunker, vector index built on a
+caller-supplied embedding fn, and the agent-facing
+``search_knowledge`` tool. Citation verification + the grounding
+eval rubric live in a follow-up.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph_kit.core.rag import (
+    DEFAULT_CHUNK_OVERLAP,
+    DEFAULT_CHUNK_SIZE,
+    Document,
+    RetrievalIndex,
+    build_search_knowledge_tool,
+    word_chunker,
+)
+from tests.conftest import MockStore
+
+# ---------------------------------------------------------------------------
+# Fake embedder — same trick used in test_memory_semantic_search
+# ---------------------------------------------------------------------------
+
+
+class _FakeEmbedder:
+    """3-dim vector keyed by counts of {dog, car, python} substrings."""
+
+    TAGS = ("dog", "car", "python")
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[list[str]] = []
+
+    async def __call__(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[float(t.lower().count(tag)) for tag in self.TAGS] for t in texts]
+
+
+# ---------------------------------------------------------------------------
+# Chunker
+# ---------------------------------------------------------------------------
+
+
+def test_word_chunker_returns_full_text_when_under_size() -> None:
+    text = "Hello world."
+    assert word_chunker(text, chunk_size=100, chunk_overlap=10) == [text]
+
+
+def test_word_chunker_splits_at_word_boundaries() -> None:
+    # 80 words of "alpha beta " -> ~880 chars; chunk into 200-char windows.
+    text = ("alpha beta " * 80).strip()
+    chunks = word_chunker(text, chunk_size=200, chunk_overlap=20)
+    assert len(chunks) > 1
+    for c in chunks:
+        # No chunk should start or end mid-word.
+        assert not c.startswith(" ")
+        assert not c.endswith(" ")
+        # No chunk should split a word — every word in the result is a
+        # whole word from {alpha, beta}.
+        for word in c.split():
+            assert word in {"alpha", "beta"}
+
+
+def test_word_chunker_overlap_must_be_smaller_than_size() -> None:
+    with pytest.raises(ValueError, match="chunk_overlap"):
+        word_chunker("text", chunk_size=10, chunk_overlap=10)
+
+
+def test_default_chunk_size_constants_are_reasonable() -> None:
+    # Sanity-check the public defaults — ~3.2k chars per chunk with 200
+    # overlap is the contract documented for the RAG module.
+    assert DEFAULT_CHUNK_SIZE == 3200
+    assert DEFAULT_CHUNK_OVERLAP == 200
+
+
+# ---------------------------------------------------------------------------
+# RetrievalIndex round trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ingest_and_search_round_trip() -> None:
+    store = MockStore()
+    index = RetrievalIndex(
+        "docs", store, _FakeEmbedder(), chunk_size=200, chunk_overlap=20
+    )
+
+    await index.aput_document(Document(id="d1", text="all about python python"))
+    await index.aput_document(Document(id="d2", text="cars and more cars and cars"))
+    await index.aput_document(Document(id="d3", text="dogs everywhere"))
+
+    results = await index.asearch("python guide", top_k=3)
+    assert results, "expected at least one result"
+    # The python doc should rank first under cosine on the python axis.
+    assert results[0].doc_id == "d1"
+    # Any returned chunk should carry score > 0 (drop_zero filter).
+    for r in results:
+        assert r.score > 0.0
+
+
+@pytest.mark.asyncio
+async def test_ingest_replaces_chunks_for_same_doc_id() -> None:
+    store = MockStore()
+    index = RetrievalIndex(
+        "docs", store, _FakeEmbedder(), chunk_size=80, chunk_overlap=10
+    )
+
+    await index.aput_document(Document(id="d1", text="python python python"))
+    initial = await index.asearch("python", top_k=10)
+    assert len(initial) >= 1
+
+    # Re-ingest with new content — old chunks should be replaced.
+    await index.aput_document(Document(id="d1", text="cars cars cars"))
+    refreshed = await index.asearch("python", top_k=10)
+    # Now the doc has no python tokens, so semantic search returns nothing.
+    assert refreshed == []
+    # ...but car queries should hit it.
+    car_results = await index.asearch("cars", top_k=10)
+    assert any(r.doc_id == "d1" for r in car_results)
+
+
+@pytest.mark.asyncio
+async def test_delete_document_removes_chunks_and_embeddings() -> None:
+    store = MockStore()
+    index = RetrievalIndex(
+        "docs", store, _FakeEmbedder(), chunk_size=80, chunk_overlap=10
+    )
+
+    await index.aput_document(Document(id="d1", text="python python python"))
+    deleted = await index.adelete_document("d1")
+    assert deleted >= 1
+    assert await index.asearch("python", top_k=5) == []
+
+    # Underlying namespaces should be empty for d1.
+    chunk_ns = ("rag", "docs", "chunks")
+    embedding_ns = ("rag", "docs", "embeddings")
+    chunk_keys = [k for k in store._data.get(chunk_ns, {}) if k.startswith("d1:")]
+    embedding_keys = [
+        k for k in store._data.get(embedding_ns, {}) if k.startswith("d1:")
+    ]
+    assert chunk_keys == []
+    assert embedding_keys == []
+
+
+@pytest.mark.asyncio
+async def test_delete_unknown_doc_id_is_noop() -> None:
+    store = MockStore()
+    index = RetrievalIndex("docs", store, _FakeEmbedder())
+    assert await index.adelete_document("nope") == 0
+
+
+@pytest.mark.asyncio
+async def test_search_with_empty_query_returns_empty() -> None:
+    store = MockStore()
+    index = RetrievalIndex("docs", store, _FakeEmbedder())
+    await index.aput_document(Document(id="d1", text="anything"))
+    assert await index.asearch("   ", top_k=5) == []
+
+
+@pytest.mark.asyncio
+async def test_search_with_zero_top_k_returns_empty() -> None:
+    store = MockStore()
+    index = RetrievalIndex("docs", store, _FakeEmbedder())
+    await index.aput_document(Document(id="d1", text="python"))
+    assert await index.asearch("python", top_k=0) == []
+
+
+@pytest.mark.asyncio
+async def test_embedding_fn_returning_wrong_count_raises() -> None:
+    class _BrokenEmbedder:
+        async def __call__(self, texts: list[str]) -> list[list[float]]:
+            # Always returns one vector regardless of input count
+            _ = texts
+            return [[0.0, 0.0, 0.0]]
+
+    store = MockStore()
+    # Force chunk_size=10 so a longer text yields multiple chunks.
+    index = RetrievalIndex(
+        "docs", store, _BrokenEmbedder(), chunk_size=10, chunk_overlap=2
+    )
+    with pytest.raises(ValueError, match="vectors"):
+        await index.aput_document(Document(id="d1", text="word " * 50))
+
+
+# ---------------------------------------------------------------------------
+# search_knowledge tool factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_tool_returns_sentinel_on_empty() -> None:
+    store = MockStore()
+    index = RetrievalIndex("docs", store, _FakeEmbedder())
+    tool = build_search_knowledge_tool(index)
+
+    result = await tool.fn(query="anything", top_k=3)
+    assert "no matching passages" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_knowledge_tool_formats_ranked_results() -> None:
+    store = MockStore()
+    index = RetrievalIndex(
+        "docs", store, _FakeEmbedder(), chunk_size=200, chunk_overlap=20
+    )
+    await index.aput_document(Document(id="doc-a", text="all about python python"))
+    await index.aput_document(Document(id="doc-b", text="cars cars"))
+    tool = build_search_knowledge_tool(index, default_top_k=2)
+
+    result = await tool.fn(query="python guide")
+    assert "Found" in result
+    assert "doc-a" in result
+    # The chunk preview should be present (truncated if huge).
+    assert "python" in result.lower()
+
+
+def test_search_knowledge_tool_capability_metadata() -> None:
+    store = MockStore()
+    index = RetrievalIndex("docs", store, _FakeEmbedder())
+    tool = build_search_knowledge_tool(index)
+    assert tool.id == "rag.search_knowledge"
+    assert tool.name == "search_knowledge"
+    assert "rag" in tool.tags
+    assert tool.prompt_guidance is not None
+
+
+# ---------------------------------------------------------------------------
+# top_k_by_score helper (sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_top_k_by_score_drops_zero_and_sorts_descending() -> None:
+    from langgraph_kit.core._vector_math import top_k_by_score
+
+    items: list[tuple[float, Any]] = [(0.0, "a"), (0.5, "b"), (0.9, "c"), (0.0, "d")]
+    out = top_k_by_score(items, k=2)
+    assert out == [(0.9, "c"), (0.5, "b")]


### PR DESCRIPTION
## Summary

- New `langgraph_kit.core.rag` module: `Document`, `word_chunker`, `RetrievalIndex` (ingest/search/delete on top of any `Store`), and `build_search_knowledge_tool(index)` factory.
- Provider-agnostic by design: caller supplies the embedding function (same convention as #8). No new heavyweight deps.
- Cosine + top-K helpers extracted to `langgraph_kit.core._vector_math` for reuse across memory and RAG.

## Deferred to follow-up

- Citation verification on `add_citation` (PR 3 in the issue's plan)
- New grounding eval rubric
- Auto-registration via `AgentConfig.rag_indexes` builder plumbing
- Sample `examples/rag_agent.py`

## Test plan

- [x] 15 cases in `tests/test_rag.py` covering chunker (under-size, word-boundary preservation across long text, overlap validation, default constants), index round trip (ingest+search, re-ingest replace, delete, unknown delete, empty query, zero top_k, vector-count mismatch), tool factory (empty sentinel, formatted multi-result, capability metadata), and a `top_k_by_score` sanity test.
- [x] Full suite: 963 passed (was 948).
- [x] ruff / basedpyright / pre-commit clean.

## Plan comment

Scope contract: https://github.com/allada-homelab/langgraph-kit/issues/16#issuecomment-4317355450

Fixes #16