### PR TITLE
Add Phase-2 examples + CLI + README sweep + nightly workflow

### DIFF
--- a/.github/workflows/examples-nightly.yml
+++ b/.github/workflows/examples-nightly.yml
@@ -1,0 +1,67 @@
+name: Examples (nightly real-LLM)
+
+on:
+  schedule:
+    # Daily at 06:00 UTC. Picks up upstream model drift overnight while
+    # the team is asleep so a failing demo greets us in the morning
+    # rather than mid-day.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  examples-real:
+    name: Examples (real LLM)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras --all-groups
+
+      - name: Run examples against real LLM
+        id: run
+        env:
+          # Cost guardrail lives inside examples/_lib.py: builds default to
+          # claude-haiku-4-5 with hard caps on max_output_tokens / turns.
+          AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
+          LANGGRAPH_KIT_EXAMPLES_LLM: real
+          # ``RUN_NETWORK=1`` un-skips ``REQUIRES_NETWORK = True`` examples
+          # (Langfuse, real MCP). Hermetic-but-LLM-touching demos run in
+          # both tiers so model drift is caught quickly.
+          RUN_NETWORK: "1"
+        run: uv run python -m examples.run_all
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `[nightly examples] failure on ${today}`;
+            const body = [
+              `Nightly real-LLM examples run failed.`,
+              ``,
+              `Logs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `Likely causes:`,
+              `- Upstream model drift (haiku-4-5 prompt format change)`,
+              `- Provider outage`,
+              `- Newly-added example missing scripted/real-LLM mode handling`,
+              ``,
+              `Triage with the warning-investigator agent if it's a model warning,`,
+              `or run \`just examples-smoke\` locally to confirm the hermetic tier still passes.`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug'],
+            });

--- a/README.md
+++ b/README.md
@@ -226,23 +226,12 @@ See [docs/memory/overview.md](docs/memory/overview.md), [extraction](docs/memory
 
 ### Tools with capability metadata
 
-Tools aren't just callables — they carry risk levels, profile/worker filters, tags, and prompt guidance. The registry supports filtering and compilation:
+Tools aren't just callables — they carry risk levels, profile/worker filters, tags, and prompt guidance. The registry supports filtering and compilation by max risk so a worker only sees what it's allowed to call.
 
-```python
-from langgraph_kit.core.tools.registry import ToolRegistry
-from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
+Runnable demo: [`examples/tools_register_capability.py`](examples/tools_register_capability.py) — registers three tools across `READ_ONLY`, `MUTATING`, and `DESTRUCTIVE` risk levels, then filters the compiled list.
 
-registry = ToolRegistry()
-registry.register(ToolCapability(
-    name="delete_branch",
-    func=my_delete_branch_impl,
-    risk=ToolRisk.DESTRUCTIVE,
-    interrupt_before=True,              # triggers HITL approval
-    profiles={"coding"},
-    worker_types={"implementer"},
-    prompt_guidance="Use only after confirming the branch is merged.",
-))
-tools = registry.compile_tools(max_risk=ToolRisk.MUTATING)  # filtered
+```bash
+uv run python -m examples.tools_register_capability
 ```
 
 See [docs/tools/overview.md](docs/tools/overview.md), [capability](docs/tools/capability.md), [registry](docs/tools/registry.md), [memory-tools](docs/tools/memory-tools.md), [worktree-tools](docs/tools/worktree-tools.md).
@@ -251,19 +240,10 @@ See [docs/tools/overview.md](docs/tools/overview.md), [capability](docs/tools/ca
 
 Layered sections + context providers, ordered stable-first for prompt-cache efficiency.
 
-```python
-from langgraph_kit.core.prompt_assembly.sections import (
-    PromptSection, SectionStability, SectionRegistry,
-)
-from langgraph_kit.core.prompt_assembly.composer import PromptComposer
+Runnable demo: [`examples/prompt_assembly_sections.py`](examples/prompt_assembly_sections.py) — registers stable / volatile / conditional sections at different priorities, shows what gets included under different `conditions` sets.
 
-registry = SectionRegistry()
-registry.register(PromptSection(
-    id="core_identity", priority=100, stability=SectionStability.STABLE,
-    content="You are a helpful coding assistant...",
-))
-composer = PromptComposer(registry, providers=[...])
-system_prompt = composer.compose_sections_only(conditions={"memory", "skills"})
+```bash
+uv run python -m examples.prompt_assembly_sections
 ```
 
 See [docs/prompt-assembly/overview.md](docs/prompt-assembly/overview.md).
@@ -295,29 +275,22 @@ See [docs/commands/overview.md](docs/commands/overview.md).
 
 Declarative worker definitions for the deepagents `task` tool, plus `start_async_task` / `check_async_task` for fire-and-forget background work and a store-backed per-thread message queue for busy threads.
 
-```python
-from langgraph_kit.core.orchestration.workers import GENERAL_WORKERS, CODING_WORKERS
-# or define your own:
-MY_WORKERS = [
-    {"name": "data-analyst", "description": "...", "system_prompt": "...", "tools": [...]},
-]
+Runnable demo: [`examples/orchestration_workers.py`](examples/orchestration_workers.py) — inspects the bundled `GENERAL_WORKERS` and `CODING_WORKERS` lists and shows how to extend them with a domain-specific worker.
+
+```bash
+uv run python -m examples.orchestration_workers
 ```
 
 See [docs/orchestration/overview.md](docs/orchestration/overview.md).
 
 ### Human-in-the-loop
 
-```python
-# In a tool or middleware:
-from langgraph_kit.core.hitl.tools import approve_action
+Pause-and-resume approval via LangGraph's `interrupt()` primitive, surfaced through the kit's `approve_action` tool and `/resume` HTTP endpoint.
 
-await approve_action(
-    action="delete_file",
-    description="Remove stale config",
-    context={"path": "config.yaml"},
-)
-# → graph pauses via interrupt, SSE emits the approval request,
-# client POSTs /resume with {"responses": [{"type": "accept"}]}.
+Runnable demo: [`examples/hitl_approval_flow.py`](examples/hitl_approval_flow.py) — wires a tiny custom graph that interrupts on a `delete_branch` request, then resumes with `Command(resume={"type": "accept"})`.
+
+```bash
+uv run python -m examples.hitl_approval_flow
 ```
 
 See [docs/hitl/overview.md](docs/hitl/overview.md).

--- a/docs/examples/context_compaction.md
+++ b/docs/examples/context_compaction.md
@@ -1,0 +1,16 @@
+# Context — compaction
+
+Builds a `PressureMonitor`, runs three synthetic conversation slices
+through it (tiny / bloated with large tool outputs / past the critical
+threshold), and shows how the monitor maps `pressure_pct` plus
+`large_tool_outputs` to a `MitigationStrategy`. The bundled
+`PressureMiddleware` consumes these signals to drive automatic
+mitigation during a real run.
+
+```bash
+uv run python -m examples.context_compaction
+```
+
+```python
+--8<-- "examples/context_compaction.py"
+```

--- a/docs/examples/fastapi_minimal_router.md
+++ b/docs/examples/fastapi_minimal_router.md
@@ -1,0 +1,17 @@
+# FastAPI — minimal router
+
+Mounts `create_agent_router(...)` onto a FastAPI app and drives it via
+`httpx.AsyncClient` with `ASGITransport`, so the demo runs hermetically
+without binding a port. Hits the discovery endpoint
+(`GET /agents/`) and the `invoke` endpoint to keep output predictable.
+The full router exposes 11 endpoints (stream / state / resume / branch /
+queue / etc.) — see `tests/e2e/test_fastapi_e2e.py` for the wider
+surface.
+
+```bash
+uv run python -m examples.fastapi_minimal_router
+```
+
+```python
+--8<-- "examples/fastapi_minimal_router.py"
+```

--- a/docs/examples/hitl_approval_flow.md
+++ b/docs/examples/hitl_approval_flow.md
@@ -1,0 +1,14 @@
+# HITL — approval flow
+
+Wires a tiny custom graph that calls `interrupt()` to pause for
+approval, then resumes with `Command(resume={"type": "accept"})`. The
+same primitive backs `ToolCapability(interrupt_before=True)` when
+`AutoInterruptMiddleware` is wired in.
+
+```bash
+uv run python -m examples.hitl_approval_flow
+```
+
+```python
+--8<-- "examples/hitl_approval_flow.py"
+```

--- a/docs/examples/orchestration_workers.md
+++ b/docs/examples/orchestration_workers.md
@@ -1,0 +1,14 @@
+# Orchestration — workers
+
+Inspects the kit's pre-composed `GENERAL_WORKERS` and `CODING_WORKERS`
+worker definitions and shows how to extend them with a domain-specific
+sub-agent. The `reference_deep_agent` and `coding_agent` builders both
+consume these lists at graph-build time.
+
+```bash
+uv run python -m examples.orchestration_workers
+```
+
+```python
+--8<-- "examples/orchestration_workers.py"
+```

--- a/docs/examples/prompt_assembly_sections.md
+++ b/docs/examples/prompt_assembly_sections.md
@@ -1,0 +1,14 @@
+# Prompt assembly — sections
+
+Builds a `SectionRegistry` with stable, volatile, and conditional
+sections at different priorities; the `PromptComposer` orders stable
+sections first (cache-friendly) and includes conditional sections only
+when their key is in the active conditions set.
+
+```bash
+uv run python -m examples.prompt_assembly_sections
+```
+
+```python
+--8<-- "examples/prompt_assembly_sections.py"
+```

--- a/docs/examples/replay_record_and_play.md
+++ b/docs/examples/replay_record_and_play.md
@@ -1,0 +1,15 @@
+# Replay — record & play
+
+Attaches `ConversationRecorder` as a LangChain callback during a
+hermetic graph run, saves the recording to disk, then reloads it via
+`ConversationRecording.model_validate_json()` and inspects captured
+LLM and tool interactions. This is how the kit's e2e suite produces
+deterministic regression fixtures.
+
+```bash
+uv run python -m examples.replay_record_and_play
+```
+
+```python
+--8<-- "examples/replay_record_and_play.py"
+```

--- a/docs/examples/tools_register_capability.md
+++ b/docs/examples/tools_register_capability.md
@@ -1,0 +1,13 @@
+# Tools — register capability
+
+Registers three tools across `READ_ONLY`, `MUTATING`, and `DESTRUCTIVE`
+risk levels, then filters the registry by `max_risk` so a worker only
+sees the capabilities it's allowed to call.
+
+```bash
+uv run python -m examples.tools_register_capability
+```
+
+```python
+--8<-- "examples/tools_register_capability.py"
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,20 +18,37 @@ LANGGRAPH_KIT_EXAMPLES_LLM=real AGENT_LLM_API_KEY=sk-... \
 just examples-smoke
 ```
 
-## What's here (Phase 1)
+## What's here
 
 | File | Showcases |
 | --- | --- |
 | [`quickstart_echo.py`](quickstart_echo.py) | The minimal `build_graph(checkpointer, store)` contract |
+| [`basic_deep_agent.py`](basic_deep_agent.py) | `build_basic_deep_agent` — deepagents framework, no kit features |
 | [`reference_deep_agent.py`](reference_deep_agent.py) | The full kit stack wired together |
 | [`memory_save_recall.py`](memory_save_recall.py) | `PersistentMemoryManager` CRUD + keyword search |
 | [`tools_register_capability.py`](tools_register_capability.py) | `ToolCapability` with risk levels + filtering |
 | [`streaming_sse_events.py`](streaming_sse_events.py) | Consuming `stream_agent_events`'s SSE output |
+| [`prompt_assembly_sections.py`](prompt_assembly_sections.py) | `SectionRegistry` + `PromptComposer` cache-aware ordering |
+| [`context_compaction.py`](context_compaction.py) | `PressureMonitor` thresholds + mitigation strategies |
+| [`orchestration_workers.py`](orchestration_workers.py) | Worker definitions + extending the catalogue |
+| [`hitl_approval_flow.py`](hitl_approval_flow.py) | `interrupt()` → `Command(resume=...)` round-trip |
+| [`fastapi_minimal_router.py`](fastapi_minimal_router.py) | Mounting the agent router via ASGI in-process client |
+| [`replay_record_and_play.py`](replay_record_and_play.py) | Recording a hermetic run + reloading the JSON |
 
-More examples land in Phase 2 (orchestration, prompt assembly, HITL,
-FastAPI router, replay) and Phase 3 (security, audit, DR, rate limit,
-plugins, observability, evals, MCP, full FastAPI). See
+The remaining demos (security, audit, DR, rate limit, plugins, MCP,
+observability, evals, full FastAPI) ship in Phase 3 — tracked in
 [issue #61](https://github.com/allada-homelab/langgraph-kit/issues/61).
+
+## CLI shortcut
+
+After `pip install` (from a source checkout), examples are also
+discoverable from the kit's CLI:
+
+```bash
+uv run python -m langgraph_kit.cli examples list
+uv run python -m langgraph_kit.cli examples run quickstart_echo
+uv run python -m langgraph_kit.cli examples run quickstart_echo --real-llm
+```
 
 ## Hermetic vs real LLM
 

--- a/examples/basic_deep_agent.py
+++ b/examples/basic_deep_agent.py
@@ -1,0 +1,76 @@
+"""Basic deep agent — minimal deepagents framework wiring.
+
+What this shows
+---------------
+- ``build_basic_deep_agent(checkpointer, store)`` — the simplest path to
+  a working deep agent with the kit's recursion-limit defaults
+- The agent has no kit-specific middleware, memory, tools, or
+  command dispatcher — see ``reference_deep_agent.py`` for that
+
+How to run
+----------
+    uv run python -m examples.basic_deep_agent                                  # hermetic
+    LANGGRAPH_KIT_EXAMPLES_LLM=real uv run python -m examples.basic_deep_agent  # real LLM
+
+Expected output (hermetic)
+--------------------------
+    user: Quick check — are you alive?
+    assistant: Yes! Basic deep agent is alive and well.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from examples._lib import (
+    answer,
+    banner,
+    configure_real_llm,
+    hermetic,
+    line,
+    make_in_memory_persistence,
+    patch_build_llm,
+    scripted_llm,
+    tmp_workspace,
+)
+
+
+async def main() -> None:
+    banner("basic_deep_agent")
+    user_message = "Quick check — are you alive?"
+    line(f"user: {user_message}")
+
+    with tmp_workspace() as workspace:
+        if hermetic():
+            llm = scripted_llm([answer("Yes! Basic deep agent is alive and well.")])
+            with patch_build_llm(llm):
+                await _run(workspace, user_message)
+        else:
+            configure_real_llm(workspace)
+            await _run(workspace, user_message)
+
+
+async def _run(workspace: object, user_message: str) -> None:
+    from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+        HumanMessage,
+    )
+
+    from langgraph_kit.graphs.basic_deep_agent import build_basic_deep_agent
+
+    _ = workspace
+
+    checkpointer, store = make_in_memory_persistence()
+    graph = build_basic_deep_agent(checkpointer, store)
+
+    config = {"configurable": {"thread_id": "demo-basic"}}
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content=user_message)]}, config=config
+    )
+
+    last = result["messages"][-1]
+    text = getattr(last, "content", "") or "[no content]"
+    line(f"assistant: {text}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/context_compaction.py
+++ b/examples/context_compaction.py
@@ -1,0 +1,101 @@
+"""Context management: pressure detection + mitigation choice.
+
+What this shows
+---------------
+- :class:`PressureMonitor` estimates token pressure from a message list
+- The same monitor chooses between ``NONE``, ``MICROCOMPACT``,
+  ``FULL_COMPACTION``, and ``STOP`` based on pressure thresholds and a
+  circuit breaker for repeated compaction failures
+- The kit's defaults: 70% → microcompact, 85% → full compaction
+
+No LLM. The bundled ``PressureMiddleware`` consumes these signals to
+drive automatic mitigation during a real run; this demo just shows the
+detection layer.
+
+How to run
+----------
+    uv run python -m examples.context_compaction
+
+Expected output
+---------------
+    Tiny conversation:
+      pressure=0.00 strategy=none
+    After bloating with 4 large tool outputs:
+      pressure=0.25 large_outputs=4 strategy=microcompact
+    After pushing past the critical threshold:
+      pressure=1.00 large_outputs=5 strategy=microcompact
+"""
+
+from __future__ import annotations
+
+from examples._lib import banner, line
+
+
+def main() -> None:
+    banner("context_compaction")
+
+    from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+        AIMessage,
+        HumanMessage,
+        ToolMessage,
+    )
+
+    from langgraph_kit.core.context_management.pressure import PressureMonitor
+
+    # Tiny window so the demo can move thresholds visibly with short
+    # messages. Production defaults to a 128k window. The token estimator
+    # is the kit's heuristic ``len(text) // 4``; swap a real tokenizer
+    # via ``token_estimator=`` when accuracy matters.
+    monitor = PressureMonitor(
+        window_limit=4_000,
+        warn_pct=0.20,
+        critical_pct=0.80,
+        large_output_threshold=200,
+    )
+
+    # 1. Tiny conversation — well below warn threshold.
+    tiny = [
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there!"),
+    ]
+    signals = monitor.assess(tiny)
+    strategy = monitor.choose_mitigation(signals)
+    line("Tiny conversation:")
+    line(f"  pressure={signals.pressure_pct:.2f} strategy={strategy.value}")
+
+    # 2. Add a few large tool outputs — crosses warn but stays below critical.
+    bloated = [
+        *tiny,
+        *[
+            ToolMessage(
+                content="x" * 1000,
+                tool_call_id=f"call-{i}",
+                name="dummy_tool",
+            )
+            for i in range(4)
+        ],
+    ]
+    signals = monitor.assess(bloated)
+    strategy = monitor.choose_mitigation(signals)
+    line("After bloating with 4 large tool outputs:")
+    line(
+        f"  pressure={signals.pressure_pct:.2f} large_outputs={signals.large_tool_outputs}"
+        f" strategy={strategy.value}"
+    )
+
+    # 3. Push hard past the critical threshold.
+    huge = [
+        *bloated,
+        AIMessage(content="y" * 16_000),
+    ]
+    signals = monitor.assess(huge)
+    strategy = monitor.choose_mitigation(signals)
+    line("After pushing past the critical threshold:")
+    line(
+        f"  pressure={signals.pressure_pct:.2f} large_outputs={signals.large_tool_outputs}"
+        f" strategy={strategy.value}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fastapi_minimal_router.py
+++ b/examples/fastapi_minimal_router.py
@@ -1,0 +1,109 @@
+"""FastAPI: mount the kit's agent router and exercise it in-process.
+
+What this shows
+---------------
+- Wiring :func:`create_agent_router` onto a FastAPI app
+- Providing the ``get_current_user`` dependency the router requires
+- Registering an agent via :func:`langgraph_kit.register` so the
+  router's ``/agents/`` endpoint discovers it
+- Calling the router via an ASGI in-process client — no real socket,
+  no port to manage, fully hermetic
+
+The full router exposes 11 endpoints (stream / invoke / state / resume /
+branch / queue / etc.); this demo hits the discovery endpoint
+(``GET /agents/``) and the simple ``invoke`` endpoint to keep output
+predictable. See ``tests/e2e/test_fastapi_e2e.py`` for the wider surface.
+
+How to run
+----------
+    uv run python -m examples.fastapi_minimal_router
+
+Expected output
+---------------
+    GET /agents/ -> 200
+    Registered agents: ['echo']
+    POST /agents/echo/invoke -> 200
+    assistant: I am the FastAPI demo agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, Any
+
+from examples._lib import (
+    answer,
+    banner,
+    line,
+    make_in_memory_persistence,
+    patch_build_llm,
+    scripted_llm,
+    tmp_workspace,
+)
+
+
+class _DemoUser:
+    """Minimal :class:`UserInfo`-compatible object the router will accept."""
+
+    id: str = "demo-user-id"
+    email: str = "demo@example.com"
+
+
+def _resolve_demo_user() -> _DemoUser:
+    """FastAPI dependency that returns a fixed user — auth-stub for the demo."""
+    return _DemoUser()
+
+
+async def main() -> None:
+    banner("fastapi_minimal_router")
+
+    import httpx  # pyright: ignore[reportMissingImports]
+    from fastapi import Depends, FastAPI  # pyright: ignore[reportMissingImports]
+
+    from langgraph_kit import register
+    from langgraph_kit.contrib.fastapi import create_agent_router
+    from langgraph_kit.graphs.echo_agent import build_graph
+
+    with tmp_workspace() as workspace:
+        _ = workspace
+
+        # 1. Register a hermetic echo agent so the router can discover it.
+        with patch_build_llm(scripted_llm([answer("I am the FastAPI demo agent.")])):
+            checkpointer, store = make_in_memory_persistence()
+            graph = build_graph(checkpointer, store)
+            register("echo", graph)
+
+            # 2. Build the FastAPI app and mount the router.
+            app = FastAPI()
+            app.state.store = store
+            app.include_router(
+                create_agent_router(
+                    get_current_user=Annotated[_DemoUser, Depends(_resolve_demo_user)]
+                )
+            )
+
+            # 3. Drive the app in-process (no port, no socket).
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://demo"
+            ) as client:
+                # Discovery endpoint
+                resp = await client.get("/agents/")
+                line(f"GET /agents/ -> {resp.status_code}")
+                payload: dict[str, Any] = resp.json()
+                line(f"Registered agents: {[a['id'] for a in payload['agents']]}")
+
+                # Invoke endpoint
+                body = {
+                    "messages": [{"role": "user", "content": "Say hello."}],
+                }
+                resp = await client.post("/agents/echo/invoke", json=body)
+                line(f"POST /agents/echo/invoke -> {resp.status_code}")
+                if resp.status_code == 200:
+                    msg = resp.json()
+                    content = msg.get("response", "") or msg.get("content", "")
+                    line(f"assistant: {content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/hitl_approval_flow.py
+++ b/examples/hitl_approval_flow.py
@@ -1,0 +1,120 @@
+"""HITL: interrupt-based approval flow end-to-end.
+
+What this shows
+---------------
+- Calling :func:`langgraph.types.interrupt` from inside a graph node to
+  pause execution and surface a request for user input
+- Resuming with :class:`langgraph.types.Command` ``resume=...`` to feed
+  the user's decision back into the run
+- The kit's :func:`build_approve_action_tool` formatter converting the
+  ``{"type": "accept"|"response"|...}`` envelope into a human-readable
+  string the agent can reason about
+
+This demo wires a tiny custom graph rather than spinning up a deep
+agent, so the interrupt/resume cycle is visible without any LLM in the
+loop. The same primitive backs ``ToolCapability(interrupt_before=True)``
+when ``AutoInterruptMiddleware`` is wired in.
+
+How to run
+----------
+    uv run python -m examples.hitl_approval_flow
+
+Expected output
+---------------
+    --- run 1: initial invoke ---
+    Graph paused. Interrupt payload:
+      action: delete_branch
+      description: Delete branch 'feature/legacy'
+    --- run 2: resume with accept ---
+    Resolution: User accepted the action.
+"""
+
+# NOTE: Do NOT add ``from __future__ import annotations`` here.
+# LangGraph's StateGraph runs ``get_type_hints()`` on the State class at
+# build time; deferred string annotations would force the eval to look
+# up ``add_messages`` in module globals before its import resolves.
+
+from typing import Annotated, Any
+
+from langgraph.graph import (  # pyright: ignore[reportMissingModuleSource]
+    END,
+    START,
+    StateGraph,
+)
+from langgraph.graph.message import (  # pyright: ignore[reportMissingModuleSource]
+    add_messages,
+)
+from langgraph.types import (  # pyright: ignore[reportMissingModuleSource]
+    Command,
+    interrupt,
+)
+from typing_extensions import TypedDict
+
+from examples._lib import banner, line, make_in_memory_persistence
+from langgraph_kit.core.hitl.tools import _format_response
+
+
+class _ApprovalState(TypedDict):
+    messages: Annotated[list[Any], add_messages]
+    resolution: str
+
+
+async def _request_approval(_state: _ApprovalState) -> dict[str, Any]:
+    """Pause the graph by calling interrupt() with an approval payload."""
+    response = interrupt(
+        {
+            "action_request": {
+                "action": "delete_branch",
+                "args": {"branch": "feature/legacy"},
+            },
+            "description": "Delete branch 'feature/legacy'",
+        }
+    )
+    # When the run is resumed, ``response`` is whatever the caller
+    # passed via ``Command(resume=...)``. Format it via the kit's bundled
+    # helper so the demo matches the agent-facing contract exactly.
+    return {"resolution": _format_response(response)}
+
+
+async def main() -> None:
+    import asyncio  # noqa: F401 — silence ruff; the loop runs from __main__
+
+    banner("hitl_approval_flow")
+
+    builder = StateGraph(_ApprovalState)
+    builder.add_node(_request_approval)  # pyright: ignore[reportArgumentType]
+    builder.add_edge(START, "_request_approval")
+    builder.add_edge("_request_approval", END)
+
+    checkpointer, _ = make_in_memory_persistence()
+    graph = builder.compile(checkpointer=checkpointer)
+    config = {"configurable": {"thread_id": "demo-hitl"}}
+
+    # --- Run 1: initial invoke pauses at the interrupt ----------------
+    line("--- run 1: initial invoke ---")
+    await graph.ainvoke({"messages": [], "resolution": ""}, config=config)
+
+    state = await graph.aget_state(config)
+    interrupts = [
+        intr for task in state.tasks for intr in getattr(task, "interrupts", [])
+    ]
+    if not interrupts:
+        line("[unexpected] no interrupts captured")
+        return
+
+    payload = interrupts[0].value
+    request = payload["action_request"]
+    line("Graph paused. Interrupt payload:")
+    line(f"  action: {request['action']}")
+    line(f"  description: {payload['description']}")
+
+    # --- Run 2: resume with an accept ---------------------------------
+    line("--- run 2: resume with accept ---")
+    final = await graph.ainvoke(Command(resume={"type": "accept"}), config=config)
+    line(f"Resolution: {final['resolution']}")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/examples/orchestration_workers.py
+++ b/examples/orchestration_workers.py
@@ -1,0 +1,75 @@
+"""Orchestration: declarative worker (sub-agent) definitions.
+
+What this shows
+---------------
+- The shape of a worker definition (``name``, ``description``,
+  ``system_prompt``) — same dict the deepagents framework consumes
+- The kit's pre-composed lists: ``GENERAL_WORKERS`` (researcher /
+  implementer / verifier) and ``CODING_WORKERS`` (specialist verifier
+  for code changes)
+- How a domain-specific agent extends the catalogue: add a custom
+  worker dict, then merge into the base list at build time
+
+No LLM. The ``reference_deep_agent`` and ``coding_agent`` builders
+already wire ``GENERAL_WORKERS`` / ``CODING_WORKERS`` into their
+``build_deep_agent(subagents=...)`` call — this demo just inspects the
+definitions so it's clear what gets shipped.
+
+How to run
+----------
+    uv run python -m examples.orchestration_workers
+
+Expected output
+---------------
+    GENERAL_WORKERS: 3 workers
+      - researcher  (Deep codebase research and investigation. ...)
+      - implementer (Focused code implementation within a bounded scope. ...)
+      - verifier    (Independent verification of changes. ...)
+    Custom mix: GENERAL_WORKERS + 'devops_runner' = 4 workers
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from examples._lib import banner, line
+
+
+def main() -> None:
+    banner("orchestration_workers")
+
+    from langgraph_kit.core.orchestration.workers import (
+        CODING_WORKERS,
+        GENERAL_WORKERS,
+    )
+
+    line(f"GENERAL_WORKERS: {len(GENERAL_WORKERS)} workers")
+    for worker in GENERAL_WORKERS:
+        # Show only the first 60 chars of description so the line stays scannable.
+        desc = worker["description"]
+        snippet = desc.split(".")[0] + "."
+        line(f"  - {worker['name']:<11} ({snippet})")
+
+    line(f"\nCODING_WORKERS: {len(CODING_WORKERS)} workers")
+    for worker in CODING_WORKERS:
+        line(f"  - {worker['name']}")
+
+    # Build a custom mix: take the general lineup and add a domain
+    # worker. Same pattern domain agents use — see
+    # src/langgraph_kit/graphs/coding_agent.py for the real-world variant.
+    devops_runner: dict[str, Any] = {
+        "name": "devops_runner",
+        "description": "Runs deployment and infra commands. Use for ops-only steps.",
+        "system_prompt": (
+            "You are an operations specialist. Run only the requested "
+            "command and report its exit code + last 20 lines of output."
+        ),
+    }
+    custom_mix = [*GENERAL_WORKERS, devops_runner]
+    line(f"\nCustom mix: GENERAL_WORKERS + 'devops_runner' = {len(custom_mix)} workers")
+    for worker in custom_mix:
+        line(f"  - {worker['name']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/prompt_assembly_sections.py
+++ b/examples/prompt_assembly_sections.py
@@ -1,0 +1,96 @@
+"""Prompt assembly: layered sections + context providers, cache-aware.
+
+What this shows
+---------------
+- Building a :class:`SectionRegistry` with stable, volatile, and
+  conditional sections at different priorities
+- :class:`PromptComposer` orders stable sections first (cache-friendly)
+  and includes conditional sections only when their key is in the
+  active conditions set
+- ``compose_sections_only`` is fully synchronous — useful for unit
+  testing prompt structure without spinning up a graph
+
+No LLM. The same composer powers the deep agents' system-prompt
+construction.
+
+How to run
+----------
+    uv run python -m examples.prompt_assembly_sections
+
+Expected output
+---------------
+    Active section ids (no conditions): ['identity', 'core_rules']
+    Active section ids (conditions={'memory'}): ['identity', 'core_rules', 'memory_briefing']
+    Composed prompt (memory active):
+    -------- BEGIN --------
+    You are a careful assistant.
+    ...
+    -------- END --------
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from examples._lib import banner, line
+
+
+async def main() -> None:
+    banner("prompt_assembly_sections")
+
+    from langgraph_kit.core.prompt_assembly.composer import PromptComposer
+    from langgraph_kit.core.prompt_assembly.sections import (
+        PromptSection,
+        SectionRegistry,
+        SectionStability,
+    )
+
+    registry = SectionRegistry()
+    registry.register_many(
+        [
+            PromptSection(
+                id="identity",
+                content="You are a careful assistant.",
+                stability=SectionStability.STABLE,
+                priority=100,
+            ),
+            PromptSection(
+                id="core_rules",
+                content="Always reason step by step before acting.",
+                stability=SectionStability.STABLE,
+                priority=90,
+            ),
+            PromptSection(
+                id="memory_briefing",
+                content="The user prefers terse responses.",
+                stability=SectionStability.CONDITIONAL,
+                condition="memory",
+                priority=50,
+            ),
+            PromptSection(
+                id="skills_briefing",
+                content="When asked to ship code, drive the change end-to-end.",
+                stability=SectionStability.CONDITIONAL,
+                condition="skills",
+                priority=40,
+            ),
+        ]
+    )
+
+    composer = PromptComposer(registry)
+
+    line(f"Active section ids (no conditions): {composer.get_active_section_ids()}")
+    line(
+        "Active section ids (conditions={'memory'}): "
+        f"{composer.get_active_section_ids(conditions={'memory'})}"
+    )
+
+    composed = composer.compose_sections_only(conditions={"memory"})
+    line("Composed prompt (memory active):")
+    line("-------- BEGIN --------")
+    line(composed)
+    line("-------- END --------")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/replay_record_and_play.py
+++ b/examples/replay_record_and_play.py
@@ -1,0 +1,92 @@
+"""Replay: record a hermetic run, then load and inspect the recording.
+
+What this shows
+---------------
+- Attaching :class:`ConversationRecorder` as a LangChain callback to
+  capture every LLM + tool interaction during a graph run
+- Serializing the recording to disk (``recorder.save(path)``) and
+  reloading it (``ConversationRecording.model_validate_json(...)``)
+- Inspecting captured ``llm_interactions`` and ``tool_interactions``
+
+This is how the kit's e2e suite produces deterministic regression
+fixtures. For full record-once / replay-many-times in tests, use
+:class:`ReplayRunner` (see ``tests/e2e/test_replay_recorder_e2e.py``).
+
+How to run
+----------
+    uv run python -m examples.replay_record_and_play
+
+Expected output
+---------------
+    Recording saved to /tmp/lgk-example-XXXX/conv.json (NN bytes)
+    Recorded LLM interactions: 1
+    Recorded tool interactions: 0
+    Last assistant content: I recorded this run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from examples._lib import (
+    answer,
+    banner,
+    line,
+    make_in_memory_persistence,
+    patch_build_llm,
+    scripted_llm,
+    tmp_workspace,
+)
+
+
+async def main() -> None:
+    banner("replay_record_and_play")
+
+    from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+        HumanMessage,
+    )
+
+    from langgraph_kit.graphs.echo_agent import build_graph
+    from langgraph_kit.replay import (
+        ConversationRecorder,
+        ConversationRecording,
+    )
+
+    with tmp_workspace() as workspace:
+        # 1. Build a hermetic graph and attach a recorder.
+        llm = scripted_llm([answer("I recorded this run.")])
+        with patch_build_llm(llm):
+            checkpointer, store = make_in_memory_persistence()
+            graph = build_graph(checkpointer, store)
+
+            recorder = ConversationRecorder(
+                agent_id="example-replay", thread_id="thread-1"
+            )
+
+            await graph.ainvoke(
+                {"messages": [HumanMessage(content="Say something memorable.")]},
+                config={  # pyright: ignore[reportArgumentType]
+                    "configurable": {"thread_id": "thread-1"},
+                    "callbacks": [recorder],
+                },
+            )
+
+        # 2. Save the recording.
+        recording_path = workspace / "conv.json"
+        recorder.save(recording_path)
+        size = recording_path.stat().st_size
+        line(f"Recording saved to {recording_path} ({size} bytes)")
+
+        # 3. Reload and inspect.
+        loaded = ConversationRecording.model_validate_json(recording_path.read_text())
+        line(f"Recorded LLM interactions: {len(loaded.llm_interactions)}")
+        line(f"Recorded tool interactions: {len(loaded.tool_interactions)}")
+
+        if loaded.llm_interactions:
+            last = loaded.llm_interactions[-1]
+            content = last.output_message.get("content", "")
+            line(f"Last assistant content: {content}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,13 @@ nav:
   - Examples:
     - Overview: examples/index.md
     - Memory — save & recall: examples/memory_save_recall.md
+    - Tools — register capability: examples/tools_register_capability.md
+    - Prompt assembly — sections: examples/prompt_assembly_sections.md
+    - HITL — approval flow: examples/hitl_approval_flow.md
+    - Orchestration — workers: examples/orchestration_workers.md
+    - Replay — record & play: examples/replay_record_and_play.md
+    - FastAPI — minimal router: examples/fastapi_minimal_router.md
+    - Context — compaction: examples/context_compaction.md
   - CLI: cli/reference.md
   - API reference:
     - Public API: api-reference/public-api.md

--- a/src/langgraph_kit/cli.py
+++ b/src/langgraph_kit/cli.py
@@ -6,11 +6,16 @@ Usage::
     python -m langgraph_kit.cli new my-agent --output-dir ./agents
     python -m langgraph_kit.cli new my-agent --force   # overwrite existing
     python -m langgraph_kit.cli list
+    python -m langgraph_kit.cli examples list
+    python -m langgraph_kit.cli examples run quickstart_echo
 """
 
 from __future__ import annotations
 
 import argparse
+import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 from textwrap import dedent
@@ -207,6 +212,93 @@ def _out(text: str) -> None:
     sys.stdout.write(text + "\n")
 
 
+# ---------------------------------------------------------------------------
+# Examples discovery
+# ---------------------------------------------------------------------------
+
+
+def _examples_dir() -> Path | None:
+    """Locate the repo-root ``examples/`` directory, or ``None`` if missing.
+
+    The kit's wheel doesn't yet ship examples (they live at the repo
+    root, not under ``src/langgraph_kit/``). When run from a source
+    checkout, walk up from the installed package to find them. When
+    run from a PyPI install, this returns None and the caller surfaces
+    a clear "clone the repo" message — see issue #61.
+    """
+    candidate = Path(__file__).resolve().parent.parent.parent / "examples"
+    return candidate if candidate.is_dir() else None
+
+
+def _example_pitch(path: Path) -> str:
+    """Return the first non-blank docstring line as the example's pitch."""
+    try:
+        head = path.read_text(encoding="utf-8")[:2000]
+    except OSError:
+        return ""
+    # Capture the docstring delimited by ``"""..."""``; the first line is
+    # the pitch.
+    match = re.search(r'"""(.+?)"""', head, re.DOTALL)
+    if not match:
+        return ""
+    body = match.group(1).strip()
+    return body.splitlines()[0] if body else ""
+
+
+def _list_examples(examples_dir: Path) -> list[Path]:
+    """Return the discoverable examples, sorted alphabetically."""
+    return sorted(
+        p
+        for p in examples_dir.glob("*.py")
+        if p.name != "run_all.py" and not p.name.startswith("_")
+    )
+
+
+def _cmd_examples_list() -> int:
+    examples_dir = _examples_dir()
+    if examples_dir is None:
+        sys.stderr.write(
+            "examples/ directory not found. Examples ship from the source "
+            "checkout — clone https://github.com/allada-homelab/langgraph-kit "
+            "and run from there.\n"
+        )
+        return 1
+    paths = _list_examples(examples_dir)
+    _out(f"{len(paths)} example(s) in {examples_dir}:")
+    for path in paths:
+        pitch = _example_pitch(path)
+        # Right-pad the name so pitches line up; widest current name is ~30.
+        _out(f"  {path.stem:<32} {pitch}")
+    return 0
+
+
+def _cmd_examples_run(name: str, *, real_llm: bool = False) -> int:
+    examples_dir = _examples_dir()
+    if examples_dir is None:
+        sys.stderr.write(
+            "examples/ directory not found. Examples ship from the source "
+            "checkout — clone the repo to use ``examples run``.\n"
+        )
+        return 1
+    target = examples_dir / f"{name}.py"
+    if not target.is_file():
+        sys.stderr.write(
+            f"No example named {name!r}. Run ``examples list`` to see options.\n"
+        )
+        return 2
+
+    repo_root = examples_dir.parent
+    env = dict(os.environ)
+    env.setdefault("LANGGRAPH_KIT_EXAMPLES_LLM", "real" if real_llm else "scripted")
+    completed = subprocess.run(  # noqa: S603 — fixed argv, no shell, internal use
+        [sys.executable, "-m", f"examples.{name}"],
+        check=False,
+        cwd=repo_root,
+        env=env,
+    )
+    return completed.returncode
+
+
 def main() -> None:
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -231,6 +323,20 @@ def main() -> None:
     # list command
     sub.add_parser("list", help="List available agent templates")
 
+    # examples command (with nested list / run subcommands)
+    examples_parser = sub.add_parser(
+        "examples", help="Discover and run the bundled feature examples"
+    )
+    ex_sub = examples_parser.add_subparsers(dest="examples_command")
+    ex_sub.add_parser("list", help="List discoverable examples")
+    run_parser = ex_sub.add_parser("run", help="Run an example by name")
+    run_parser.add_argument("name", help="Example file name without extension")
+    run_parser.add_argument(
+        "--real-llm",
+        action="store_true",
+        help="Use the real LLM (requires AGENT_LLM_API_KEY)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "new":
@@ -254,6 +360,13 @@ def main() -> None:
     elif args.command == "list":
         _out("Available templates:")
         _out("  default — Full-featured agent with memory, tools, commands, middleware")
+    elif args.command == "examples":
+        if args.examples_command == "list":
+            sys.exit(_cmd_examples_list())
+        elif args.examples_command == "run":
+            sys.exit(_cmd_examples_run(args.name, real_llm=args.real_llm))
+        else:
+            examples_parser.print_help()
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary

- **7 new examples** (basic_deep_agent, prompt_assembly_sections, context_compaction, orchestration_workers, hitl_approval_flow, fastapi_minimal_router, replay_record_and_play) — all hermetic, all green
- **CLI subcommands**: `langgraph-kit examples list` and `langgraph-kit examples run <name> [--real-llm]`
- **README sweep**: 4 inline code blocks replaced with links to runnable examples (Tools, Prompt assembly, Multi-agent orchestration, HITL)
- **Nightly real-LLM workflow** with auto-opened issues on failure

## Highlights

### CLI

```bash
$ uv run python -m langgraph_kit.cli examples list
12 example(s) in /home/.../langgraph-kit/examples:
  basic_deep_agent           Basic deep agent — minimal deepagents framework wiring.
  context_compaction         Context management: pressure detection + mitigation choice.
  ...
$ uv run python -m langgraph_kit.cli examples run quickstart_echo
quickstart_echo
===============
user: Hello, kit!
assistant: Hi there — this is the echo agent saying hello back.
```

The CLI walks up from the installed package to find the repo's `examples/` directory. If the kit is installed from a PyPI wheel (where examples aren't shipped), the CLI surfaces a clear "clone the repo" message rather than silently failing. Shipping examples in the wheel itself is a Phase 3+ decision — see #61 for context.

### Nightly workflow

`.github/workflows/examples-nightly.yml` runs every day at 06:00 UTC against `claude-haiku-4-5` with the cost guardrail in `_lib.py` capping output tokens / turns per example. On failure, the workflow auto-opens an issue with a triage hint. This catches upstream model drift overnight rather than mid-day.

### README sweep — what was replaced and why

The four feature snippets that swapped to example links all had silent drift problems:

- The Tools snippet used `name=`, `func=`, and `set` profiles — none of which match `ToolCapability`'s actual signature (`id`, `name`, `fn`, `list[str]`).
- The Prompt assembly snippet showed `providers=[...]` without a runnable example.
- HITL claimed `await approve_action(context={...})` — `approve_action` actually takes `action_args=`.

Quickstart blocks (configure / register / stream / FastAPI) intentionally stay inline because they're teaching kit bootstrapping, not feature usage.

## Notable decisions

1. **HITL example deliberately skips `from __future__ import annotations`.** LangGraph's `StateGraph` calls `get_type_hints()` at compile time; deferred string annotations would force `add_messages` lookup before its module-level import resolves. Same gotcha echo_agent.py addresses.
2. **FastAPI example uses `httpx.ASGITransport`.** No real socket, no port allocation, runs hermetically alongside the other examples.
3. **`replay_record_and_play.py` doesn't use `ReplayRunner`.** ReplayRunner expects a `graph_builder(checkpointer, store, llm=...)` signature; the kit's `build_graph` doesn't take `llm`. The example demonstrates the recorder + JSON round-trip, which is the more common starting point for users.

## Test plan

- [x] `just examples-smoke` — 12 examples all green in <10s
- [x] `uv run python -m langgraph_kit.cli examples list` works; `examples run quickstart_echo` runs the demo end-to-end; bad name exits 2 with clear message
- [x] `uv run pytest` — 1109 passed, no regressions
- [x] `uv run basedpyright` — 0 errors (52 pre-existing warnings unrelated)
- [x] `uv run ruff check . && ruff format --check .` — clean
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run mkdocs build --strict` — Examples nav now lists 8 pages, all render via pymdownx.snippets
- [ ] Confirm in CI: hermetic `examples` job stays green, ci-success rolls up
- [ ] Confirm rendered README: feature sections show links, not inline drifty code

Fixes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)