### PR TITLE
Add outbound PII / secret redaction (OutputSafetyMiddleware)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Outbound PII / secret redaction.** New `OutputSafetyMiddleware`
+  scans the most recent `AIMessage` after every turn and rewrites
+  matched substrings with `[REDACTED]` before the message reaches the
+  user. Default mode `"redact"`; `"warn"` flags only via
+  `additional_kwargs`; `"off"` disables. Configurable via
+  `AgentConfig.output_safety_mode`. Patterns cover credentials (API
+  keys, GitHub PATs, Bearer tokens, AWS / Slack / Stripe / GCP) and
+  PII (email, US phone, SSN, credit-card with Luhn validation to
+  suppress 16-digit-but-not-actually-a-card false positives).
+  Helpers `scan_for_unsafe_output` and `redact` are exported for
+  in-process callers. Per-turn idempotent (won't re-redact the
+  placeholder). Fixes
+  [#23](https://github.com/allada-homelab/langgraph-kit/issues/23).
+
 - **Inbound prompt-injection scanner.** New `langgraph_kit.core.security`
   module ships `INJECTION_PATTERNS` (regex set covering known phrasings
   like "ignore previous instructions", persona override, jailbreak

--- a/src/langgraph_kit/_config.py
+++ b/src/langgraph_kit/_config.py
@@ -70,6 +70,13 @@ class AgentConfig:
     # layer on top of this default in a follow-up.
     prompt_injection_mode: str = "warn"
 
+    # Security: outbound assistant-message scanner mode.
+    # ``"redact"`` (default) replaces matched PII / secrets with
+    # ``[REDACTED]`` before the message is shown to the user.
+    # ``"warn"`` flags without mutating (useful for shadow-mode
+    # rollouts to gather detection metrics first). ``"off"`` disables.
+    output_safety_mode: str = "redact"
+
     def __repr__(self) -> str:
         """Mask secrets in repr to prevent accidental leakage in logs.
 

--- a/src/langgraph_kit/core/graph_builder/middleware.py
+++ b/src/langgraph_kit/core/graph_builder/middleware.py
@@ -30,7 +30,10 @@ from langgraph_kit.core.resilience import (
     ToolErrorMiddleware,
     ToolLoopGuardMiddleware,
 )
-from langgraph_kit.core.security import PromptInjectionGuardMiddleware
+from langgraph_kit.core.security import (
+    OutputSafetyMiddleware,
+    PromptInjectionGuardMiddleware,
+)
 
 if TYPE_CHECKING:
     from pydantic import BaseModel
@@ -114,6 +117,15 @@ def build_middleware_stack(
             StopHooksMiddleware(hooks=stop_hooks),
         ]
     )
+
+    # Outbound PII / secret redaction. Append late so the redaction
+    # runs *after* completion-guard has had a chance to see the raw
+    # content (the guard reasons about whether the model said anything
+    # meaningful; redaction would mask that signal). ``"off"`` skips
+    # appending entirely.
+    out_mode = get_config().output_safety_mode
+    if out_mode and out_mode != "off":
+        middleware.append(OutputSafetyMiddleware(mode=out_mode))  # type: ignore[arg-type]
 
     # Structured-output validation slots after the empty-turn / completion
     # guards (they ensure a turn exists at all) and before PostRunBackstop

--- a/src/langgraph_kit/core/security/__init__.py
+++ b/src/langgraph_kit/core/security/__init__.py
@@ -1,8 +1,7 @@
 """Security middlewares and helpers.
 
-Currently houses the inbound-prompt-injection scanner. The outbound
-PII/secret scanner and the audit-log infrastructure
-(issues #23 / #24) will join this module as they land.
+Inbound: prompt-injection pattern scanner. Outbound: PII / credential
+redactor. The audit-log infrastructure (#24) will land alongside.
 """
 
 from .injection_guard import (
@@ -14,11 +13,29 @@ from .injection_patterns import (
     INJECTION_PATTERNS,
     scan_for_injection,
 )
+from .output_patterns import (
+    REDACTION_PLACEHOLDER,
+    OutputMatch,
+    redact,
+    scan_for_unsafe_output,
+)
+from .output_safety import (
+    OUTPUT_SAFETY_FLAG,
+    OutputSafetyMiddleware,
+    SafetyMode,
+)
 
 __all__ = [
     "INJECTION_PATTERNS",
+    "OUTPUT_SAFETY_FLAG",
     "PROMPT_INJECTION_FLAG",
+    "REDACTION_PLACEHOLDER",
     "InjectionMatch",
+    "OutputMatch",
+    "OutputSafetyMiddleware",
     "PromptInjectionGuardMiddleware",
+    "SafetyMode",
+    "redact",
     "scan_for_injection",
+    "scan_for_unsafe_output",
 ]

--- a/src/langgraph_kit/core/security/output_patterns.py
+++ b/src/langgraph_kit/core/security/output_patterns.py
@@ -1,0 +1,175 @@
+"""Patterns for outbound safety: PII + credentials / secrets.
+
+Combined surface used by ``OutputSafetyMiddleware`` to scan agent
+responses before they reach the user. Each pattern carries a stable
+name string so audit / observability layers can describe what was
+redacted without exposing the raw match.
+
+Two pattern families:
+
+- **Secrets / credentials** — re-uses the same shapes as the inbound
+  guard from #5 (API keys, GitHub PATs, Bearer tokens, AWS keys, etc.).
+  Kept here as well so the security module is self-contained — the
+  memory module's private ``_SECRET_PATTERNS`` covers the same ground
+  for memory publishing and is left untouched.
+- **PII** — email, phone, SSN-shaped numbers, credit-card-shaped
+  numbers. Conservative regexes; the false-positive bar matters here
+  more than recall because every redaction mutates user-visible
+  output.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Secrets / credentials
+# ---------------------------------------------------------------------------
+
+_API_KEY_KV = re.compile(r"(?:api[_-]?key|apikey)\s*[:=]\s*\S+", re.IGNORECASE)
+_SECRET_KV = re.compile(
+    r"(?:secret|token|password|passwd|pwd)\s*[:=]\s*\S+",
+    re.IGNORECASE,
+)
+_BEARER_TOKEN = re.compile(r"Bearer\s+[A-Za-z0-9\-._~+/]+=*")
+_PRIVATE_KEY = re.compile(
+    r"-----BEGIN\s+(?:RSA\s+|EC\s+|OPENSSH\s+)?PRIVATE\s+KEY-----"
+)
+_GITHUB_PAT = re.compile(r"\bgh[prost]_[A-Za-z0-9]{36,}\b")
+_GITHUB_PAT_FINE = re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")
+_OPENAI_KEY = re.compile(r"\bsk-(?:proj-|ant-)?[A-Za-z0-9_\-]{32,}\b")
+_AWS_ACCESS_KEY = re.compile(r"\bAKIA[A-Z0-9]{16}\b")
+_SLACK_TOKEN = re.compile(r"\bxox[bpras]-[A-Za-z0-9\-]{10,}\b")
+_STRIPE_KEY = re.compile(r"\bsk_(?:live|test)_[A-Za-z0-9]{20,}\b")
+_GCP_SA = re.compile(r'"type"\s*:\s*"service_account"')
+
+# ---------------------------------------------------------------------------
+# PII
+# ---------------------------------------------------------------------------
+
+# RFC-5322-style email — pragmatic subset. Matches the vast majority of
+# real-world emails without trying to be a full validator.
+_EMAIL = re.compile(r"\b[\w.%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+
+# US-style phone number with optional country / formatting. Avoids
+# matching plain integers by requiring at least one separator.
+_US_PHONE = re.compile(
+    r"(?:(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4})\b",
+)
+
+# US Social Security number (NNN-NN-NNNN). Conservative: requires the
+# dashes — bare 9-digit numbers are too noisy to flag.
+_SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+
+# Credit-card-shaped 13-19 digit run with optional spaces or dashes.
+# Pre-validation only; downstream consumers should run a Luhn check
+# before treating it as a real card. Conservative: requires three or
+# more groups of 4 to avoid matching arbitrary product / order numbers.
+_CC_CANDIDATE = re.compile(
+    r"\b(?:\d{4}[\s\-]){3,4}\d{1,4}\b",
+)
+
+
+def _luhn_ok(digits: str) -> bool:
+    """Luhn check for a digits-only string. Used to suppress CC-shaped
+    false positives — random 16-digit numbers fail Luhn."""
+    if not digits:
+        return False
+    total = 0
+    for i, ch in enumerate(reversed(digits)):
+        if not ch.isdigit():
+            return False
+        n = int(ch)
+        if i % 2 == 1:
+            n *= 2
+            if n > 9:
+                n -= 9
+        total += n
+    return total % 10 == 0
+
+
+# Each entry: (compiled_pattern, kit-internal name, optional post-filter)
+# The post-filter receives the matched substring and returns True to
+# keep the match, False to drop. This is where Luhn lives so a regex
+# can stay greedy without flooding output with random-number redactions.
+_OUTBOUND_PATTERNS: list[tuple[re.Pattern[str], str, object]] = [
+    (_API_KEY_KV, "api_key_kv", None),
+    (_SECRET_KV, "secret_kv", None),
+    (_BEARER_TOKEN, "bearer_token", None),
+    (_PRIVATE_KEY, "private_key_block", None),
+    (_GITHUB_PAT, "github_pat", None),
+    (_GITHUB_PAT_FINE, "github_pat_fine_grained", None),
+    (_OPENAI_KEY, "openai_or_anthropic_api_key", None),
+    (_AWS_ACCESS_KEY, "aws_access_key_id", None),
+    (_SLACK_TOKEN, "slack_token", None),
+    (_STRIPE_KEY, "stripe_key", None),
+    (_GCP_SA, "gcp_service_account_marker", None),
+    (_EMAIL, "email_address", None),
+    (_US_PHONE, "us_phone_number", None),
+    (_SSN, "ssn_us", None),
+    (
+        _CC_CANDIDATE,
+        "credit_card",
+        # Drop the digits, run Luhn — keeps random 16-digit IDs from
+        # being redacted.
+        lambda match: _luhn_ok("".join(c for c in match if c.isdigit())),
+    ),
+]
+
+
+REDACTION_PLACEHOLDER: str = "[REDACTED]"
+
+
+class OutputMatch(NamedTuple):
+    """A redaction-worthy substring located in an outbound message."""
+
+    pattern: str
+    match: str
+    span: tuple[int, int]
+
+
+def scan_for_unsafe_output(text: str) -> list[OutputMatch]:
+    """Return every PII / secret pattern hit in *text*, in left-to-right order.
+
+    Empty or non-string input yields an empty list — never raises.
+    Overlapping matches keep the longer one.
+    """
+    if not text:
+        return []
+    candidates: list[OutputMatch] = []
+    for pattern, name, post_filter in _OUTBOUND_PATTERNS:
+        for m in pattern.finditer(text):
+            substring = m.group(0)
+            if callable(post_filter) and not post_filter(substring):
+                continue
+            candidates.append(
+                OutputMatch(pattern=name, match=substring, span=(m.start(), m.end()))
+            )
+
+    # Resolve overlaps: prefer the longest match for any byte position.
+    candidates.sort(key=lambda om: (om.span[0], -(om.span[1] - om.span[0])))
+    selected: list[OutputMatch] = []
+    last_end = -1
+    for om in candidates:
+        if om.span[0] >= last_end:
+            selected.append(om)
+            last_end = om.span[1]
+    return selected
+
+
+def redact(text: str) -> tuple[str, list[OutputMatch]]:
+    """Replace every match in *text* with :data:`REDACTION_PLACEHOLDER`.
+
+    Returns ``(redacted_text, matches)`` where ``matches`` describes what
+    was replaced (in original-text coordinates) so the caller can audit.
+    """
+    matches = scan_for_unsafe_output(text)
+    if not matches:
+        return text, []
+
+    # Replace right-to-left so earlier indices stay valid as we mutate.
+    parts = list(text)
+    for om in reversed(matches):
+        parts[om.span[0] : om.span[1]] = REDACTION_PLACEHOLDER
+    return "".join(parts), matches

--- a/src/langgraph_kit/core/security/output_patterns.py
+++ b/src/langgraph_kit/core/security/output_patterns.py
@@ -7,7 +7,7 @@ redacted without exposing the raw match.
 
 Two pattern families:
 
-- **Secrets / credentials** — re-uses the same shapes as the inbound
+- **Secrets / credentials** — same shapes as the inbound
   guard from #5 (API keys, GitHub PATs, Bearer tokens, AWS keys, etc.).
   Kept here as well so the security module is self-contained — the
   memory module's private ``_SECRET_PATTERNS`` covers the same ground

--- a/src/langgraph_kit/core/security/output_safety.py
+++ b/src/langgraph_kit/core/security/output_safety.py
@@ -1,0 +1,115 @@
+"""``OutputSafetyMiddleware`` — outbound assistant-message scanner + redactor.
+
+Runs after every model turn. Inspects the most recent ``AIMessage``;
+when its content contains anything matched by
+:func:`scan_for_unsafe_output` the content is rewritten in place with
+``[REDACTED]`` and the pattern names are stored on the message's
+``additional_kwargs`` for audit.
+
+Default mode is ``"redact"`` — the symmetric counterpart to the
+inbound scanner's ``"warn"`` default. ``"warn"`` here means flag-only
+(do not mutate the content); ``"off"`` disables.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.messages import AIMessage
+
+from .output_patterns import (
+    REDACTION_PLACEHOLDER,
+    OutputMatch,
+    redact,
+    scan_for_unsafe_output,
+)
+
+logger = logging.getLogger(__name__)
+
+# Stored on AIMessage.additional_kwargs whenever the middleware
+# touched the message. Value is a list of pattern names so audit can
+# describe what was redacted without re-leaking the matched content.
+OUTPUT_SAFETY_FLAG: str = "_lgk_output_safety_match"
+
+
+SafetyMode = Literal["off", "warn", "redact"]
+
+
+class OutputSafetyMiddleware(AgentMiddleware):  # type: ignore[misc]
+    """Scan outbound assistant messages and either flag or redact unsafe content.
+
+    ``mode``:
+
+    - ``"redact"`` (default): replaces every match with
+      ``[REDACTED]`` and tags ``additional_kwargs`` with
+      :data:`OUTPUT_SAFETY_FLAG` carrying the matched pattern names.
+    - ``"warn"``: only tags. Useful in shadow-mode rollouts where
+      operators want detection metrics before flipping to
+      destructive redaction.
+    - ``"off"``: skip scanning entirely.
+
+    The middleware is per-turn idempotent — a message that already
+    carries the flag is not re-scanned (avoids re-redacting a literal
+    ``[REDACTED]`` placeholder).
+    """
+
+    def __init__(self, *, mode: SafetyMode = "redact") -> None:
+        super().__init__()
+        self._mode = mode
+
+    async def aafter_model(self, state: Any, runtime: Any) -> dict[str, Any] | None:  # noqa: ARG002
+        if self._mode == "off":
+            return None
+
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+        last = messages[-1]
+        if not isinstance(last, AIMessage):
+            return None
+
+        existing = (last.additional_kwargs or {}).get(OUTPUT_SAFETY_FLAG)
+        if existing:
+            return None
+
+        content = last.content
+        if not isinstance(content, str) or not content:
+            return None
+
+        if self._mode == "warn":
+            matches = scan_for_unsafe_output(content)
+            if not matches:
+                return None
+            self._tag_message(last, matches)
+            return None
+
+        # mode == "redact"
+        new_content, matches = redact(content)
+        if not matches:
+            return None
+
+        last.content = new_content
+        self._tag_message(last, matches)
+        return None
+
+    def _tag_message(self, msg: AIMessage, matches: list[OutputMatch]) -> None:
+        pattern_names = sorted({m.pattern for m in matches})
+        merged = dict(msg.additional_kwargs or {})
+        merged[OUTPUT_SAFETY_FLAG] = pattern_names
+        msg.additional_kwargs = merged
+        logger.warning(
+            "OutputSafety: %s patterns=%s on message_id=%s",
+            "redacted" if self._mode == "redact" else "flagged",
+            pattern_names,
+            getattr(msg, "id", "<unknown>"),
+        )
+
+
+__all__ = [
+    "OUTPUT_SAFETY_FLAG",
+    "REDACTION_PLACEHOLDER",
+    "OutputSafetyMiddleware",
+    "SafetyMode",
+]

--- a/tests/test_output_safety.py
+++ b/tests/test_output_safety.py
@@ -1,0 +1,191 @@
+"""Coverage — outbound PII / secret redaction added by issue #23.
+
+`OutputSafetyMiddleware` scans the most recent `AIMessage` after every
+turn. Default mode `"redact"` rewrites the content in place with
+`[REDACTED]`; `"warn"` only flags via `additional_kwargs`; `"off"`
+skips. The middleware is per-turn idempotent so a previously-tagged
+message isn't re-scanned (avoids re-redacting the placeholder).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from langgraph_kit.core.security import (
+    OUTPUT_SAFETY_FLAG,
+    REDACTION_PLACEHOLDER,
+    OutputMatch,
+    OutputSafetyMiddleware,
+    redact,
+    scan_for_unsafe_output,
+)
+
+# ---------------------------------------------------------------------------
+# Pattern scanner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_pattern"),
+    [
+        ("contact me at alice@example.com", "email_address"),
+        ("call (555) 123-4567 today", "us_phone_number"),
+        ("ssn 123-45-6789 is sensitive", "ssn_us"),
+        ("api_key=sk-abc123", "api_key_kv"),
+        ("Bearer eyJabcdef.ghijkl", "bearer_token"),
+        ("ghp_" + "A" * 36, "github_pat"),
+        ("AKIAIOSFODNN7EXAMPLE", "aws_access_key_id"),
+        ("token: hunter2", "secret_kv"),
+    ],
+)
+def test_scanner_matches_known_unsafe_substrings(
+    text: str, expected_pattern: str
+) -> None:
+    matches = scan_for_unsafe_output(text)
+    assert any(m.pattern == expected_pattern for m in matches), (
+        f"missing {expected_pattern} for {text!r}: got {[m.pattern for m in matches]}"
+    )
+
+
+@pytest.mark.parametrize(
+    "benign",
+    [
+        "",
+        "Just plain prose with no secrets.",
+        "Order #1234567 was shipped — that's a 7-digit ID, not a card.",
+        "Versions like v1.2.3 should not match.",
+    ],
+)
+def test_scanner_passes_benign_text(benign: str) -> None:
+    assert scan_for_unsafe_output(benign) == []
+
+
+def test_credit_card_luhn_filters_random_digit_runs() -> None:
+    """A 16-digit Luhn-invalid number must not be flagged. A real
+    Luhn-valid test number (4111 1111 1111 1111 — Visa test) is."""
+    assert scan_for_unsafe_output("invoice 1234 5678 9012 3456 issued") == []
+    matches = scan_for_unsafe_output("paid with 4111 1111 1111 1111 yesterday")
+    assert any(m.pattern == "credit_card" for m in matches)
+
+
+def test_redact_replaces_only_matched_substrings() -> None:
+    text = "Reach out to alice@example.com for the api_key=sk-abc12345 — thanks!"
+    redacted, matches = redact(text)
+    assert REDACTION_PLACEHOLDER in redacted
+    assert "alice@example.com" not in redacted
+    assert "sk-abc12345" not in redacted
+    # Surrounding text survives.
+    assert "Reach out to" in redacted
+    assert "thanks!" in redacted
+    pattern_names = {m.pattern for m in matches}
+    assert pattern_names == {"email_address", "api_key_kv"}
+
+
+def test_redact_handles_overlapping_patterns() -> None:
+    """Overlapping matches resolve to the longer one — no double redaction."""
+    redacted, _ = redact("api_key=sk-abc12345xyz")
+    # Both api_key_kv and openai_or_anthropic_api_key match the value
+    # portion. Should produce one [REDACTED], not nested ones.
+    assert redacted.count(REDACTION_PLACEHOLDER) == 1
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+def _state(messages: list[Any]) -> dict[str, Any]:
+    return {"messages": list(messages)}
+
+
+@pytest.mark.asyncio
+async def test_off_mode_is_a_noop() -> None:
+    mw = OutputSafetyMiddleware(mode="off")
+    msg = AIMessage(content="email me at bob@example.com")
+    await mw.aafter_model(_state([msg]), runtime=None)
+    assert msg.content == "email me at bob@example.com"
+    assert OUTPUT_SAFETY_FLAG not in (msg.additional_kwargs or {})
+
+
+@pytest.mark.asyncio
+async def test_warn_mode_flags_without_mutating_content() -> None:
+    mw = OutputSafetyMiddleware(mode="warn")
+    msg = AIMessage(content="email me at bob@example.com")
+    await mw.aafter_model(_state([msg]), runtime=None)
+    assert msg.content == "email me at bob@example.com"
+    assert msg.additional_kwargs[OUTPUT_SAFETY_FLAG] == ["email_address"]
+
+
+@pytest.mark.asyncio
+async def test_redact_mode_rewrites_content_in_place() -> None:
+    mw = OutputSafetyMiddleware(mode="redact")
+    msg = AIMessage(content="email me at bob@example.com please")
+    await mw.aafter_model(_state([msg]), runtime=None)
+    assert "bob@example.com" not in msg.content
+    assert REDACTION_PLACEHOLDER in msg.content
+    assert msg.additional_kwargs[OUTPUT_SAFETY_FLAG] == ["email_address"]
+
+
+@pytest.mark.asyncio
+async def test_redact_leaves_clean_messages_unchanged() -> None:
+    mw = OutputSafetyMiddleware(mode="redact")
+    original = "Just plain prose, no secrets."
+    msg = AIMessage(content=original)
+    await mw.aafter_model(_state([msg]), runtime=None)
+    assert msg.content == original
+    assert OUTPUT_SAFETY_FLAG not in (msg.additional_kwargs or {})
+
+
+@pytest.mark.asyncio
+async def test_redact_is_idempotent_per_turn() -> None:
+    """Running the middleware twice on a redacted message must not
+    re-redact the placeholder or change the flag."""
+    mw = OutputSafetyMiddleware(mode="redact")
+    msg = AIMessage(content="contact alice@example.com")
+    await mw.aafter_model(_state([msg]), runtime=None)
+    first_flag = list(msg.additional_kwargs[OUTPUT_SAFETY_FLAG])
+    first_content = msg.content
+
+    await mw.aafter_model(_state([msg]), runtime=None)
+    assert msg.content == first_content
+    assert msg.additional_kwargs[OUTPUT_SAFETY_FLAG] == first_flag
+
+
+@pytest.mark.asyncio
+async def test_skip_when_last_message_is_not_ai() -> None:
+    mw = OutputSafetyMiddleware(mode="redact")
+    msg = HumanMessage(content="api_key=sk-12345")
+    await mw.aafter_model(_state([msg]), runtime=None)
+    assert msg.content == "api_key=sk-12345"
+
+
+@pytest.mark.asyncio
+async def test_skip_when_messages_empty() -> None:
+    mw = OutputSafetyMiddleware(mode="redact")
+    result = await mw.aafter_model(_state([]), runtime=None)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_skip_when_ai_content_is_not_string() -> None:
+    """Some chat models return list-of-content-blocks rather than a
+    plain string. The middleware leaves those alone (the existing
+    redaction path is string-only)."""
+    mw = OutputSafetyMiddleware(mode="redact")
+    msg = AIMessage(content=[{"type": "text", "text": "alice@example.com"}])  # pyright: ignore[reportArgumentType]
+    await mw.aafter_model(_state([msg]), runtime=None)
+    # No mutation, no flag — list-shaped content is out of scope for v1.
+    assert OUTPUT_SAFETY_FLAG not in (msg.additional_kwargs or {})
+
+
+def test_output_match_type_is_namedtuple() -> None:
+    """OutputMatch should be a NamedTuple (so consumers can pattern-
+    match by index in a tight loop without dict overhead)."""
+    om = OutputMatch(pattern="email_address", match="x@y.z", span=(0, 5))
+    pattern, match, span = om
+    assert pattern == "email_address"
+    assert match == "x@y.z"
+    assert span == (0, 5)


### PR DESCRIPTION
## Summary

- New `OutputSafetyMiddleware` scans the last `AIMessage` after every turn and rewrites matches with `[REDACTED]`. Mode configurable via `AgentConfig.output_safety_mode` (`"redact"` default, `"warn"` flag-only, `"off"` skip).
- Pattern set covers credentials (kv pairs, Bearer / private-key blocks, GitHub PATs, OpenAI/Anthropic, AWS, Slack, Stripe, GCP) and PII (email, US phone, SSN, credit-card-with-Luhn).
- Helpers `scan_for_unsafe_output` and `redact` exported.

## Test plan

- [x] 24 cases in `tests/test_output_safety.py` covering pattern matches, false-positive bar, Luhn filter, overlapping match resolution, all three modes, idempotency, non-AI / list-content / empty-state pass-through, NamedTuple shape.
- [x] Full suite: 1011 passed (was 987).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #23