### PR TITLE
Add per-user rate-limit middleware (token bucket, in-memory backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Per-user rate limiting.** New `langgraph_kit.contrib.rate_limit`
+  module with a token-bucket primitive (`TokenBucket`), an
+  in-memory backend (`InMemoryRateLimitBackend`), and an ASGI
+  middleware (`RateLimitMiddleware`) that emits `429 Too Many
+  Requests` with a `Retry-After` header on bucket exhaustion. Keyed
+  by the FastAPI `current_user` dependency by default; anonymous
+  traffic shares one bucket; health-check paths bypass. Backend is
+  swappable via the `RateLimitBackend` Protocol so a multi-process
+  Redis backend can drop in later (#27 cross-process consistency).
+  Tokens-per-day enforcement (the second limit in the issue) is
+  deferred — it integrates with the existing `BudgetManager`. Fixes
+  [#25](https://github.com/allada-homelab/langgraph-kit/issues/25).
+
 - **Append-only audit log.** New `langgraph_kit.core.audit` module ships
   `AuditAction` (bounded enum: agent_invoke, memory_create/update/delete,
   hitl_approve/reject, injection_detected, output_redacted, data_export/

--- a/src/langgraph_kit/contrib/rate_limit/__init__.py
+++ b/src/langgraph_kit/contrib/rate_limit/__init__.py
@@ -1,0 +1,29 @@
+"""Per-user rate limiting for the FastAPI surface.
+
+Issue #25 lands the foundation: a token-bucket implementation, an
+in-memory single-process backend, a generic backend Protocol so a
+multi-process Redis backend can drop in later, and a Starlette /
+FastAPI middleware that enforces requests-per-minute keyed by the
+``current_user`` dependency.
+
+Tokens-per-day enforcement (the second limit in the issue) is
+deferred — it integrates with the existing :class:`BudgetManager`
+and is materially separate work.
+"""
+
+from .backend import (
+    InMemoryRateLimitBackend,
+    RateLimitBackend,
+    RateLimitDecision,
+    TokenBucket,
+)
+from .middleware import RateLimitMiddleware, default_user_key
+
+__all__ = [
+    "InMemoryRateLimitBackend",
+    "RateLimitBackend",
+    "RateLimitDecision",
+    "RateLimitMiddleware",
+    "TokenBucket",
+    "default_user_key",
+]

--- a/src/langgraph_kit/contrib/rate_limit/backend.py
+++ b/src/langgraph_kit/contrib/rate_limit/backend.py
@@ -1,0 +1,139 @@
+"""Token-bucket rate-limit primitives.
+
+Two pieces:
+
+- :class:`TokenBucket` — a single bucket with a configurable rate
+  (tokens / second) and capacity (max burst). Pure data structure;
+  no I/O, async-safe under a single-thread event loop.
+- :class:`RateLimitBackend` — the protocol the middleware speaks to.
+  In-memory backend ships in this module; a multi-process Redis
+  backend can implement the same protocol later (#27 cross-process
+  consistency).
+
+The bucket uses a continuous-refill model: every check first refills
+based on wall-clock time since the last touch, then attempts to
+spend ``n`` tokens. If the bucket lacks the tokens, ``take`` returns
+:class:`RateLimitDecision` with ``allowed=False`` and a
+``retry_after_seconds`` that says how long until the requested
+amount would be available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass
+class RateLimitDecision:
+    """Result of a single :meth:`RateLimitBackend.take` call."""
+
+    allowed: bool
+    retry_after_seconds: float = 0.0
+    remaining: float = 0.0
+
+
+@dataclass
+class TokenBucket:
+    """Continuous-refill token bucket.
+
+    ``rate_per_second`` controls the steady-state refill rate;
+    ``capacity`` is the max burst the bucket can hold. The bucket
+    starts full so first-request latency isn't spent waiting on
+    a fill. Internal state is wall-clock based (``time.monotonic``)
+    so freezing/thawing the process doesn't grant retroactive
+    capacity.
+    """
+
+    capacity: float
+    rate_per_second: float
+    tokens: float = field(init=False)
+    _last_refill: float = field(init=False, default_factory=time.monotonic)
+
+    def __post_init__(self) -> None:
+        if self.capacity <= 0 or self.rate_per_second <= 0:
+            msg = "capacity and rate_per_second must be positive"
+            raise ValueError(msg)
+        self.tokens = float(self.capacity)
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        elapsed = now - self._last_refill
+        if elapsed > 0:
+            self.tokens = min(
+                self.capacity, self.tokens + elapsed * self.rate_per_second
+            )
+            self._last_refill = now
+
+    def take(self, n: float = 1.0) -> RateLimitDecision:
+        """Attempt to spend ``n`` tokens. Refills first.
+
+        Returns ``allowed=False`` when the bucket lacks tokens, with
+        ``retry_after_seconds`` set to the wait that would make the
+        request fit. Does not deduct tokens on a denied take.
+        """
+        if n <= 0:
+            return RateLimitDecision(allowed=True, remaining=self.tokens)
+        self._refill()
+        if self.tokens >= n:
+            self.tokens -= n
+            return RateLimitDecision(allowed=True, remaining=self.tokens)
+        deficit = n - self.tokens
+        wait = deficit / self.rate_per_second if self.rate_per_second > 0 else 0.0
+        return RateLimitDecision(
+            allowed=False,
+            retry_after_seconds=wait,
+            remaining=self.tokens,
+        )
+
+
+class RateLimitBackend(Protocol):
+    """Pluggable backing store for per-key rate limits.
+
+    The middleware only depends on ``take``; new backends (Redis,
+    Postgres advisory locks, etc.) implement this Protocol without
+    needing to be subclasses of :class:`InMemoryRateLimitBackend`.
+    """
+
+    async def take(
+        self, key: str, n: float = 1.0
+    ) -> RateLimitDecision:  # pragma: no cover — interface only
+        ...
+
+
+class InMemoryRateLimitBackend:
+    """Token-bucket store keyed by string. Single-process only.
+
+    Multi-worker deployments need a cross-process backend (Redis is
+    the obvious choice; #27 covers the broader cross-process story).
+    """
+
+    def __init__(
+        self,
+        *,
+        capacity: float,
+        rate_per_second: float,
+    ) -> None:
+        super().__init__()
+        if capacity <= 0 or rate_per_second <= 0:
+            msg = "capacity and rate_per_second must be positive"
+            raise ValueError(msg)
+        self._capacity = float(capacity)
+        self._rate = float(rate_per_second)
+        self._buckets: dict[str, TokenBucket] = {}
+        self._lock = asyncio.Lock()
+
+    def _bucket(self, key: str) -> TokenBucket:
+        bucket = self._buckets.get(key)
+        if bucket is None:
+            bucket = TokenBucket(capacity=self._capacity, rate_per_second=self._rate)
+            self._buckets[key] = bucket
+        return bucket
+
+    async def take(self, key: str, n: float = 1.0) -> RateLimitDecision:
+        # asyncio.Lock guards the dict-mutation + bucket take so two
+        # concurrent requests for the same key don't double-spend.
+        async with self._lock:
+            return self._bucket(key).take(n)

--- a/src/langgraph_kit/contrib/rate_limit/middleware.py
+++ b/src/langgraph_kit/contrib/rate_limit/middleware.py
@@ -1,0 +1,111 @@
+"""Starlette/FastAPI middleware that enforces per-user rate limits.
+
+Drops in via :meth:`fastapi.FastAPI.add_middleware` (or directly on
+a Starlette app). When a request would exceed the configured rate
+the middleware returns ``HTTP 429 Too Many Requests`` with a
+``Retry-After`` header and a small JSON body describing the limit
+that fired.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from .backend import RateLimitBackend
+
+_ANONYMOUS_KEY: str = "anonymous"
+
+
+def default_user_key(scope: dict[str, Any]) -> str:
+    """Default key extractor: ASGI scope -> rate-limit bucket key.
+
+    Looks at ``scope["state"]["current_user"]`` (set by FastAPI's
+    dependency-injection pipeline at request time) and falls back to
+    a single shared ``"anonymous"`` bucket so unauthenticated traffic
+    is still bounded.
+    """
+    state = scope.get("state") or {}
+    user = state.get("current_user")
+    if user is None:
+        return _ANONYMOUS_KEY
+    user_id = getattr(user, "id", None) or getattr(user, "user_id", None)
+    if user_id is None:
+        return _ANONYMOUS_KEY
+    return f"user:{user_id}"
+
+
+class RateLimitMiddleware:
+    """ASGI middleware enforcing a per-user request rate.
+
+    Uses a :class:`RateLimitBackend` (in-memory by default) to take
+    one token per HTTP request. Excludes the configured set of paths
+    (default ``/healthz``, ``/readyz``) so probes never get throttled.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        backend: RateLimitBackend,
+        *,
+        key_fn: Callable[[dict[str, Any]], str] = default_user_key,
+        excluded_paths: tuple[str, ...] = ("/healthz", "/readyz"),
+        cost_per_request: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self._app = app
+        self._backend = backend
+        self._key_fn = key_fn
+        self._excluded = tuple(excluded_paths)
+        self._cost = float(cost_per_request)
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if any(
+            path == ex or path.startswith(ex.rstrip("/") + "/") for ex in self._excluded
+        ):
+            await self._app(scope, receive, send)
+            return
+
+        key = self._key_fn(scope)
+        decision = await self._backend.take(key, n=self._cost)
+        if decision.allowed:
+            await self._app(scope, receive, send)
+            return
+
+        # Limit hit — short-circuit with 429 + Retry-After.
+        retry_after = max(1, math.ceil(decision.retry_after_seconds))
+        body = json.dumps(
+            {
+                "error": "rate_limited",
+                "message": (
+                    f"Rate limit exceeded for {key}. Retry after {retry_after}s."
+                ),
+                "retry_after_seconds": retry_after,
+            }
+        ).encode()
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 429,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"retry-after", str(retry_after).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,296 @@
+"""Coverage — per-user rate limit middleware + token bucket added by issue #25.
+
+Tests exercise the bucket primitive, the in-memory backend's
+multi-key isolation + concurrency safety, and the ASGI middleware's
+allow / deny / excluded-path / anonymous-key behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import pytest
+
+from langgraph_kit.contrib.rate_limit import (
+    InMemoryRateLimitBackend,
+    RateLimitMiddleware,
+    TokenBucket,
+    default_user_key,
+)
+
+# ---------------------------------------------------------------------------
+# TokenBucket
+# ---------------------------------------------------------------------------
+
+
+def test_token_bucket_starts_full() -> None:
+    bucket = TokenBucket(capacity=10.0, rate_per_second=1.0)
+    assert bucket.tokens == 10.0
+
+
+def test_token_bucket_take_succeeds_until_empty() -> None:
+    bucket = TokenBucket(capacity=3.0, rate_per_second=1.0)
+    for _ in range(3):
+        assert bucket.take(1.0).allowed is True
+    decision = bucket.take(1.0)
+    assert decision.allowed is False
+    assert decision.retry_after_seconds > 0
+
+
+def test_token_bucket_does_not_deduct_on_denial() -> None:
+    bucket = TokenBucket(capacity=1.0, rate_per_second=1.0)
+    assert bucket.take(1.0).allowed is True
+    assert bucket.tokens < 1.0
+    pre = bucket.tokens
+    decision = bucket.take(1.0)
+    assert decision.allowed is False
+    # Deduction did not happen on the denied take (tokens may have
+    # refilled slightly between checks but never go down by 1.0).
+    assert bucket.tokens >= pre - 1e-6
+
+
+def test_token_bucket_refills_over_time() -> None:
+    bucket = TokenBucket(capacity=1.0, rate_per_second=100.0)
+    bucket.take(1.0)
+    assert bucket.take(1.0).allowed is False
+    time.sleep(0.05)  # ~5 tokens worth
+    assert bucket.take(1.0).allowed is True
+
+
+def test_token_bucket_caps_at_capacity_after_long_idle() -> None:
+    bucket = TokenBucket(capacity=2.0, rate_per_second=1000.0)
+    bucket.take(2.0)
+    time.sleep(0.05)
+    bucket._refill()  # explicit, deterministic
+    assert bucket.tokens == 2.0
+
+
+def test_token_bucket_rejects_invalid_init() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        TokenBucket(capacity=0, rate_per_second=1.0)
+    with pytest.raises(ValueError, match="positive"):
+        TokenBucket(capacity=1.0, rate_per_second=-1.0)
+
+
+def test_token_bucket_take_zero_is_always_allowed() -> None:
+    bucket = TokenBucket(capacity=1.0, rate_per_second=1.0)
+    bucket.take(1.0)  # drain
+    assert bucket.take(0.0).allowed is True
+
+
+# ---------------------------------------------------------------------------
+# InMemoryRateLimitBackend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backend_separate_buckets_per_key() -> None:
+    backend = InMemoryRateLimitBackend(capacity=2.0, rate_per_second=0.001)
+    # Drain user A
+    assert (await backend.take("user:a")).allowed is True
+    assert (await backend.take("user:a")).allowed is True
+    assert (await backend.take("user:a")).allowed is False
+    # User B is unaffected
+    assert (await backend.take("user:b")).allowed is True
+
+
+@pytest.mark.asyncio
+async def test_backend_concurrent_takes_dont_oversubscribe() -> None:
+    """asyncio.Lock guards the bucket — N concurrent takes against
+    capacity=N must all succeed exactly N times."""
+    backend = InMemoryRateLimitBackend(capacity=10.0, rate_per_second=0.001)
+    decisions = await asyncio.gather(*(backend.take("k") for _ in range(20)))
+    allowed = sum(1 for d in decisions if d.allowed)
+    assert allowed == 10  # exactly the capacity, no over-take
+
+
+# ---------------------------------------------------------------------------
+# default_user_key
+# ---------------------------------------------------------------------------
+
+
+def test_default_user_key_falls_back_to_anonymous_when_no_user() -> None:
+    assert default_user_key({}) == "anonymous"
+    assert default_user_key({"state": {}}) == "anonymous"
+    assert default_user_key({"state": {"current_user": None}}) == "anonymous"
+
+
+def test_default_user_key_extracts_user_id() -> None:
+    class _User:
+        id = "alice"
+
+    assert default_user_key({"state": {"current_user": _User()}}) == "user:alice"
+
+
+def test_default_user_key_falls_back_when_user_has_no_id() -> None:
+    class _User:
+        pass
+
+    assert default_user_key({"state": {"current_user": _User()}}) == "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# Middleware (ASGI-level smoke test)
+# ---------------------------------------------------------------------------
+
+
+class _DummyApp:
+    """Trivial ASGI app that always returns 200 OK with empty body."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Any,
+        send: Any,
+    ) -> None:
+        self.calls += 1
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+
+async def _drive(
+    middleware: RateLimitMiddleware, scope: dict[str, Any]
+) -> tuple[int, dict[bytes, bytes], bytes]:
+    """Run a request through the middleware and capture the response."""
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    headers = dict(start.get("headers", []))
+    body_message = next(
+        (m for m in sent if m["type"] == "http.response.body"), {"body": b""}
+    )
+    return start["status"], headers, body_message.get("body", b"")
+
+
+@pytest.mark.asyncio
+async def test_middleware_allows_under_limit() -> None:
+    app = _DummyApp()
+    backend = InMemoryRateLimitBackend(capacity=2.0, rate_per_second=0.001)
+    mw = RateLimitMiddleware(app, backend)
+    scope = {"type": "http", "path": "/agents", "state": {}}
+
+    status, _, _ = await _drive(mw, scope)
+    assert status == 200
+    assert app.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_middleware_blocks_over_limit_with_429() -> None:
+    app = _DummyApp()
+    backend = InMemoryRateLimitBackend(capacity=1.0, rate_per_second=0.001)
+    mw = RateLimitMiddleware(app, backend)
+    scope = {"type": "http", "path": "/agents", "state": {}}
+
+    # First request consumes the only token.
+    s1, _, _ = await _drive(mw, scope)
+    assert s1 == 200
+    # Second request is denied.
+    s2, headers, body = await _drive(mw, scope)
+    assert s2 == 429
+    assert b"retry-after" in headers
+    parsed = json.loads(body)
+    assert parsed["error"] == "rate_limited"
+    assert parsed["retry_after_seconds"] >= 1
+    # Underlying app was NOT called the second time.
+    assert app.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_middleware_excludes_health_paths_from_limiting() -> None:
+    app = _DummyApp()
+    backend = InMemoryRateLimitBackend(capacity=1.0, rate_per_second=0.001)
+    mw = RateLimitMiddleware(app, backend)
+
+    # Pre-drain the anonymous bucket.
+    await backend.take("anonymous")
+
+    for path in ("/healthz", "/readyz"):
+        status, _, _ = await _drive(mw, {"type": "http", "path": path, "state": {}})
+        assert status == 200, f"{path} should bypass rate limit"
+
+
+@pytest.mark.asyncio
+async def test_middleware_passes_non_http_through() -> None:
+    """Lifespan / websocket scopes shouldn't go through the rate
+    limiter — they aren't user-driven requests."""
+    app = _DummyApp()
+    backend = InMemoryRateLimitBackend(
+        capacity=0.0001, rate_per_second=0.001
+    )  # super-tight
+    # Backend init forbids 0; use a bigger lifespan-shaped scope and
+    # confirm the middleware short-circuits.
+    backend = InMemoryRateLimitBackend(capacity=1.0, rate_per_second=0.001)
+    mw = RateLimitMiddleware(app, backend)
+
+    # Drain so HTTP would be denied; lifespan should still pass through.
+    await backend.take("anonymous")
+
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "lifespan.startup"}
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+
+    await mw({"type": "lifespan"}, receive, send)
+    # The dummy app responds with http.response.start for any scope
+    # — confirms our pass-through reached it.
+    assert any(m["type"] == "http.response.start" for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_middleware_buckets_anonymous_users_together() -> None:
+    """No user_id in scope → all anonymous traffic shares one bucket."""
+    app = _DummyApp()
+    backend = InMemoryRateLimitBackend(capacity=1.0, rate_per_second=0.001)
+    mw = RateLimitMiddleware(app, backend)
+    scope = {"type": "http", "path": "/agents", "state": {}}
+
+    s1, _, _ = await _drive(mw, scope)
+    s2, _, _ = await _drive(mw, scope)
+    assert s1 == 200
+    assert s2 == 429
+
+
+@pytest.mark.asyncio
+async def test_middleware_separates_buckets_per_user() -> None:
+    class _User:
+        def __init__(self, uid: str) -> None:
+            self.id = uid
+
+    app = _DummyApp()
+    backend = InMemoryRateLimitBackend(capacity=1.0, rate_per_second=0.001)
+    mw = RateLimitMiddleware(app, backend)
+
+    alice_scope = {
+        "type": "http",
+        "path": "/agents",
+        "state": {"current_user": _User("alice")},
+    }
+    bob_scope = {
+        "type": "http",
+        "path": "/agents",
+        "state": {"current_user": _User("bob")},
+    }
+
+    s1, _, _ = await _drive(mw, alice_scope)
+    s2, _, _ = await _drive(mw, bob_scope)
+    assert s1 == 200
+    assert s2 == 200  # different bucket, also allowed
+    s3, _, _ = await _drive(mw, alice_scope)
+    assert s3 == 429  # alice ran out


### PR DESCRIPTION
## Summary

- New `langgraph_kit.contrib.rate_limit` module: `TokenBucket`, `RateLimitDecision`, `RateLimitBackend` Protocol, `InMemoryRateLimitBackend`, `RateLimitMiddleware`, `default_user_key`.
- Token-bucket algorithm (continuous refill; bursts allowed; wall-clock based).
- Middleware emits `429 Too Many Requests` with `Retry-After`. Keyed by FastAPI `current_user`; anonymous traffic shares one bucket; `/healthz` + `/readyz` bypass.
- Concurrency-safe via `asyncio.Lock` — N concurrent takes against capacity=N succeed exactly N times.

## Deferred to follow-up

- Tokens-per-day budget (integrates with existing `BudgetManager`).
- Redis backend (drops in via the Protocol).
- Multi-tenant key prefixing.

## Test plan

- [x] 18 cases covering bucket primitive, backend isolation + concurrency, key extractor, middleware allow/deny/excluded-paths/anonymous/per-user/non-HTTP.
- [x] Full suite: 1043 passed (was 1025).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #25