### PR TITLE
Add append-only AuditStore + AuditEntry model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Append-only audit log.** New `langgraph_kit.core.audit` module ships
+  `AuditAction` (bounded enum: agent_invoke, memory_create/update/delete,
+  hitl_approve/reject, injection_detected, output_redacted, data_export/
+  delete), `AuditEntry` (immutable five-tuple of timestamp/actor/action/
+  target/metadata), and `AuditStore` (the only sanctioned read/write
+  surface). Storage is time-bucketed by year-month under `("audit",
+  "YYYY_MM")` so monthly listings stay cheap; `query(...)` walks
+  buckets newest-first so the common "last N entries" path stops as
+  soon as it has enough. Store write failures are logged and swallowed
+  so audit never blocks a real action. The FastAPI admin endpoint that
+  queries the log is deferred to a follow-up. Fixes
+  [#24](https://github.com/allada-homelab/langgraph-kit/issues/24).
+
 - **Outbound PII / secret redaction.** New `OutputSafetyMiddleware`
   scans the most recent `AIMessage` after every turn and rewrites
   matched substrings with `[REDACTED]` before the message reaches the

--- a/src/langgraph_kit/core/audit/__init__.py
+++ b/src/langgraph_kit/core/audit/__init__.py
@@ -1,0 +1,21 @@
+"""Append-only audit log: who did what, to what, when.
+
+Exports:
+
+- :class:`AuditAction` — bounded set of audit-worthy actions.
+- :class:`AuditEntry` — the immutable five-tuple.
+- :class:`AuditStore` — Store-backed writer/reader.
+
+Producers should call :meth:`AuditStore.write` rather than poking the
+underlying store directly so future additions (signature chaining,
+external sinks, retention policies) land in a single place.
+"""
+
+from .models import AuditAction, AuditEntry
+from .store import AuditStore
+
+__all__ = [
+    "AuditAction",
+    "AuditEntry",
+    "AuditStore",
+]

--- a/src/langgraph_kit/core/audit/models.py
+++ b/src/langgraph_kit/core/audit/models.py
@@ -1,0 +1,59 @@
+"""Models for the audit log.
+
+Append-only tuples ``(timestamp, actor, action, target, metadata)``
+describing who did what, to what, when. Stored via
+:class:`langgraph_kit.core.audit.AuditStore` in time-bucketed
+namespaces so listings stay cheap.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AuditAction(StrEnum):
+    """Bounded set of audit-worthy action kinds.
+
+    Extend conservatively — every consumer that filters on action
+    must be updated when new variants land.
+    """
+
+    AGENT_INVOKE = "agent_invoke"
+    AGENT_RUN_COMPLETE = "agent_run_complete"
+    MEMORY_CREATE = "memory_create"
+    MEMORY_UPDATE = "memory_update"
+    MEMORY_DELETE = "memory_delete"
+    HITL_APPROVE = "hitl_approve"
+    HITL_REJECT = "hitl_reject"
+    INJECTION_DETECTED = "injection_detected"
+    OUTPUT_REDACTED = "output_redacted"
+    DATA_EXPORT = "data_export"
+    DATA_DELETE = "data_delete"
+
+
+class AuditEntry(BaseModel):
+    """A single immutable audit row."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    # Actor: ``user:<id>``, ``agent:<id>``, ``system``, or any caller-defined
+    # prefix. Free-form on purpose so audit consumers don't need to mirror
+    # an enum that grows over time.
+    actor: str
+    action: AuditAction
+    # Target: the entity acted upon. ``thread:<id>``, ``memory:<id>``,
+    # ``message:<id>``, ``namespace:<tuple>``. Free-form like ``actor``.
+    target: str
+    # Free-form payload. The schema is intentionally flexible because
+    # audit producers vary widely (a memory delete carries the deleted
+    # title; an injection detection carries pattern names).
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    def bucket_key(self) -> str:
+        """Year-month bucket the entry lives under in the Store."""
+        return f"{self.timestamp.year:04d}_{self.timestamp.month:02d}"

--- a/src/langgraph_kit/core/audit/store.py
+++ b/src/langgraph_kit/core/audit/store.py
@@ -1,0 +1,160 @@
+"""Append-only audit log over a LangGraph ``BaseStore``.
+
+The :class:`AuditStore` is the only sanctioned writer and reader for
+audit data. Every audit producer (security middleware, memory CRUD,
+HITL hooks, FastAPI lifespan) calls :meth:`write` rather than poking
+the store directly, so future additions like signature chaining or
+external sinks land in one place.
+
+Storage layout: entries are written to the namespace
+``("audit", <YYYY_MM>)`` keyed by ``entry.id``. Bucket-by-month keeps
+month-range listings to a single namespace scan instead of a global
+table walk; multi-month queries iterate buckets in reverse order so
+the common "give me the last N entries" path stops as soon as it has
+enough.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from .models import AuditAction, AuditEntry
+
+logger = logging.getLogger(__name__)
+
+
+_AUDIT_NS_PREFIX: str = "audit"
+
+
+def _bucket_namespace(bucket_key: str) -> tuple[str, str]:
+    return (_AUDIT_NS_PREFIX, bucket_key)
+
+
+def _month_buckets_descending(start: datetime, end: datetime) -> list[str]:
+    """Year-month bucket keys covering [start, end] in reverse order.
+
+    Both endpoints are inclusive at month granularity.
+    """
+    if start > end:
+        start, end = end, start
+    cursor = datetime(end.year, end.month, 1, tzinfo=UTC)
+    floor = datetime(start.year, start.month, 1, tzinfo=UTC)
+    out: list[str] = []
+    while cursor >= floor:
+        out.append(f"{cursor.year:04d}_{cursor.month:02d}")
+        # Step back one month.
+        if cursor.month == 1:
+            cursor = cursor.replace(year=cursor.year - 1, month=12)
+        else:
+            cursor = cursor.replace(month=cursor.month - 1)
+    return out
+
+
+class AuditStore:
+    """Sanctioned read/write surface for the audit log."""
+
+    def __init__(self, store: Any) -> None:
+        super().__init__()
+        self._store = store
+
+    async def write(
+        self,
+        *,
+        actor: str,
+        action: AuditAction,
+        target: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> AuditEntry:
+        """Append a new audit entry. Returns the persisted record."""
+        entry = AuditEntry(
+            actor=actor,
+            action=action,
+            target=target,
+            metadata=metadata or {},
+        )
+        try:
+            await self._store.aput(
+                _bucket_namespace(entry.bucket_key()),
+                entry.id,
+                entry.model_dump(mode="json"),
+            )
+        except Exception:
+            # Audit must never block a real action. Log and swallow.
+            logger.exception(
+                "AuditStore.write failed: actor=%s action=%s target=%s",
+                actor,
+                action.value,
+                target,
+            )
+        return entry
+
+    async def query(
+        self,
+        *,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        actor: str | None = None,
+        action: AuditAction | None = None,
+        target: str | None = None,
+        limit: int = 100,
+    ) -> list[AuditEntry]:
+        """Return matching entries, newest-first.
+
+        All filters are AND'd. ``since`` defaults to the earliest
+        timestamp in the store (effectively unbounded); ``until``
+        defaults to ``now``. Returned list is at most ``limit`` long.
+        Buckets are scanned newest-first so the common case
+        ("last N entries") is cheap.
+        """
+        if limit <= 0:
+            return []
+        end_dt = until if until is not None else datetime.now(UTC)
+        # Default ``since`` to a wide window — without a real lower bound
+        # we'd have to know every bucket the store has ever held, which
+        # we don't. 10 years is arbitrary but cheap (120 buckets).
+        start_dt = (
+            since
+            if since is not None
+            else end_dt.replace(year=max(end_dt.year - 10, 1))
+        )
+
+        results: list[AuditEntry] = []
+        for bucket in _month_buckets_descending(start_dt, end_dt):
+            try:
+                items: list[Any] = await self._store.asearch(
+                    _bucket_namespace(bucket), limit=10_000
+                )
+            except Exception:
+                logger.exception("AuditStore.query failed on bucket %s", bucket)
+                continue
+            entries: list[AuditEntry] = []
+            for item in items:
+                payload = item.value
+                if not isinstance(payload, dict):
+                    continue
+                try:
+                    entry = AuditEntry.model_validate(payload)
+                except Exception:
+                    logger.exception(
+                        "AuditStore: invalid entry %s in bucket %s",
+                        item.key,
+                        bucket,
+                    )
+                    continue
+                if entry.timestamp < start_dt or entry.timestamp > end_dt:
+                    continue
+                if actor is not None and entry.actor != actor:
+                    continue
+                if action is not None and entry.action != action:
+                    continue
+                if target is not None and entry.target != target:
+                    continue
+                entries.append(entry)
+            entries.sort(key=lambda e: e.timestamp, reverse=True)
+            for entry in entries:
+                results.append(entry)
+                if len(results) >= limit:
+                    return results
+        return results

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,232 @@
+"""Coverage — append-only audit log added by issue #24.
+
+The :class:`AuditStore` is the only sanctioned read/write surface
+for audit data. Entries land in time-bucketed namespaces so monthly
+listings stay cheap; query supports newest-first iteration with
+filters by actor / action / target / time window.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from langgraph_kit.core.audit import AuditAction, AuditEntry, AuditStore
+from tests.conftest import MockStore
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+def test_audit_entry_defaults_are_set() -> None:
+    entry = AuditEntry(
+        actor="user:1", action=AuditAction.AGENT_INVOKE, target="thread:abc"
+    )
+    assert entry.id  # UUID populated
+    assert entry.timestamp.tzinfo is not None
+    assert entry.metadata == {}
+
+
+def test_bucket_key_is_year_month() -> None:
+    entry = AuditEntry(
+        actor="user:1",
+        action=AuditAction.AGENT_INVOKE,
+        target="thread:abc",
+        timestamp=datetime(2026, 4, 15, 12, 0, tzinfo=UTC),
+    )
+    assert entry.bucket_key() == "2026_04"
+
+
+def test_audit_action_enum_has_expected_members() -> None:
+    members = {a.value for a in AuditAction}
+    assert "agent_invoke" in members
+    assert "memory_create" in members
+    assert "injection_detected" in members
+    assert "output_redacted" in members
+
+
+# ---------------------------------------------------------------------------
+# Store: write
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_persists_entry_to_correct_bucket() -> None:
+    store = MockStore()
+    audit = AuditStore(store)
+    entry = await audit.write(
+        actor="user:1",
+        action=AuditAction.AGENT_INVOKE,
+        target="thread:abc",
+        metadata={"foo": "bar"},
+    )
+    bucket_ns = ("audit", entry.bucket_key())
+    assert entry.id in store._data.get(bucket_ns, {})
+    payload = store._data[bucket_ns][entry.id]
+    assert payload["actor"] == "user:1"
+    assert payload["action"] == "agent_invoke"
+    assert payload["metadata"] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_write_returns_persisted_entry_with_id_and_timestamp() -> None:
+    audit = AuditStore(MockStore())
+    entry = await audit.write(
+        actor="system",
+        action=AuditAction.OUTPUT_REDACTED,
+        target="message:m1",
+    )
+    assert entry.id
+    assert entry.actor == "system"
+    assert entry.timestamp <= datetime.now(UTC)
+
+
+@pytest.mark.asyncio
+async def test_write_failure_in_underlying_store_does_not_raise(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Audit must never block a real action — Store failures get logged."""
+
+    class _BrokenStore(MockStore):
+        async def aput(self, namespace, key, value) -> None:  # type: ignore[no-untyped-def]
+            raise RuntimeError("audit store offline")
+
+    audit = AuditStore(_BrokenStore())
+    with caplog.at_level("ERROR"):
+        result = await audit.write(
+            actor="system",
+            action=AuditAction.AGENT_INVOKE,
+            target="thread:1",
+        )
+    assert result.actor == "system"
+    assert any("AuditStore.write failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Store: query
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_returns_newest_first() -> None:
+    audit = AuditStore(MockStore())
+    e1 = await audit.write(
+        actor="user:1", action=AuditAction.AGENT_INVOKE, target="t:1"
+    )
+    e2 = await audit.write(
+        actor="user:1", action=AuditAction.AGENT_INVOKE, target="t:2"
+    )
+    e3 = await audit.write(
+        actor="user:1", action=AuditAction.AGENT_INVOKE, target="t:3"
+    )
+    results = await audit.query(limit=10)
+    # Within the same bucket, sort is by timestamp descending.
+    ids = [r.id for r in results]
+    assert ids[0] == e3.id
+    assert e2.id in ids
+    assert e1.id in ids
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_actor() -> None:
+    audit = AuditStore(MockStore())
+    await audit.write(actor="user:1", action=AuditAction.AGENT_INVOKE, target="t1")
+    await audit.write(actor="user:2", action=AuditAction.AGENT_INVOKE, target="t2")
+    results = await audit.query(actor="user:1")
+    assert all(r.actor == "user:1" for r in results)
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_action() -> None:
+    audit = AuditStore(MockStore())
+    await audit.write(actor="x", action=AuditAction.AGENT_INVOKE, target="t1")
+    await audit.write(actor="x", action=AuditAction.OUTPUT_REDACTED, target="t1")
+    await audit.write(actor="x", action=AuditAction.INJECTION_DETECTED, target="t1")
+    results = await audit.query(action=AuditAction.OUTPUT_REDACTED)
+    assert len(results) == 1
+    assert results[0].action == AuditAction.OUTPUT_REDACTED
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_target() -> None:
+    audit = AuditStore(MockStore())
+    await audit.write(actor="x", action=AuditAction.AGENT_INVOKE, target="t1")
+    await audit.write(actor="x", action=AuditAction.AGENT_INVOKE, target="t2")
+    results = await audit.query(target="t2")
+    assert len(results) == 1
+    assert results[0].target == "t2"
+
+
+@pytest.mark.asyncio
+async def test_query_respects_limit() -> None:
+    audit = AuditStore(MockStore())
+    for i in range(20):
+        await audit.write(actor="x", action=AuditAction.AGENT_INVOKE, target=f"t:{i}")
+    results = await audit.query(limit=5)
+    assert len(results) == 5
+
+
+@pytest.mark.asyncio
+async def test_query_with_zero_limit_returns_empty() -> None:
+    audit = AuditStore(MockStore())
+    await audit.write(actor="x", action=AuditAction.AGENT_INVOKE, target="t")
+    assert await audit.query(limit=0) == []
+
+
+@pytest.mark.asyncio
+async def test_query_filters_by_time_window() -> None:
+    audit = AuditStore(MockStore())
+    await audit.write(actor="x", action=AuditAction.AGENT_INVOKE, target="now")
+    now = datetime.now(UTC)
+    # Window in the past — excludes the entry we just wrote.
+    results = await audit.query(
+        since=now - timedelta(days=30), until=now - timedelta(days=29)
+    )
+    assert results == []
+    # Wide window — includes it.
+    results = await audit.query(
+        since=now - timedelta(hours=1), until=now + timedelta(hours=1)
+    )
+    assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_walks_buckets_in_reverse_chronological_order() -> None:
+    """Spread entries across two month buckets via direct store write
+    (bypassing AuditStore.write so we control the timestamp), then
+    confirm the newer bucket is read first."""
+    store = MockStore()
+    # Old entry in 2025_12 bucket.
+    old_entry = AuditEntry(
+        actor="x",
+        action=AuditAction.AGENT_INVOKE,
+        target="old",
+        timestamp=datetime(2025, 12, 15, 12, 0, tzinfo=UTC),
+    )
+    await store.aput(
+        ("audit", "2025_12"), old_entry.id, old_entry.model_dump(mode="json")
+    )
+    # New entry in 2026_04 bucket.
+    new_entry = AuditEntry(
+        actor="x",
+        action=AuditAction.AGENT_INVOKE,
+        target="new",
+        timestamp=datetime(2026, 4, 15, 12, 0, tzinfo=UTC),
+    )
+    await store.aput(
+        ("audit", "2026_04"), new_entry.id, new_entry.model_dump(mode="json")
+    )
+
+    audit = AuditStore(store)
+    # Query a window that includes both.
+    results = await audit.query(
+        since=datetime(2025, 1, 1, tzinfo=UTC),
+        until=datetime(2026, 12, 31, tzinfo=UTC),
+        limit=10,
+    )
+    assert len(results) == 2
+    assert results[0].target == "new"
+    assert results[1].target == "old"


### PR DESCRIPTION
## Summary

- New `langgraph_kit.core.audit` module: `AuditAction` enum, `AuditEntry` Pydantic model, `AuditStore` (Store-backed read/write).
- Time-bucketed storage (`("audit", "YYYY_MM")`) for cheap month-range listings; `query()` walks newest-first and short-circuits.
- `write()` is failure-tolerant: Store errors are logged + swallowed so audit never blocks the action it's recording.

## Deferred to follow-up

- FastAPI admin endpoint for query.
- Instrumentation of memory CRUD / HITL / agent invoke (one-line additions but touch many call sites).
- Signature chain.
- Retention policies (linked to #31 GDPR work).

## Test plan

- [x] 14 cases in `tests/test_audit_log.py`: model defaults and bucket_key, enum surface, write persists to the right bucket, write returns persisted entry, write-failure is swallowed-and-logged, query newest-first, filters by actor / action / target / time-window, limit + zero-limit, walks buckets in reverse chronological order.
- [x] Full suite: 1025 passed (was 1011).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #24