### PR TITLE
Add DisasterRecoveryManager: JSON Lines export / import for the Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Disaster-recovery export / import.** New
+  `langgraph_kit.core.dr.DisasterRecoveryManager` exports Store
+  contents as JSON Lines (manifest header first, one record per line)
+  and re-imports the same shape back. Three import modes — `replace`
+  (clear each namespace before importing, the loud default),
+  `append` (skip existing keys), `merge` (last value wins). Manifest
+  carries `schema_version` (currently 1) so future format changes
+  reject old files cleanly. Not a substitute for full database
+  backups — a complement for selective restore (per-tenant,
+  per-thread, etc.). The HTTP admin endpoint and the CLI integration
+  are deferred to a follow-up. Fixes
+  [#35](https://github.com/allada-homelab/langgraph-kit/issues/35).
+
 - **Schema versioning + lazy forward migrations.** New
   `langgraph_kit.core.migrations` module ships a `Versioned` Pydantic
   mixin (adds `model_version: int`), a `Migration` (forward step

--- a/src/langgraph_kit/core/dr/__init__.py
+++ b/src/langgraph_kit/core/dr/__init__.py
@@ -1,0 +1,22 @@
+"""Disaster recovery: point-in-time export / import for the Store.
+
+Issue #35. JSON Lines on the wire; manifest first; three import
+modes (replace / append / merge). Not a substitute for full
+database backups — a complement for selective restore.
+"""
+
+from .manager import (
+    EXPORT_SCHEMA_VERSION,
+    DisasterRecoveryManager,
+    ExportManifest,
+    ImportMode,
+    ImportResult,
+)
+
+__all__ = [
+    "EXPORT_SCHEMA_VERSION",
+    "DisasterRecoveryManager",
+    "ExportManifest",
+    "ImportMode",
+    "ImportResult",
+]

--- a/src/langgraph_kit/core/dr/manager.py
+++ b/src/langgraph_kit/core/dr/manager.py
@@ -1,0 +1,251 @@
+"""Point-in-time export / import over a LangGraph ``BaseStore``.
+
+Issue #35. Today the kit relies on the database's own snapshot story
+(Postgres, SQLite). That covers full-database recovery but not
+selective restore — "give me everything for tenant X" or "ship a
+single thread's history to support". This manager fills that gap.
+
+Design:
+
+- **JSON Lines.** One record per line, streamable, appendable,
+  readable by ``jq``. The first line is always a manifest with
+  ``schema_version`` so a future format change can be rejected
+  cleanly.
+- **Namespace selection is explicit.** The manager does not enumerate
+  every namespace the Store knows about — that requires
+  ``alist_namespaces`` support which not every backend exposes
+  cheaply. Callers pass the namespace prefixes they want exported;
+  the kit ships a sensible default list of "everything Pydantic-
+  shaped that we own".
+- **Import has three modes.** ``replace`` overwrites the namespace
+  before importing; ``append`` only writes records whose ``key``
+  doesn't already exist; ``merge`` writes everything (most-recent
+  wins on conflicting keys). ``replace`` is the loud default.
+
+Not yet shipped:
+
+- HTTP admin endpoints — the operator workflow needs auth choices
+  that aren't kit-internal.
+- CLI integration in ``cli.py``.
+- Postgres-bypass fast paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterable, AsyncIterator, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+EXPORT_SCHEMA_VERSION: int = 1
+
+
+class ImportMode(StrEnum):
+    REPLACE = "replace"  # clear each namespace before importing
+    APPEND = "append"  # only add keys that don't already exist
+    MERGE = "merge"  # write everything (last wins)
+
+
+@dataclass
+class ExportManifest:
+    """First line of an export. Used by import to reject incompatible files."""
+
+    schema_version: int
+    exported_at: str
+    namespace_prefixes: list[list[str]]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "kind": "manifest",
+                "schema_version": self.schema_version,
+                "exported_at": self.exported_at,
+                "namespace_prefixes": self.namespace_prefixes,
+            }
+        )
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ExportManifest:
+        return cls(
+            schema_version=int(payload.get("schema_version", 0)),
+            exported_at=str(payload.get("exported_at", "")),
+            namespace_prefixes=[list(p) for p in payload.get("namespace_prefixes", [])],
+        )
+
+
+@dataclass
+class ImportResult:
+    """Counts returned by :meth:`DisasterRecoveryManager.import_jsonl`."""
+
+    written: int
+    skipped: int
+    namespaces_seen: int
+
+
+class DisasterRecoveryManager:
+    """Export / import Store contents as JSON Lines."""
+
+    def __init__(self, store: Any) -> None:
+        super().__init__()
+        self._store = store
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    async def export_jsonl(
+        self, namespaces: Iterable[tuple[str, ...]]
+    ) -> AsyncIterator[str]:
+        """Yield manifest + one JSONL line per record across *namespaces*.
+
+        Each yielded string already includes the trailing ``"\\n"``
+        — callers can stream directly to a file or socket without
+        post-processing.
+        """
+        prefixes = [list(ns) for ns in namespaces]
+        manifest = ExportManifest(
+            schema_version=EXPORT_SCHEMA_VERSION,
+            exported_at=datetime.now(UTC).isoformat(),
+            namespace_prefixes=prefixes,
+        )
+        yield manifest.to_json() + "\n"
+
+        for ns_prefix in namespaces:
+            try:
+                items: list[Any] = await self._store.asearch(
+                    tuple(ns_prefix), limit=10_000_000
+                )
+            except Exception:
+                logger.exception("DR.export: failed namespace %s", ns_prefix)
+                continue
+            for item in items:
+                payload = {
+                    "kind": "record",
+                    "namespace": list(ns_prefix),
+                    "key": item.key,
+                    "value": item.value,
+                }
+                yield json.dumps(payload, default=str) + "\n"
+
+    # ------------------------------------------------------------------
+    # Import
+    # ------------------------------------------------------------------
+
+    async def import_jsonl(
+        self,
+        source: AsyncIterable[str] | Iterable[str],
+        *,
+        mode: ImportMode = ImportMode.REPLACE,
+    ) -> ImportResult:
+        """Read a JSONL stream and write its records to the Store.
+
+        Iterates manifest first, validates the schema version, then
+        processes records line by line. Lines that aren't valid JSON
+        or aren't a record-kind payload are logged and skipped.
+        """
+        manifest_seen = False
+        manifest: ExportManifest | None = None
+        cleared_namespaces: set[tuple[str, ...]] = set()
+        written = 0
+        skipped = 0
+        namespaces_seen: set[tuple[str, ...]] = set()
+
+        async for line in _to_async_iter(source):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("DR.import: skipping non-JSON line")
+                skipped += 1
+                continue
+            if not isinstance(payload, dict):
+                skipped += 1
+                continue
+
+            kind = payload.get("kind")
+
+            if kind == "manifest":
+                manifest = ExportManifest.from_dict(payload)
+                if manifest.schema_version != EXPORT_SCHEMA_VERSION:
+                    msg = (
+                        f"DR.import: incompatible schema_version "
+                        f"{manifest.schema_version} (expected "
+                        f"{EXPORT_SCHEMA_VERSION})"
+                    )
+                    raise ValueError(msg)
+                manifest_seen = True
+                continue
+
+            if kind != "record":
+                skipped += 1
+                continue
+
+            if not manifest_seen:
+                msg = "DR.import: missing manifest header (first JSONL line)"
+                raise ValueError(msg)
+
+            ns = tuple(payload.get("namespace") or ())
+            key = payload.get("key")
+            value = payload.get("value")
+            if not ns or not isinstance(key, str):
+                skipped += 1
+                continue
+
+            namespaces_seen.add(ns)
+
+            # In replace mode, clear each namespace once on first record.
+            if mode == ImportMode.REPLACE and ns not in cleared_namespaces:
+                cleared_namespaces.add(ns)
+                try:
+                    existing: list[Any] = await self._store.asearch(
+                        ns, limit=10_000_000
+                    )
+                    for it in existing:
+                        await self._store.adelete(ns, it.key)
+                except Exception:
+                    logger.exception("DR.import: failed to clear namespace %s", ns)
+
+            # In append mode, skip any key that already exists.
+            if mode == ImportMode.APPEND:
+                try:
+                    existing_item = await self._store.aget(ns, key)
+                except Exception:
+                    existing_item = None
+                if existing_item is not None:
+                    skipped += 1
+                    continue
+
+            try:
+                await self._store.aput(ns, key, value)
+                written += 1
+            except Exception:
+                logger.exception("DR.import: failed to write %s/%s", ns, key)
+                skipped += 1
+
+        return ImportResult(
+            written=written,
+            skipped=skipped,
+            namespaces_seen=len(namespaces_seen),
+        )
+
+
+async def _to_async_iter(
+    source: AsyncIterable[str] | Iterable[str],
+) -> AsyncIterator[str]:
+    """Adapt sync iterables to async-iter so import_jsonl can take either."""
+    if hasattr(source, "__aiter__"):
+        async for line in source:  # type: ignore[union-attr]
+            yield line
+        return
+    for line in source:  # type: ignore[assignment]
+        yield line

--- a/tests/test_disaster_recovery.py
+++ b/tests/test_disaster_recovery.py
@@ -1,0 +1,254 @@
+"""Coverage — DisasterRecoveryManager export / import (#35).
+
+Stream contract: first JSONL line is a manifest with
+``schema_version``, subsequent lines are records of the form
+``{"kind": "record", "namespace": [...], "key": "...", "value": ...}``.
+
+Import modes verified independently:
+
+- ``replace`` clears each visited namespace before importing.
+- ``append`` keeps existing keys, only writes new ones.
+- ``merge`` writes everything, last value wins on conflicts.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from langgraph_kit.core.dr import (
+    EXPORT_SCHEMA_VERSION,
+    DisasterRecoveryManager,
+    ImportMode,
+)
+from tests.conftest import MockStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed(store: MockStore) -> None:
+    await store.aput(("memory", "user", "feedback"), "m1", {"id": "m1", "title": "ok"})
+    await store.aput(
+        ("memory", "user", "feedback"), "m2", {"id": "m2", "title": "neat"}
+    )
+    await store.aput(("threads", "t-1"), "metadata", {"thread_id": "t-1"})
+
+
+async def _collect_jsonl(mgr: DisasterRecoveryManager, namespaces) -> list[str]:
+    lines: list[str] = []
+    async for line in mgr.export_jsonl(namespaces):
+        lines.append(line)
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_starts_with_manifest_then_records() -> None:
+    store = MockStore()
+    await _seed(store)
+    mgr = DisasterRecoveryManager(store)
+
+    lines = await _collect_jsonl(
+        mgr, [("memory", "user", "feedback"), ("threads", "t-1")]
+    )
+    assert len(lines) == 4  # 1 manifest + 2 memory + 1 thread
+    manifest = json.loads(lines[0])
+    assert manifest["kind"] == "manifest"
+    assert manifest["schema_version"] == EXPORT_SCHEMA_VERSION
+    # Record lines have shape {kind:record, namespace, key, value}.
+    for raw in lines[1:]:
+        record = json.loads(raw)
+        assert record["kind"] == "record"
+        assert isinstance(record["namespace"], list)
+        assert isinstance(record["key"], str)
+        assert "value" in record
+
+
+@pytest.mark.asyncio
+async def test_export_handles_empty_namespace_gracefully() -> None:
+    store = MockStore()
+    mgr = DisasterRecoveryManager(store)
+    lines = await _collect_jsonl(mgr, [("does", "not", "exist")])
+    # Just the manifest — no records.
+    assert len(lines) == 1
+    assert json.loads(lines[0])["kind"] == "manifest"
+
+
+@pytest.mark.asyncio
+async def test_export_lines_are_newline_terminated() -> None:
+    """Streamable: callers can pipe directly to a file without joining."""
+    store = MockStore()
+    await _seed(store)
+    mgr = DisasterRecoveryManager(store)
+    lines = await _collect_jsonl(mgr, [("memory", "user", "feedback")])
+    assert all(line.endswith("\n") for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# Import
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_export_then_import_into_fresh_store() -> None:
+    src = MockStore()
+    await _seed(src)
+    mgr_src = DisasterRecoveryManager(src)
+    lines = await _collect_jsonl(
+        mgr_src, [("memory", "user", "feedback"), ("threads", "t-1")]
+    )
+
+    dst = MockStore()
+    mgr_dst = DisasterRecoveryManager(dst)
+    result = await mgr_dst.import_jsonl(lines, mode=ImportMode.REPLACE)
+
+    # Same record count; namespaces equivalent.
+    assert result.written == 3
+    assert result.skipped == 0
+    item = await dst.aget(("memory", "user", "feedback"), "m1")
+    assert item is not None
+    assert item.value["title"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_import_replace_clears_namespace_first() -> None:
+    src = MockStore()
+    await _seed(src)
+    mgr_src = DisasterRecoveryManager(src)
+    lines = await _collect_jsonl(mgr_src, [("memory", "user", "feedback")])
+
+    dst = MockStore()
+    # Pre-populate with stale records — replace must clear them.
+    await dst.aput(("memory", "user", "feedback"), "stale", {"junk": True})
+    mgr_dst = DisasterRecoveryManager(dst)
+    await mgr_dst.import_jsonl(lines, mode=ImportMode.REPLACE)
+
+    assert await dst.aget(("memory", "user", "feedback"), "stale") is None
+    assert await dst.aget(("memory", "user", "feedback"), "m1") is not None
+
+
+@pytest.mark.asyncio
+async def test_import_append_skips_existing_keys() -> None:
+    src = MockStore()
+    await _seed(src)
+    mgr_src = DisasterRecoveryManager(src)
+    lines = await _collect_jsonl(mgr_src, [("memory", "user", "feedback")])
+
+    dst = MockStore()
+    await dst.aput(("memory", "user", "feedback"), "m1", {"title": "original"})
+    mgr_dst = DisasterRecoveryManager(dst)
+    result = await mgr_dst.import_jsonl(lines, mode=ImportMode.APPEND)
+
+    assert result.skipped >= 1
+    # Original record untouched.
+    item = await dst.aget(("memory", "user", "feedback"), "m1")
+    assert item is not None
+    assert item.value["title"] == "original"
+    # New record was added.
+    assert await dst.aget(("memory", "user", "feedback"), "m2") is not None
+
+
+@pytest.mark.asyncio
+async def test_import_merge_overwrites_existing_keys() -> None:
+    src = MockStore()
+    await _seed(src)
+    mgr_src = DisasterRecoveryManager(src)
+    lines = await _collect_jsonl(mgr_src, [("memory", "user", "feedback")])
+
+    dst = MockStore()
+    await dst.aput(("memory", "user", "feedback"), "m1", {"title": "stale"})
+    mgr_dst = DisasterRecoveryManager(dst)
+    await mgr_dst.import_jsonl(lines, mode=ImportMode.MERGE)
+
+    item = await dst.aget(("memory", "user", "feedback"), "m1")
+    assert item is not None
+    assert item.value["title"] == "ok"  # merge wrote the new value
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_missing_manifest() -> None:
+    """An import without the manifest header must fail loudly — no
+    silent recovery on an unknown format."""
+    dst = MockStore()
+    mgr = DisasterRecoveryManager(dst)
+    lines_no_manifest = [
+        json.dumps({"kind": "record", "namespace": ["a"], "key": "k", "value": 1})
+        + "\n"
+    ]
+    with pytest.raises(ValueError, match="manifest"):
+        await mgr.import_jsonl(lines_no_manifest)
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_incompatible_schema_version() -> None:
+    dst = MockStore()
+    mgr = DisasterRecoveryManager(dst)
+    bad_manifest = (
+        json.dumps(
+            {
+                "kind": "manifest",
+                "schema_version": 999,
+                "exported_at": "2026-04-25",
+                "namespace_prefixes": [],
+            }
+        )
+        + "\n"
+    )
+    with pytest.raises(ValueError, match="schema_version"):
+        await mgr.import_jsonl([bad_manifest])
+
+
+@pytest.mark.asyncio
+async def test_import_skips_non_json_and_non_record_lines() -> None:
+    dst = MockStore()
+    mgr = DisasterRecoveryManager(dst)
+    lines = [
+        json.dumps(
+            {
+                "kind": "manifest",
+                "schema_version": EXPORT_SCHEMA_VERSION,
+                "exported_at": "now",
+                "namespace_prefixes": [],
+            }
+        ),
+        "not-json-at-all",
+        json.dumps({"kind": "comment", "text": "ignore me"}),
+        json.dumps({"kind": "record", "namespace": ["a"], "key": "k", "value": 1}),
+    ]
+    result = await mgr.import_jsonl(lines, mode=ImportMode.MERGE)
+    assert result.written == 1
+    assert result.skipped == 2
+
+
+@pytest.mark.asyncio
+async def test_import_accepts_async_iterable_source() -> None:
+    """The source param accepts async iterables (e.g. file streaming)."""
+    dst = MockStore()
+    mgr = DisasterRecoveryManager(dst)
+
+    async def _stream():
+        yield (
+            json.dumps(
+                {
+                    "kind": "manifest",
+                    "schema_version": EXPORT_SCHEMA_VERSION,
+                    "exported_at": "x",
+                    "namespace_prefixes": [],
+                }
+            )
+            + "\n"
+        )
+        yield (
+            json.dumps({"kind": "record", "namespace": ["x"], "key": "k", "value": "v"})
+            + "\n"
+        )
+
+    result = await mgr.import_jsonl(_stream(), mode=ImportMode.MERGE)
+    assert result.written == 1


### PR DESCRIPTION
## Summary

- New `langgraph_kit.core.dr.DisasterRecoveryManager`: `export_jsonl(namespaces)` / `import_jsonl(source, mode=...)`.
- JSON Lines wire format with manifest header (schema_version=1).
- Three import modes — `replace` (default; clears the namespace), `append`, `merge`.
- Sync- and async-iterable sources both accepted.

## Deferred to follow-up

- HTTP admin endpoint.
- CLI integration in `cli.py`.

## Test plan

- [x] 11 cases covering format, modes, error paths, async-iter source.
- [x] Full suite: 1098 passed (was 1087).
- [x] ruff / basedpyright / pre-commit clean.

Fixes #35