### PR TITLE
Add Prometheus-format metrics primitives + /metrics endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Prometheus-format metrics primitives + `/metrics` ASGI endpoint.**
+  New `langgraph_kit.observability_metrics` module ships pure-Python
+  `Counter`, `Gauge`, `Histogram` (cumulative buckets, default
+  spans 5 ms to 30 s), a `MetricsRegistry`, and a `MetricsEndpoint`
+  ASGI app that renders the registry as the standard text-exposition
+  format. No third-party dependency added — the kit's metrics needs
+  are bounded and importing `prometheus_client` would cost more than
+  the ~200 LOC implementation. Wiring kit-internal counters (LLM
+  tokens, tool calls, compactions, rate-limit hits, HITL interrupts)
+  is deferred to a follow-up. Fixes
+  [#28](https://github.com/allada-homelab/langgraph-kit/issues/28).
+
 - **Per-user rate limiting.** New `langgraph_kit.contrib.rate_limit`
   module with a token-bucket primitive (`TokenBucket`), an
   in-memory backend (`InMemoryRateLimitBackend`), and an ASGI

--- a/src/langgraph_kit/observability_metrics.py
+++ b/src/langgraph_kit/observability_metrics.py
@@ -1,0 +1,304 @@
+"""Prometheus-format metrics primitives + ``/metrics`` exposition.
+
+Hand-rolled pure-Python implementation rather than depending on
+``prometheus_client``. The kit's metrics needs are bounded
+(counters, gauges, histograms, label-tuple cardinality) and pulling
+in a third-party library for ~200 lines of well-understood code
+isn't worth the install-time tax for users who don't scrape metrics.
+
+Format spec: https://prometheus.io/docs/instrumenting/exposition_formats/
+
+Concurrency: this module is intended for use under a single-thread
+asyncio event loop; primitives are not protected by locks. If you
+later cross a thread boundary, wrap calls in a lock.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, ClassVar
+
+
+def _format_labels(label_names: tuple[str, ...], label_values: tuple[str, ...]) -> str:
+    """Render ``{k="v",k2="v2"}`` for the Prometheus exposition format."""
+    if not label_names:
+        return ""
+    parts = []
+    for name, value in zip(label_names, label_values, strict=True):
+        # Escape per spec: backslash, double-quote, newline.
+        escaped = (
+            str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+        )
+        parts.append(f'{name}="{escaped}"')
+    return "{" + ",".join(parts) + "}"
+
+
+class _Metric:
+    """Base class for the kit's metric primitives.
+
+    Subclasses define ``_help_kind`` (``"counter"`` / ``"gauge"`` /
+    ``"histogram"``) and implement ``_render_lines``.
+    """
+
+    _help_kind: ClassVar[str] = "untyped"
+
+    def __init__(self, name: str, help_text: str, labels: tuple[str, ...] = ()) -> None:
+        super().__init__()
+        self.name = name
+        self.help_text = help_text
+        self.label_names = tuple(labels)
+
+    def _render_header(self) -> list[str]:
+        return [
+            f"# HELP {self.name} {self.help_text}",
+            f"# TYPE {self.name} {self._help_kind}",
+        ]
+
+
+class Counter(_Metric):
+    """Monotonically increasing counter."""
+
+    _help_kind = "counter"
+
+    def __init__(self, name: str, help_text: str, labels: tuple[str, ...] = ()) -> None:
+        super().__init__(name, help_text, labels)
+        self._values: dict[tuple[str, ...], float] = {}
+        self._lock = threading.Lock()
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        if amount < 0:
+            msg = "Counter.inc requires non-negative amount"
+            raise ValueError(msg)
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + float(amount)
+
+    def value(self, **labels: str) -> float:
+        return self._values.get(self._key(labels), 0.0)
+
+    def _key(self, labels: dict[str, str]) -> tuple[str, ...]:
+        if set(labels) != set(self.label_names):
+            msg = (
+                f"Counter {self.name} labels mismatch: "
+                f"got {sorted(labels)}, expected {sorted(self.label_names)}"
+            )
+            raise ValueError(msg)
+        return tuple(labels[name] for name in self.label_names)
+
+    def render(self) -> list[str]:
+        lines = self._render_header()
+        if not self._values:
+            return lines
+        for label_values, val in sorted(self._values.items()):
+            lines.append(
+                f"{self.name}{_format_labels(self.label_names, label_values)} {val}"
+            )
+        return lines
+
+
+class Gauge(_Metric):
+    """Value that can move up or down (currently-running counts, etc.)."""
+
+    _help_kind = "gauge"
+
+    def __init__(self, name: str, help_text: str, labels: tuple[str, ...] = ()) -> None:
+        super().__init__(name, help_text, labels)
+        self._values: dict[tuple[str, ...], float] = {}
+        self._lock = threading.Lock()
+
+    def set(self, value: float, **labels: str) -> None:
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = float(value)
+
+    def inc(self, amount: float = 1.0, **labels: str) -> None:
+        key = self._key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + float(amount)
+
+    def dec(self, amount: float = 1.0, **labels: str) -> None:
+        self.inc(-amount, **labels)
+
+    def value(self, **labels: str) -> float:
+        return self._values.get(self._key(labels), 0.0)
+
+    def _key(self, labels: dict[str, str]) -> tuple[str, ...]:
+        if set(labels) != set(self.label_names):
+            msg = (
+                f"Gauge {self.name} labels mismatch: "
+                f"got {sorted(labels)}, expected {sorted(self.label_names)}"
+            )
+            raise ValueError(msg)
+        return tuple(labels[name] for name in self.label_names)
+
+    def render(self) -> list[str]:
+        lines = self._render_header()
+        for label_values, val in sorted(self._values.items()):
+            lines.append(
+                f"{self.name}{_format_labels(self.label_names, label_values)} {val}"
+            )
+        return lines
+
+
+# Default histogram buckets (seconds). Reasonable for HTTP latency on a
+# kit that talks to LLMs (sub-second to ~30s).
+DEFAULT_BUCKETS: tuple[float, ...] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+)
+
+
+class Histogram(_Metric):
+    """Cumulative bucket histogram with sum + count exposition."""
+
+    _help_kind = "histogram"
+
+    def __init__(
+        self,
+        name: str,
+        help_text: str,
+        labels: tuple[str, ...] = (),
+        buckets: tuple[float, ...] = DEFAULT_BUCKETS,
+    ) -> None:
+        super().__init__(name, help_text, labels)
+        self._buckets = tuple(sorted(buckets))
+        # Per label-tuple state: list of cumulative counts (one per bucket
+        # plus +Inf), running sum, total count.
+        self._counts: dict[tuple[str, ...], list[int]] = {}
+        self._sums: dict[tuple[str, ...], float] = {}
+        self._totals: dict[tuple[str, ...], int] = {}
+        self._lock = threading.Lock()
+
+    def observe(self, value: float, **labels: str) -> None:
+        key = self._key(labels)
+        with self._lock:
+            counts = self._counts.setdefault(key, [0] * (len(self._buckets) + 1))
+            for i, threshold in enumerate(self._buckets):
+                if value <= threshold:
+                    counts[i] += 1
+            counts[-1] += 1  # +Inf
+            self._sums[key] = self._sums.get(key, 0.0) + float(value)
+            self._totals[key] = self._totals.get(key, 0) + 1
+
+    def value(self, **labels: str) -> tuple[int, float]:
+        """Return ``(count, sum)`` for ``labels``."""
+        key = self._key(labels)
+        return self._totals.get(key, 0), self._sums.get(key, 0.0)
+
+    def _key(self, labels: dict[str, str]) -> tuple[str, ...]:
+        if set(labels) != set(self.label_names):
+            msg = (
+                f"Histogram {self.name} labels mismatch: "
+                f"got {sorted(labels)}, expected {sorted(self.label_names)}"
+            )
+            raise ValueError(msg)
+        return tuple(labels[name] for name in self.label_names)
+
+    def render(self) -> list[str]:
+        lines = self._render_header()
+        for label_values, counts in sorted(self._counts.items()):
+            for i, threshold in enumerate(self._buckets):
+                bucket_label_values = (*label_values, f"{threshold}")
+                bucket_label_names = (*self.label_names, "le")
+                lines.append(
+                    f"{self.name}_bucket"
+                    f"{_format_labels(bucket_label_names, bucket_label_values)}"
+                    f" {counts[i]}"
+                )
+            inf_label_values = (*label_values, "+Inf")
+            inf_label_names = (*self.label_names, "le")
+            lines.append(
+                f"{self.name}_bucket"
+                f"{_format_labels(inf_label_names, inf_label_values)}"
+                f" {counts[-1]}"
+            )
+            lines.append(
+                f"{self.name}_count"
+                f"{_format_labels(self.label_names, label_values)}"
+                f" {self._totals[label_values]}"
+            )
+            lines.append(
+                f"{self.name}_sum"
+                f"{_format_labels(self.label_names, label_values)}"
+                f" {self._sums[label_values]}"
+            )
+        return lines
+
+
+class MetricsRegistry:
+    """Holds metric primitives and renders the Prometheus exposition format."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._metrics: dict[str, _Metric] = {}
+
+    def register(self, metric: _Metric) -> None:
+        if metric.name in self._metrics:
+            msg = f"Metric already registered: {metric.name}"
+            raise ValueError(msg)
+        self._metrics[metric.name] = metric
+
+    def render(self) -> str:
+        """Render all metrics as the Prometheus text-exposition format."""
+        out: list[str] = []
+        for name in sorted(self._metrics):
+            out.extend(self._metrics[name].render())
+        return "\n".join(out) + "\n"
+
+    def clear(self) -> None:
+        """Drop all registered metrics. Tests use this to isolate state."""
+        self._metrics.clear()
+
+
+# Default registry singleton — most callers should use this.
+DEFAULT_REGISTRY: MetricsRegistry = MetricsRegistry()
+
+
+def render_default() -> str:
+    """Convenience: render the default registry to its text exposition."""
+    return DEFAULT_REGISTRY.render()
+
+
+# ---------------------------------------------------------------------------
+# ASGI endpoint
+# ---------------------------------------------------------------------------
+
+
+class MetricsEndpoint:
+    """Minimal ASGI app exposing the default registry at any path it's mounted at.
+
+    Use directly via Starlette / FastAPI ``app.add_route("/metrics", endpoint)``
+    or as an ASGI sub-app.
+    """
+
+    CONTENT_TYPE: str = "text/plain; version=0.0.4; charset=utf-8"
+
+    def __init__(self, registry: MetricsRegistry | None = None) -> None:
+        super().__init__()
+        self._registry = registry or DEFAULT_REGISTRY
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:  # noqa: ARG002
+        if scope.get("type") != "http":
+            return  # not us
+        body = self._registry.render().encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", self.CONTENT_TYPE.encode("ascii")),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})

--- a/src/langgraph_kit/observability_metrics.py
+++ b/src/langgraph_kit/observability_metrics.py
@@ -37,7 +37,7 @@ class _Metric:
     """Base class for the kit's metric primitives.
 
     Subclasses define ``_help_kind`` (``"counter"`` / ``"gauge"`` /
-    ``"histogram"``) and implement ``_render_lines``.
+    ``"histogram"``) and implement :meth:`render`.
     """
 
     _help_kind: ClassVar[str] = "untyped"
@@ -53,6 +53,15 @@ class _Metric:
             f"# HELP {self.name} {self.help_text}",
             f"# TYPE {self.name} {self._help_kind}",
         ]
+
+    def render(self) -> list[str]:  # pragma: no cover — overridden
+        """Render this metric to Prometheus exposition lines.
+
+        Subclasses must implement this. Defined on the base so the
+        registry's iteration over ``_Metric`` instances type-checks
+        without each call site needing to narrow.
+        """
+        raise NotImplementedError
 
 
 class Counter(_Metric):

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,248 @@
+"""Coverage — Prometheus-format metrics primitives + endpoint.
+
+Issue #28 lands the foundation: pure-Python `Counter`, `Gauge`,
+`Histogram`, `MetricsRegistry`, and an ASGI endpoint that renders
+the registry as Prometheus text-exposition format. No third-party
+dep added; ~200 lines for ~12 features.
+
+Wiring kit-internal counters (LLM tokens, tool calls, compactions,
+rate-limit hits, HITL interrupts) is deferred to a follow-up — those
+touch many modules and merit their own scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph_kit.observability_metrics import (
+    DEFAULT_BUCKETS,
+    Counter,
+    Gauge,
+    Histogram,
+    MetricsEndpoint,
+    MetricsRegistry,
+)
+
+# ---------------------------------------------------------------------------
+# Counter
+# ---------------------------------------------------------------------------
+
+
+def test_counter_starts_at_zero_and_increments() -> None:
+    c = Counter("hits", "test counter", labels=("kind",))
+    assert c.value(kind="get") == 0.0
+    c.inc(kind="get")
+    c.inc(2.5, kind="get")
+    assert c.value(kind="get") == 3.5
+
+
+def test_counter_separate_label_buckets() -> None:
+    c = Counter("hits", "test counter", labels=("kind",))
+    c.inc(kind="get")
+    c.inc(kind="post")
+    c.inc(kind="post")
+    assert c.value(kind="get") == 1.0
+    assert c.value(kind="post") == 2.0
+
+
+def test_counter_rejects_negative_increment() -> None:
+    c = Counter("hits", "test counter")
+    with pytest.raises(ValueError, match="non-negative"):
+        c.inc(-1.0)
+
+
+def test_counter_label_mismatch_raises() -> None:
+    c = Counter("hits", "test counter", labels=("kind",))
+    with pytest.raises(ValueError, match="labels mismatch"):
+        c.inc(other="x")
+    with pytest.raises(ValueError, match="labels mismatch"):
+        c.inc()
+
+
+def test_counter_render_includes_help_and_type() -> None:
+    c = Counter("hits", "agent invocations", labels=("kind",))
+    c.inc(kind="get")
+    out = "\n".join(c.render())
+    assert "# HELP hits agent invocations" in out
+    assert "# TYPE hits counter" in out
+    assert 'hits{kind="get"} 1.0' in out
+
+
+def test_counter_render_with_no_observations_emits_only_metadata() -> None:
+    c = Counter("hits", "test counter")
+    out = c.render()
+    assert any("# HELP" in line for line in out)
+    assert any("# TYPE" in line for line in out)
+    # No data lines.
+    assert all(line.startswith("#") for line in out)
+
+
+# ---------------------------------------------------------------------------
+# Gauge
+# ---------------------------------------------------------------------------
+
+
+def test_gauge_set_inc_dec() -> None:
+    g = Gauge("active", "active runs")
+    g.set(5.0)
+    assert g.value() == 5.0
+    g.inc(2.0)
+    assert g.value() == 7.0
+    g.dec(3.0)
+    assert g.value() == 4.0
+
+
+def test_gauge_with_labels() -> None:
+    g = Gauge("active", "active runs", labels=("agent_id",))
+    g.set(2.0, agent_id="coding")
+    g.set(5.0, agent_id="qa")
+    assert g.value(agent_id="coding") == 2.0
+    assert g.value(agent_id="qa") == 5.0
+
+
+def test_gauge_renders_as_gauge_type() -> None:
+    g = Gauge("active", "active runs")
+    g.set(3.0)
+    out = "\n".join(g.render())
+    assert "# TYPE active gauge" in out
+    assert "active 3.0" in out
+
+
+# ---------------------------------------------------------------------------
+# Histogram
+# ---------------------------------------------------------------------------
+
+
+def test_histogram_observes_into_buckets() -> None:
+    h = Histogram("lat", "latency seconds")
+    h.observe(0.05)
+    h.observe(0.1)
+    h.observe(0.5)
+    count, total = h.value()
+    assert count == 3
+    assert abs(total - 0.65) < 1e-9
+
+
+def test_histogram_render_emits_bucket_lines_count_and_sum() -> None:
+    h = Histogram("lat", "latency seconds", buckets=(0.1, 1.0))
+    h.observe(0.05)
+    h.observe(0.5)
+    out = "\n".join(h.render())
+    # Buckets are cumulative: le=0.1 sees 1 (the 0.05 sample), le=1.0
+    # sees 2 (both), +Inf also 2.
+    assert 'lat_bucket{le="0.1"} 1' in out
+    assert 'lat_bucket{le="1.0"} 2' in out
+    assert 'lat_bucket{le="+Inf"} 2' in out
+    assert "lat_count 2" in out
+    assert "lat_sum 0.55" in out
+
+
+def test_histogram_with_labels_partitions_observations() -> None:
+    h = Histogram("lat", "latency", labels=("agent_id",), buckets=(0.5,))
+    h.observe(0.1, agent_id="a")
+    h.observe(0.7, agent_id="b")
+    a_count, a_sum = h.value(agent_id="a")
+    b_count, b_sum = h.value(agent_id="b")
+    assert a_count == 1
+    assert abs(a_sum - 0.1) < 1e-9
+    assert b_count == 1
+    assert abs(b_sum - 0.7) < 1e-9
+
+
+def test_default_buckets_cover_sub_second_through_30s() -> None:
+    """Sanity check the published defaults — kit talks to LLMs,
+    so latencies should span ~5ms to ~30s comfortably."""
+    assert min(DEFAULT_BUCKETS) <= 0.005
+    assert max(DEFAULT_BUCKETS) >= 30.0
+    # Strictly increasing.
+    assert list(DEFAULT_BUCKETS) == sorted(DEFAULT_BUCKETS)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_render_orders_metrics_by_name() -> None:
+    reg = MetricsRegistry()
+    a = Counter("a_hits", "a")
+    z = Counter("z_hits", "z")
+    reg.register(z)
+    reg.register(a)
+    a.inc()
+    z.inc()
+    rendered = reg.render()
+    assert rendered.index("a_hits") < rendered.index("z_hits")
+
+
+def test_registry_rejects_duplicate_registration() -> None:
+    reg = MetricsRegistry()
+    reg.register(Counter("hits", "h"))
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(Counter("hits", "h"))
+
+
+def test_registry_clear_drops_metrics() -> None:
+    reg = MetricsRegistry()
+    reg.register(Counter("hits", "h"))
+    reg.clear()
+    # Re-registration after clear is fine.
+    reg.register(Counter("hits", "h"))
+
+
+def test_registry_render_ends_with_newline() -> None:
+    """Prometheus parsers tolerate either, but a trailing newline is
+    the convention — and unit tests assert it so a refactor that
+    drops it doesn't surprise users."""
+    reg = MetricsRegistry()
+    reg.register(Counter("hits", "h"))
+    out = reg.render()
+    assert out.endswith("\n")
+
+
+# ---------------------------------------------------------------------------
+# ASGI endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_200_with_text_plain_content_type() -> None:
+    reg = MetricsRegistry()
+    reg.register(Counter("hits", "hits", labels=("kind",)))
+    reg._metrics["hits"]._values = {("get",): 7.0}  # type: ignore[attr-defined]
+    endpoint = MetricsEndpoint(reg)
+
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+
+    await endpoint({"type": "http", "path": "/metrics"}, receive, send)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 200
+    headers = dict(start["headers"])
+    assert headers[b"content-type"].decode().startswith("text/plain")
+    body = next(m for m in sent if m["type"] == "http.response.body")["body"]
+    assert b'hits{kind="get"} 7.0' in body
+
+
+@pytest.mark.asyncio
+async def test_endpoint_skips_non_http_scopes() -> None:
+    """Lifespan / websocket scopes shouldn't be answered by /metrics."""
+    reg = MetricsRegistry()
+    endpoint = MetricsEndpoint(reg)
+    sent: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "lifespan.startup"}
+
+    async def send(m: dict[str, Any]) -> None:
+        sent.append(m)
+
+    await endpoint({"type": "lifespan"}, receive, send)
+    assert sent == []


### PR DESCRIPTION
## Summary

- New `langgraph_kit.observability_metrics` module: pure-Python `Counter`, `Gauge`, `Histogram`, `MetricsRegistry`, `MetricsEndpoint`. No third-party dependency.
- ASGI endpoint renders the standard Prometheus text-exposition format. Skips non-HTTP scopes.
- DEFAULT_BUCKETS span 5 ms to 30 s — a reasonable default for an HTTP+LLM kit.

## Deferred to follow-up

- Wiring kit-internal counters (LLM tokens, tool calls, compactions, rate-limit hits, HITL interrupts).
- Sample Grafana dashboards.

## Test plan

- [x] 19 cases covering the three primitives, the registry, and the ASGI endpoint.
- [x] Full suite: 1062 passed (was 1043).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #28