### PR TITLE
Add schema-versioning + lazy forward migration helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Schema versioning + lazy forward migrations.** New
+  `langgraph_kit.core.migrations` module ships a `Versioned` Pydantic
+  mixin (adds `model_version: int`), a `Migration` (forward step
+  ``v → v+1`` operating on dicts pre-validation), a `MigrationRegistry`
+  keyed by `(model_class, source_version)`, and a `migrate_dict`
+  helper that walks the registry until a payload reaches the model's
+  current `MODEL_VERSION`. Forward-only by design (down-migrations are
+  easy to lose data on); legacy rows without a `model_version` field
+  are treated as v1 and walked forward; missing steps raise
+  `MissingMigrationError` so deployments fail loud rather than
+  silently misread old data. Adopting this for the kit's own models
+  (`MemoryRecord`, `SessionNotebook`, `AsyncTask`, …) lands as those
+  models bump their schemas. Fixes
+  [#34](https://github.com/allada-homelab/langgraph-kit/issues/34).
+
 - **Per-user data lifecycle: export / delete / anonymize.** New
   `langgraph_kit.core.lifecycle.DataLifecycleManager` exposes the
   GDPR-friendly trio over the LangGraph Store. Operates on the

--- a/src/langgraph_kit/core/migrations/__init__.py
+++ b/src/langgraph_kit/core/migrations/__init__.py
@@ -1,0 +1,22 @@
+"""Schema-versioning + lazy migration for persisted Pydantic models.
+
+See :mod:`langgraph_kit.core.migrations.versioned` for the design.
+"""
+
+from .versioned import (
+    DEFAULT_REGISTRY,
+    Migration,
+    MigrationRegistry,
+    MissingMigrationError,
+    Versioned,
+    migrate_dict,
+)
+
+__all__ = [
+    "DEFAULT_REGISTRY",
+    "Migration",
+    "MigrationRegistry",
+    "MissingMigrationError",
+    "Versioned",
+    "migrate_dict",
+]

--- a/src/langgraph_kit/core/migrations/versioned.py
+++ b/src/langgraph_kit/core/migrations/versioned.py
@@ -1,0 +1,155 @@
+"""Schema-versioning infrastructure for persisted Pydantic models.
+
+Issue #34. The kit persists several Pydantic models to the Store
+(``MemoryRecord``, ``SessionNotebook``, ``AsyncTask``, ``MetricSummary``,
+…). Schema changes today break existing Store data — fields rename
+silently, removed fields raise validation errors, new required fields
+have no defaults for old rows.
+
+This module ships the minimum infrastructure to evolve those models
+forward without a stop-the-world upgrade:
+
+- :class:`Versioned` — Pydantic mixin that adds ``model_version: int``.
+- :class:`Migration` — a single forward step ``v → v+1``.
+- :class:`MigrationRegistry` — keyed by ``(model_class, source_version)``;
+  one registered migration per step. Forward-only by design (down
+  migrations are easy to lose data on and rarely actually needed).
+- :func:`migrate_dict` — read-time entry point. Walks the registry
+  forward until the dict is at the model's ``MODEL_VERSION``.
+
+Usage convention:
+
+1. Each persisted model declares ``MODEL_VERSION`` (class var) and
+   inherits :class:`Versioned`.
+2. When the schema changes, bump ``MODEL_VERSION`` and register a
+   :class:`Migration` for the previous version.
+3. Read paths call ``migrate_dict(cls, payload)`` before
+   ``cls.model_validate(...)`` — old rows are upgraded transparently
+   and the upgraded form is written back on the next persist.
+
+The registry is global. Tests can swap in a private registry via
+``MigrationRegistry()`` and pass it to ``migrate_dict``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class MissingMigrationError(LookupError):
+    """No migration is registered for the requested step."""
+
+
+class Versioned(BaseModel):
+    """Mixin for persisted Pydantic models.
+
+    Subclasses set ``MODEL_VERSION`` to the current schema version.
+    Defaults to ``1`` so legacy rows (no ``model_version`` in the
+    payload) are treated as v1 and walked through any registered
+    migrations on the way to the current version.
+    """
+
+    MODEL_VERSION: ClassVar[int] = 1
+
+    model_version: int = Field(
+        default=1,
+        description="Schema version of the persisted record.",
+    )
+
+
+class Migration:
+    """A single forward-step migration ``source_version → source_version + 1``.
+
+    The transform receives a raw dict (pre-validation) and returns a
+    raw dict the next-version model will accept. Operating in dict
+    space lets a migration drop, rename, or split fields that the new
+    model wouldn't validate.
+    """
+
+    def __init__(
+        self,
+        model_cls: type[Versioned],
+        source_version: int,
+        transform: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> None:
+        super().__init__()
+        if source_version < 1:
+            msg = "source_version must be >= 1"
+            raise ValueError(msg)
+        self.model_cls = model_cls
+        self.source_version = source_version
+        self.transform = transform
+
+    def apply(self, payload: dict[str, Any]) -> dict[str, Any]:
+        new_payload = self.transform(dict(payload))
+        new_payload["model_version"] = self.source_version + 1
+        return new_payload
+
+
+class MigrationRegistry:
+    """Holds the registered migrations for one or more :class:`Versioned` models."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # (model_cls, source_version) -> Migration
+        self._migrations: dict[tuple[type[Versioned], int], Migration] = {}
+
+    def register(self, migration: Migration) -> None:
+        key = (migration.model_cls, migration.source_version)
+        if key in self._migrations:
+            msg = (
+                f"Migration already registered for "
+                f"{migration.model_cls.__name__} v{migration.source_version}"
+            )
+            raise ValueError(msg)
+        self._migrations[key] = migration
+
+    def get(self, model_cls: type[Versioned], source_version: int) -> Migration | None:
+        return self._migrations.get((model_cls, source_version))
+
+    def clear(self) -> None:
+        """Drop every registered migration. Intended for tests."""
+        self._migrations.clear()
+
+
+# Default registry the kit's own model migrations will be registered against.
+DEFAULT_REGISTRY: MigrationRegistry = MigrationRegistry()
+
+
+def migrate_dict(
+    model_cls: type[Versioned],
+    payload: dict[str, Any],
+    *,
+    registry: MigrationRegistry | None = None,
+) -> dict[str, Any]:
+    """Walk migrations forward until *payload* reaches ``model_cls.MODEL_VERSION``.
+
+    Returns a *new* dict; the input is not mutated. Raises
+    :class:`MissingMigrationError` when a step has no registered
+    migration — the caller can decide whether to fail loudly or fall
+    back to best-effort decoding.
+    """
+    reg = registry or DEFAULT_REGISTRY
+    target = model_cls.MODEL_VERSION
+    current = payload.get("model_version", 1)
+    if current >= target:
+        # Nothing to do — and we never down-migrate.
+        return dict(payload)
+
+    walked = dict(payload)
+    while current < target:
+        migration = reg.get(model_cls, current)
+        if migration is None:
+            msg = (
+                f"No migration registered for {model_cls.__name__} "
+                f"v{current} → v{current + 1}"
+            )
+            raise MissingMigrationError(msg)
+        walked = migration.apply(walked)
+        current += 1
+    return walked

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,189 @@
+"""Coverage — schema-versioning + lazy forward migration helpers (#34).
+
+Tests use a private ``MigrationRegistry`` so they don't touch the
+default registry that the kit's own models will eventually populate.
+That isolation is the whole point of accepting a registry argument
+on :func:`migrate_dict`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+import pytest
+
+from langgraph_kit.core.migrations import (
+    DEFAULT_REGISTRY,
+    Migration,
+    MigrationRegistry,
+    MissingMigrationError,
+    Versioned,
+    migrate_dict,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: a tiny model that evolves v1 → v2 → v3
+# ---------------------------------------------------------------------------
+
+
+class _NoteV3(Versioned):
+    """Latest schema: v3 has ``title`` (renamed from v2's ``name``)
+    and a required ``priority``.
+    """
+
+    MODEL_VERSION: ClassVar[int] = 3
+
+    id: str
+    title: str
+    priority: str = "normal"
+
+
+def _v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
+    """v1 had no title/name; default an empty name so v2 validates."""
+    payload.setdefault("name", "")
+    return payload
+
+
+def _v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
+    """v2's ``name`` becomes v3's ``title``; ``priority`` default."""
+    if "name" in payload:
+        payload["title"] = payload.pop("name")
+    payload.setdefault("priority", "normal")
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Versioned mixin
+# ---------------------------------------------------------------------------
+
+
+def test_versioned_default_model_version_is_1() -> None:
+    class _M(Versioned):
+        MODEL_VERSION: ClassVar[int] = 1
+
+    instance = _M()
+    assert instance.model_version == 1
+
+
+def test_versioned_subclass_can_override_model_version() -> None:
+    class _M(Versioned):
+        MODEL_VERSION: ClassVar[int] = 5
+
+    assert _M.MODEL_VERSION == 5
+
+
+# ---------------------------------------------------------------------------
+# MigrationRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_register_and_get() -> None:
+    reg = MigrationRegistry()
+    m = Migration(_NoteV3, 1, _v1_to_v2)
+    reg.register(m)
+    assert reg.get(_NoteV3, 1) is m
+    assert reg.get(_NoteV3, 2) is None
+
+
+def test_registry_rejects_duplicate_step() -> None:
+    reg = MigrationRegistry()
+    reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+
+
+def test_registry_clear_drops_migrations() -> None:
+    reg = MigrationRegistry()
+    reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+    reg.clear()
+    assert reg.get(_NoteV3, 1) is None
+    # Re-register works after clear.
+    reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+
+
+def test_migration_rejects_invalid_source_version() -> None:
+    with pytest.raises(ValueError, match="source_version"):
+        Migration(_NoteV3, 0, _v1_to_v2)
+
+
+# ---------------------------------------------------------------------------
+# migrate_dict
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_dict_walks_v1_to_target_through_chain() -> None:
+    reg = MigrationRegistry()
+    reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+    reg.register(Migration(_NoteV3, 2, _v2_to_v3))
+
+    payload = {"model_version": 1, "id": "n1"}
+    out = migrate_dict(_NoteV3, payload, registry=reg)
+
+    assert out["model_version"] == 3
+    assert out["title"] == ""
+    assert out["priority"] == "normal"
+    # Original isn't mutated.
+    assert "title" not in payload
+    assert payload["model_version"] == 1
+
+
+def test_migrate_dict_returns_copy_when_already_at_target() -> None:
+    reg = MigrationRegistry()
+    payload = {"model_version": 3, "id": "x", "title": "y", "priority": "high"}
+    out = migrate_dict(_NoteV3, payload, registry=reg)
+    assert out == payload
+    assert out is not payload  # caller can mutate without aliasing
+
+
+def test_migrate_dict_treats_missing_version_as_v1() -> None:
+    """Legacy data without an explicit ``model_version`` key must be
+    walked from v1 — that's the whole point of "lazy on read"."""
+    reg = MigrationRegistry()
+    reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+    reg.register(Migration(_NoteV3, 2, _v2_to_v3))
+    payload = {"id": "old", "name": "legacy"}  # no model_version key
+    out = migrate_dict(_NoteV3, payload, registry=reg)
+    assert out["model_version"] == 3
+    assert out["title"] == "legacy"
+
+
+def test_migrate_dict_raises_on_missing_step() -> None:
+    """A gap in the chain must surface loudly so deployments don't
+    silently misread old data as if it were upgraded."""
+    reg = MigrationRegistry()
+    reg.register(Migration(_NoteV3, 2, _v2_to_v3))  # v1 step missing
+    payload = {"model_version": 1, "id": "x"}
+    with pytest.raises(MissingMigrationError):
+        migrate_dict(_NoteV3, payload, registry=reg)
+
+
+def test_migrate_dict_then_validate_round_trip() -> None:
+    """End-to-end: legacy v1 dict → migrate → model_validate succeeds
+    against the latest schema."""
+    reg = MigrationRegistry()
+    reg.register(Migration(_NoteV3, 1, _v1_to_v2))
+    reg.register(Migration(_NoteV3, 2, _v2_to_v3))
+
+    legacy = {"id": "n1"}  # no model_version, no name, no title
+    migrated = migrate_dict(_NoteV3, legacy, registry=reg)
+    note = _NoteV3.model_validate(migrated)
+    assert note.id == "n1"
+    assert note.title == ""
+    assert note.priority == "normal"
+    assert note.model_version == 3
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_REGISTRY isolation
+# ---------------------------------------------------------------------------
+
+
+def test_tests_do_not_pollute_default_registry() -> None:
+    """The kit-internal default registry should be untouched by these
+    tests — they all pass a private registry to :func:`migrate_dict`.
+    Guard against future test additions accidentally registering on
+    the global one."""
+    # If a future test pollutes the default registry, this guard
+    # catches it before it leaks across test modules.
+    assert DEFAULT_REGISTRY.get(_NoteV3, 1) is None
+    assert DEFAULT_REGISTRY.get(_NoteV3, 2) is None


### PR DESCRIPTION
## Summary

- New `langgraph_kit.core.migrations` module: `Versioned` mixin, `Migration`, `MigrationRegistry`, `migrate_dict`.
- Forward-only by design; lazy on read; missing-step raises rather than silently misreads.
- Adopting on kit-internal models (MemoryRecord etc) lands as those models bump their schemas.

## Test plan

- [x] 12 cases covering mixin / registry / migration step / chain walking / idempotency / missing-step errors / round-trip with a real Pydantic model.
- [x] Full suite: 1087 passed (was 1075).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #34