### PR TITLE
Phase 0: prompt-bench harness + 12 seed scenarios + nightly workflow (#69)

### DIFF
--- a/.github/workflows/prompt-bench-nightly.yml
+++ b/.github/workflows/prompt-bench-nightly.yml
@@ -1,0 +1,85 @@
+name: Prompt-bench (nightly harness check)
+
+on:
+  schedule:
+    # Daily at 07:30 UTC — staggered behind the examples-nightly cron at
+    # 06:00 so failures from the two suites don't pile into one issue
+    # tracker burst.
+    - cron: "30 7 * * *"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Optional bench target for signal-check (e.g. reference_deep_agent.core_identity)"
+        required: false
+        default: ""
+
+jobs:
+  prompt-bench-harness:
+    name: Prompt-bench harness (hermetic)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+      - run: uv sync --all-extras --all-groups
+
+      - name: Run prompt-bench unit tests
+        run: uv run pytest tests/prompt_bench -v
+
+      - name: Discover scenarios
+        run: uv run python -m tests.prompt_bench.run list-scenarios
+
+      - name: Discover targets
+        run: uv run python -m tests.prompt_bench.run list-targets
+
+      # Phase 0 ships the harness modules + scenarios + diff API but
+      # defers live signal-check (baseline-vs-baseline + baseline-vs-
+      # deliberately-broken) to Phase 1, which wires the run.py CLI to
+      # the profile builders. The placeholder step below lights up once
+      # the CLI's `signal-check` exits 0 instead of 3.
+      - name: Signal validation (Phase 1+)
+        if: ${{ inputs.target != '' }}
+        env:
+          AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
+          PROMPT_BENCH_LLM: real
+        run: |
+          set -euo pipefail
+          if uv run python -m tests.prompt_bench.run signal-check --target "${{ inputs.target }}"; then
+            echo "Signal-check passed."
+          else
+            echo "::warning::signal-check exited non-zero; Phase 0 surfaces this command but does not yet wire end-to-end execution."
+          fi
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const today = new Date().toISOString().slice(0, 10);
+            const title = `[nightly prompt-bench] harness failure on ${today}`;
+            const body = [
+              `Nightly prompt-bench harness check failed.`,
+              ``,
+              `Logs: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              ``,
+              `Likely causes:`,
+              `- Pydantic / pytest schema drift after a kit upgrade`,
+              `- Scenario YAML schema regression`,
+              `- Profile section list moved or renamed (e.g. _CORE_SECTIONS)`,
+              ``,
+              `Run \`uv run pytest tests/prompt_bench -v\` locally to reproduce.`,
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug'],
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,41 @@ The hermetic substrate is `langgraph_kit.replay.RecordedChatModel`,
 which is also what the e2e suite uses — patterns that work in
 `tests/e2e/` work for an example.
 
+## Optimizing a prompt
+
+The kit has ~25 distinct prompts (agent system prompts, prompt-assembly
+sections, middleware prompts, worker definitions). They evolve through
+the internal **prompt-bench** harness under `tests/prompt_bench/`.
+
+Iteration loop:
+
+1. **Read [tests/prompt_bench/README.md](tests/prompt_bench/README.md)** for the full workflow,
+   acceptance bar, and seven variant dimensions to try (one per
+   iteration).
+2. **Drop a candidate** at `tests/prompt_bench/variants/<target>/<variant_name>.md`.
+   Frontmatter (notes, dimension changed) is stripped; everything below
+   is the prompt text the overlay injects.
+3. **Run the harness** (Phase 1 onwards — hermetic check works today via
+   `just prompt-bench-test`):
+   ```bash
+   PROMPT_BENCH_LLM=real AGENT_LLM_API_KEY=... \
+     uv run python -m tests.prompt_bench.run run \
+       --target <target> --variant <variant_name>
+   ```
+4. **Diff** baseline vs variant; the markdown report goes in the PR.
+5. **Strict acceptance bar** — a change ships only when:
+   - Pairwise win rate ≥ 60% across decided pairs
+   - Two-judge agreement ≥ 70%
+   - No rule-based metric regression > 5%
+   - Cross-prompt regression suite passes
+   - N=5 samples per scenario (re-run high-variance scenarios with N=10)
+
+Do not lower the thresholds (`WIN_RATE_THRESHOLD` /
+`JUDGE_AGREEMENT_THRESHOLD` / `METRIC_REGRESSION_TOLERANCE` in
+`tests/prompt_bench/diff.py`) per-PR. If a candidate doesn't clear the
+bar, it doesn't ship — iterate the prompt instead of relaxing the
+gate.
+
 ## Releasing
 
 Releases are tag-driven via PyPI Trusted Publishing (no manual API tokens).

--- a/justfile
+++ b/justfile
@@ -45,6 +45,22 @@ testapp:
 examples-smoke:
     uv run python -m examples.run_all
 
+# Prompt-bench — internal prompt-optimization harness under tests/prompt_bench/.
+# Hermetic by default. Set PROMPT_BENCH_LLM=real and AGENT_LLM_API_KEY for live runs.
+prompt-bench-test:
+    uv run pytest tests/prompt_bench -v
+
+prompt-bench-targets:
+    uv run python -m tests.prompt_bench.run list-targets
+
+prompt-bench-scenarios target="":
+    uv run python -m tests.prompt_bench.run list-scenarios {{ if target != "" { "--target " + target } else { "" } }}
+
+# Phase 0 surfaces signal-check via the CLI; it exits non-zero until the
+# Phase 1 PR wires live execution. Remove the leading "-" once that lands.
+prompt-bench-signal-check target:
+    -uv run python -m tests.prompt_bench.run signal-check --target {{target}}
+
 # Release
 build:
     uv build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ markers = [
     "asyncio: mark test as async",
     "integration: mark test as integration (requires external services)",
     "e2e: end-to-end test — runs a real compiled graph with a scripted LLM",
+    "prompt_bench: prompt-optimization bench scenario (real LLM when PROMPT_BENCH_LLM=real)",
 ]
 
 [tool.coverage.run]

--- a/tests/prompt_bench/README.md
+++ b/tests/prompt_bench/README.md
@@ -1,0 +1,139 @@
+# prompt_bench — internal prompt-optimization harness
+
+Internal tooling for systematically optimizing the prompts the kit ships
+(agent system prompts, prompt-assembly sections, middleware prompts,
+worker definitions, skill content). **Not** part of the public API —
+lives under `tests/` deliberately.
+
+## Why pairwise, not absolute scoring
+
+Absolute scores from a single LLM judge are noisy and drift across
+models, runs, and prompt families. Pairwise comparisons (A vs B for
+the same input, with the same scenario state, with the same execution
+LLM) are far more stable: the judge only has to decide "which is
+better and why", not "score this 0-1." The literature converges on
+pairwise preference as the lower-variance signal, and this harness
+follows that convention.
+
+## Acceptance bar (strict)
+
+A prompt change ships only if **all** hold:
+
+1. **Pairwise win rate ≥ 60%** of decided pairs across all scenarios
+   for the target prompt.
+2. **Two-judge agreement ≥ 70%** across all pairs (pairs are *decided*
+   only when every judge agrees on a non-tie winner *or* every judge
+   agrees on a tie).
+3. **No rule-based metric regression > 5%** on `LatencyMetric`,
+   `ErrorFreeMetric`, `ToolEfficiencyMetric`, `ResponseLengthMetric`.
+4. **Cross-prompt regression suite passes** — small bench against
+   scenarios from other tiers to catch coupling effects.
+5. **N=5 samples per scenario**; high-variance scenarios (IQR > 0.3
+   on score) get re-run with N=10 before counting.
+
+The thresholds are encoded in `diff.py`:
+`WIN_RATE_THRESHOLD`, `JUDGE_AGREEMENT_THRESHOLD`,
+`METRIC_REGRESSION_TOLERANCE`. Adjust there if the bar moves; do not
+override per-PR.
+
+## Layout
+
+```
+tests/prompt_bench/
+├── runner.py        BenchRunner — iterates scenarios x samples
+├── pairwise.py      PairwiseJudge + PairwisePanel — A/B comparison
+├── variants.py      PromptOverlay + middleware patch context manager
+├── profiles.py      Per-agent overlay-application bridges
+├── diff.py          DiffReport + acceptance-criteria evaluation
+├── scenarios.py     Scenario YAML schema + loader
+├── conftest.py      Pytest fixtures (mocked LLM by default; real LLM
+│                    when PROMPT_BENCH_LLM=real and AGENT_LLM_API_KEY)
+├── run.py           CLI entry: list-targets, list-scenarios, ...
+├── scenarios/<target>/*.yaml      Scenario library, grows over time
+├── rubrics/*.md                   Pairwise + per-target rubrics
+└── variants/<target>/*.md         baseline.md + named candidates
+```
+
+## Variant dimensions to try (one per iteration)
+
+Each candidate variant should change exactly one dimension so we know
+what moved the needle. Pulled from current Anthropic prompt-engineering
+guidance:
+
+- **Structure**: XML tags vs markdown headings vs prose paragraphs
+- **Role priming**: "You are X" vs imperative vs second-person
+- **Examples**: 0-shot vs 1-shot vs few-shot; positive only vs positive+negative
+- **Specificity**: terse rules vs verbose explanations with rationale
+- **Output format**: explicit JSON schema vs natural language
+- **Position**: instructions in system message vs first user message vs both
+- **Ordering**: instructions-then-context vs context-then-instructions
+
+## Workflow — adding a new variant
+
+1. **Pick a target.** `python -m tests.prompt_bench.run list-targets`
+2. **Author the candidate.** Drop a markdown file under
+   `variants/<target>/<variant_name>.md`. The file may carry a YAML
+   frontmatter block (notes, rationale, dimension changed) — the
+   loader strips it. Everything below the frontmatter is the prompt
+   text the overlay will inject.
+3. **Run the bench.** Once the live `run`/`diff` CLI lands (Phase 1),
+   it'll be:
+
+   ```bash
+   PROMPT_BENCH_LLM=real AGENT_LLM_API_KEY=... \
+     python -m tests.prompt_bench.run run --target reference_deep_agent.core_identity --variant my_candidate
+   ```
+
+   For now the bench is exercised via the pytest harness and the
+   nightly workflow.
+4. **Diff.** `python -m tests.prompt_bench.run diff --base base.json --variant variant.json --out diff.md`
+5. **Open a PR** with the variant file, the diff report (markdown),
+   and a one-paragraph note on which dimension you changed.
+
+## Workflow — adding a new scenario
+
+A scenario is a YAML file under `scenarios/<target>/`. Schema lives in
+`scenarios.py:Scenario`. Required fields:
+
+- `id` — unique identifier
+- `target` — dotted prompt target (e.g. `reference_deep_agent.core_identity`)
+- `turns` — list of user turns
+- `samples` — N for the harness (default 5)
+- `rubric` — relative path to a rubric markdown file (per-target rubric
+  for the LLM judge; the pairwise system rubric is added on top)
+
+Optional: `seeded_state`, `expected_behaviors`, `description`.
+
+## Hermetic vs real-LLM
+
+Default mode is **hermetic** — `bench_llm` is a deterministic stub.
+Use this for:
+
+- Unit-testing harness logic (`pytest tests/prompt_bench/`)
+- CI's per-PR run (no API key required)
+
+**Real-LLM mode** is enabled by `PROMPT_BENCH_LLM=real` +
+`AGENT_LLM_API_KEY`. Use this for:
+
+- Actual prompt-iteration cycles
+- The nightly CI workflow
+- Local validation before opening a PR
+
+The execution LLM defaults to `claude-sonnet-4-6` (quality matters);
+judges default to `claude-opus-4-7` and `claude-haiku-4-5`. Override
+in `conftest.py` if needed.
+
+## Signal validation (run before optimizing real prompts)
+
+Two sanity checks the harness must pass before any optimization PR is
+trusted:
+
+1. **Floor:** baseline-vs-baseline produces a pairwise win rate
+   within `[0.45, 0.55]` (noise band). Outside this band → harness
+   has bias.
+2. **Ceiling:** baseline-vs-`deliberately_broken.md` produces a
+   baseline win rate ≥ 80%. Lower → the judges aren't discriminating.
+
+Both are exercised by the nightly workflow. The `deliberately_broken.md`
+variants under `variants/<target>/` exist for this reason — do not
+delete them.

--- a/tests/prompt_bench/__init__.py
+++ b/tests/prompt_bench/__init__.py
@@ -1,0 +1,19 @@
+"""Internal prompt-optimization harness.
+
+Lives in ``tests/`` (not ``src/``) — this is our internal optimization
+tool, not a shipped feature of the kit. Reuses ``langgraph_kit.evals``
+primitives (``LLMJudgeMetric``, ``TraceData``, rule-based metrics)
+rather than re-implementing them.
+
+Workflow
+--------
+1. Author a scenario YAML under ``scenarios/<target>/``.
+2. Author a variant prompt under ``variants/<target>/<variant>.md``.
+3. Run baseline + variant: ``python -m tests.prompt_bench.run run --target <target> --variant <variant>``.
+4. Diff the two reports: ``python -m tests.prompt_bench.run diff --base base.json --variant variant.json``.
+
+See ``tests/prompt_bench/README.md`` for the full iteration loop and
+acceptance criteria.
+"""
+
+from __future__ import annotations

--- a/tests/prompt_bench/conftest.py
+++ b/tests/prompt_bench/conftest.py
@@ -1,0 +1,195 @@
+"""Pytest fixtures for the prompt-bench harness.
+
+Lives at the package root (under ``tests/``) so unit tests can import
+fixtures with no ``--rootdir`` gymnastics. Provides:
+
+- ``bench_llm`` — chat model used for *agent execution*. Hermetic by
+  default (a deterministic stub that echoes the input). When
+  ``PROMPT_BENCH_LLM=real`` and ``AGENT_LLM_API_KEY`` is set, returns
+  a real Claude model pinned to ``DEFAULT_EXECUTION_MODEL``.
+- ``judge_llms`` — two-model panel for pairwise judging. Same hermetic
+  default; real mode pulls in a Claude judge + an external judge if
+  configured (otherwise two Claude judges with different temperature).
+- ``bench_pairwise_panel`` — a :class:`PairwisePanel` wired up with
+  ``judge_llms``.
+- ``mock_section_registry_factory`` — returns a fresh
+  ``SectionRegistry`` populated with ``reference_deep_agent``'s
+  ``_CORE_SECTIONS``.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tests.prompt_bench.pairwise import PairwiseJudge, PairwisePanel
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ---------------------------------------------------------------------------
+# Mode detection — separate env vars from the examples harness so the two
+# harnesses don't accidentally cross-talk (examples use scripted by default
+# even with PROMPT_BENCH_LLM=real, and vice versa).
+# ---------------------------------------------------------------------------
+
+_LLM_MODE_ENV = "PROMPT_BENCH_LLM"
+_API_KEY_ENV = "AGENT_LLM_API_KEY"
+
+# The model under evaluation (we want quality signal — Sonnet matters).
+DEFAULT_EXECUTION_MODEL = "claude-sonnet-4-6"
+# Judges should be capable but cheaper than the executor — Opus is the
+# default high-end judge; the second judge is OpenAI / Gemini if their
+# env vars are set, falling back to a second Claude with different temp.
+DEFAULT_JUDGE_MODEL_PRIMARY = "claude-opus-4-7"
+DEFAULT_JUDGE_MODEL_SECONDARY = "claude-haiku-4-5"
+
+
+def _real_llm_enabled() -> bool:
+    return os.environ.get(_LLM_MODE_ENV, "stub").lower() == "real"
+
+
+# ---------------------------------------------------------------------------
+# Stub chat model for hermetic tests
+# ---------------------------------------------------------------------------
+
+
+class _DeterministicStub:
+    """Tiny chat-model substitute used in unit tests.
+
+    Returns a fixed JSON for the pairwise judge protocol so we can drive
+    panel logic without invoking a real LLM. Configure via ``responses``
+    (a list of dicts that get returned in order; loops on overflow).
+    """
+
+    def __init__(self, responses: list[dict[str, Any]] | None = None) -> None:
+        super().__init__()
+        self._responses = responses or [{"winner": "tie", "confidence": 0.5, "reason": "stub"}]
+        self._call_index = 0
+
+    async def ainvoke(self, _messages: list[Any]) -> Any:
+        import json
+
+        idx = self._call_index % len(self._responses)
+        self._call_index += 1
+        payload = json.dumps(self._responses[idx])
+
+        class _Response:
+            content = payload
+
+        return _Response()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_llm() -> _DeterministicStub:
+    """Default: a stub that always returns ``{"winner": "tie"}``."""
+    return _DeterministicStub()
+
+
+@pytest.fixture
+def stub_llm_factory():
+    """Factory: build a stub with a custom response list."""
+    def _make(responses: list[dict[str, Any]]) -> _DeterministicStub:
+        return _DeterministicStub(responses=responses)
+
+    return _make
+
+
+@pytest.fixture
+def bench_llm() -> Any:
+    """Chat model used for *agent execution* in scenarios.
+
+    Hermetic stub by default; switches to real Claude when
+    ``PROMPT_BENCH_LLM=real`` + ``AGENT_LLM_API_KEY`` are set.
+    """
+    if _real_llm_enabled() and os.environ.get(_API_KEY_ENV):
+        return _build_real_chat_model(DEFAULT_EXECUTION_MODEL)
+    return _DeterministicStub()
+
+
+@pytest.fixture
+def judge_llms() -> list[Any]:
+    """Two-model panel for pairwise judging (real or stub)."""
+    if _real_llm_enabled() and os.environ.get(_API_KEY_ENV):
+        return [
+            _build_real_chat_model(DEFAULT_JUDGE_MODEL_PRIMARY),
+            _build_real_chat_model(DEFAULT_JUDGE_MODEL_SECONDARY),
+        ]
+    return [_DeterministicStub(), _DeterministicStub()]
+
+
+@pytest.fixture
+def bench_pairwise_panel(judge_llms: list[Any]) -> PairwisePanel:
+    """Two-judge panel wired to :func:`judge_llms`."""
+    judges = [
+        PairwiseJudge(name=f"judge_{i + 1}", llm=llm)
+        for i, llm in enumerate(judge_llms)
+    ]
+    return PairwisePanel(judges=judges, rng=random.Random(0))
+
+
+@pytest.fixture
+def reference_section_registry_factory():
+    """Return a callable that builds a fresh registry for the reference agent."""
+    from langgraph_kit.core.prompt_assembly.sections import SectionRegistry
+    from langgraph_kit.graphs.reference_deep_agent import _CORE_SECTIONS
+
+    def _make() -> SectionRegistry:
+        registry = SectionRegistry()
+        registry.register_many(_CORE_SECTIONS)
+        return registry
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Real chat model construction
+# ---------------------------------------------------------------------------
+
+
+def _build_real_chat_model(model_id: str) -> Any:
+    """Build a real Anthropic chat model with the given model id.
+
+    Matches what ``langgraph_kit.llm.build_llm`` would have produced,
+    but lets us pin different models for executor vs judges without
+    going through ``configure(AgentConfig(...))`` (which is global).
+    """
+    from langchain_anthropic import (  # pyright: ignore[reportMissingImports]
+        ChatAnthropic,
+    )
+
+    # Pass via **kwargs so basedpyright's stricter stub doesn't flag the
+    # well-known runtime kwargs (``model``, ``max_tokens``, ``timeout``)
+    # as unrecognised — langchain_anthropic accepts them at runtime.
+    kwargs: dict[str, Any] = {
+        "model": model_id,
+        "api_key": os.environ[_API_KEY_ENV],
+        "max_tokens": 1024,
+        "timeout": 60,
+    }
+    return ChatAnthropic(**kwargs)  # pyright: ignore[reportCallIssue]
+
+
+# ---------------------------------------------------------------------------
+# Disable the warnings-as-errors filter for the bench harness — we
+# explicitly invoke real or stubbed LLM clients here and don't want a
+# stray DeprecationWarning from langchain to nuke a 30-minute bench run.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _silence_bench_warnings() -> Iterator[None]:
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("default")
+        yield

--- a/tests/prompt_bench/conftest.py
+++ b/tests/prompt_bench/conftest.py
@@ -68,7 +68,9 @@ class _DeterministicStub:
 
     def __init__(self, responses: list[dict[str, Any]] | None = None) -> None:
         super().__init__()
-        self._responses = responses or [{"winner": "tie", "confidence": 0.5, "reason": "stub"}]
+        self._responses = responses or [
+            {"winner": "tie", "confidence": 0.5, "reason": "stub"}
+        ]
         self._call_index = 0
 
     async def ainvoke(self, _messages: list[Any]) -> Any:
@@ -98,6 +100,7 @@ def stub_llm() -> _DeterministicStub:
 @pytest.fixture
 def stub_llm_factory():
     """Factory: build a stub with a custom response list."""
+
     def _make(responses: list[dict[str, Any]]) -> _DeterministicStub:
         return _DeterministicStub(responses=responses)
 

--- a/tests/prompt_bench/diff.py
+++ b/tests/prompt_bench/diff.py
@@ -266,16 +266,16 @@ def render_markdown(diff: DiffReport) -> str:
         + f"({win_status} {WIN_RATE_THRESHOLD:.0%} bar)"
     )
     agree_status = (
-        "meets" if diff.overall_judge_agreement >= JUDGE_AGREEMENT_THRESHOLD else "BELOW"
+        "meets"
+        if diff.overall_judge_agreement >= JUDGE_AGREEMENT_THRESHOLD
+        else "BELOW"
     )
     lines.append(
         f"- Judge agreement: **{diff.overall_judge_agreement:.1%}** "
         + f"({agree_status} {JUDGE_AGREEMENT_THRESHOLD:.0%} bar)"
     )
     if diff.regression_flags:
-        lines.append(
-            f"- Regressions flagged on: {', '.join(diff.regression_flags)}"
-        )
+        lines.append(f"- Regressions flagged on: {', '.join(diff.regression_flags)}")
     else:
         lines.append("- No rule-based metric regressions beyond tolerance")
     lines.append("")

--- a/tests/prompt_bench/diff.py
+++ b/tests/prompt_bench/diff.py
@@ -1,0 +1,341 @@
+"""Diff and report generation for two bench runs.
+
+Pairs base/variant samples by ``scenario_id + sample_index``, runs the
+pairwise judge panel on each pair, computes per-scenario and overall
+win rates / agreement, applies rule-based metrics, and renders a
+markdown report fit for an issue comment or PR artifact.
+
+Strict acceptance criteria (the bar for shipping a prompt change):
+
+1. Pairwise win rate >= 60% across decided pairs.
+2. Two-judge agreement >= 70%.
+3. No rule-based metric regression > 5%.
+4. (Caller's responsibility) cross-prompt regression suite passes.
+5. (Caller's responsibility) high-variance scenarios re-run with N=10.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from langgraph_kit.evals.metrics.rule_based import (
+    ErrorFreeMetric,
+    LatencyMetric,
+    ResponseLengthMetric,
+    ToolEfficiencyMetric,
+)
+
+if TYPE_CHECKING:
+    from langgraph_kit.evals.models import EvalMetric
+    from tests.prompt_bench.pairwise import PairwisePanel
+    from tests.prompt_bench.runner import BenchReport, BenchSample
+
+
+logger = logging.getLogger(__name__)
+
+
+# Acceptance thresholds — the strict bar we agreed to in the plan.
+WIN_RATE_THRESHOLD = 0.60
+JUDGE_AGREEMENT_THRESHOLD = 0.70
+METRIC_REGRESSION_TOLERANCE = 0.05
+
+
+def default_rule_metrics() -> list[EvalMetric]:
+    """The four rule-based metrics applied to every diff."""
+    return [
+        LatencyMetric(),
+        ErrorFreeMetric(),
+        ToolEfficiencyMetric(),
+        ResponseLengthMetric(),
+    ]
+
+
+@dataclass
+class ScenarioDiff:
+    """Diff result for a single scenario."""
+
+    scenario_id: str
+    pair_count: int = 0
+    decided_pairs: int = 0
+    base_wins: int = 0
+    variant_wins: int = 0
+    ties: int = 0
+    judge_agreement: float = 0.0
+    base_metric_means: dict[str, float] = field(default_factory=dict)
+    variant_metric_means: dict[str, float] = field(default_factory=dict)
+    sample_score_iqr: float = 0.0
+
+    @property
+    def decided_win_rate(self) -> float:
+        if self.decided_pairs == 0:
+            return 0.0
+        return round(self.variant_wins / self.decided_pairs, 3)
+
+    @property
+    def metric_deltas(self) -> dict[str, float]:
+        deltas: dict[str, float] = {}
+        for name, base_mean in self.base_metric_means.items():
+            var_mean = self.variant_metric_means.get(name, base_mean)
+            deltas[name] = round(var_mean - base_mean, 3)
+        return deltas
+
+
+@dataclass
+class DiffReport:
+    """Aggregate diff across all scenarios."""
+
+    base_overlay: str
+    variant_overlay: str
+    scenarios: list[ScenarioDiff] = field(default_factory=list)
+
+    @property
+    def total_pairs(self) -> int:
+        return sum(s.pair_count for s in self.scenarios)
+
+    @property
+    def total_decided(self) -> int:
+        return sum(s.decided_pairs for s in self.scenarios)
+
+    @property
+    def total_variant_wins(self) -> int:
+        return sum(s.variant_wins for s in self.scenarios)
+
+    @property
+    def total_base_wins(self) -> int:
+        return sum(s.base_wins for s in self.scenarios)
+
+    @property
+    def total_ties(self) -> int:
+        return sum(s.ties for s in self.scenarios)
+
+    @property
+    def overall_win_rate(self) -> float:
+        if self.total_decided == 0:
+            return 0.0
+        return round(self.total_variant_wins / self.total_decided, 3)
+
+    @property
+    def overall_judge_agreement(self) -> float:
+        if self.total_pairs == 0:
+            return 0.0
+        return round(self.total_decided / self.total_pairs, 3)
+
+    @property
+    def regression_flags(self) -> list[str]:
+        """List of metric names that regressed beyond tolerance."""
+        flags: list[str] = []
+        for scenario in self.scenarios:
+            for name, delta in scenario.metric_deltas.items():
+                if delta < -METRIC_REGRESSION_TOLERANCE and name not in flags:
+                    flags.append(name)
+        return flags
+
+    @property
+    def passes_acceptance(self) -> bool:
+        return (
+            self.overall_win_rate >= WIN_RATE_THRESHOLD
+            and self.overall_judge_agreement >= JUDGE_AGREEMENT_THRESHOLD
+            and not self.regression_flags
+        )
+
+
+async def compute_diff(
+    base_report: BenchReport,
+    variant_report: BenchReport,
+    panel: PairwisePanel,
+    rule_metrics: list[EvalMetric] | None = None,
+) -> DiffReport:
+    """Diff base vs variant — pairwise + rule-based metric deltas."""
+    metrics = rule_metrics or default_rule_metrics()
+    diff = DiffReport(
+        base_overlay=base_report.overlay_name,
+        variant_overlay=variant_report.overlay_name,
+    )
+
+    by_scenario_base = _group_by_scenario(base_report.samples)
+    by_scenario_variant = _group_by_scenario(variant_report.samples)
+
+    for scenario_id, base_samples in by_scenario_base.items():
+        variant_samples = by_scenario_variant.get(scenario_id, [])
+        scenario_diff = await _diff_scenario(
+            scenario_id, base_samples, variant_samples, panel, metrics
+        )
+        diff.scenarios.append(scenario_diff)
+
+    diff.scenarios.sort(key=lambda s: s.scenario_id)
+    return diff
+
+
+async def _diff_scenario(
+    scenario_id: str,
+    base_samples: list[BenchSample],
+    variant_samples: list[BenchSample],
+    panel: PairwisePanel,
+    metrics: list[EvalMetric],
+) -> ScenarioDiff:
+    diff = ScenarioDiff(scenario_id=scenario_id)
+    pairs = list(zip(base_samples, variant_samples, strict=False))
+    diff.pair_count = len(pairs)
+
+    for base_sample, variant_sample in pairs:
+        result = await panel.compare(
+            input_text=scenario_id,
+            base_trace=base_sample.to_trace(),
+            variant_trace=variant_sample.to_trace(),
+        )
+        if result.decided:
+            diff.decided_pairs += 1
+            if result.winner == "tie":
+                diff.ties += 1
+            elif result.base_won:
+                diff.base_wins += 1
+            else:
+                diff.variant_wins += 1
+
+    diff.judge_agreement = (
+        round(diff.decided_pairs / diff.pair_count, 3) if diff.pair_count else 0.0
+    )
+
+    diff.base_metric_means = await _metric_means(metrics, base_samples)
+    diff.variant_metric_means = await _metric_means(metrics, variant_samples)
+
+    base_scores = [s.duration_ms for s in base_samples if s.duration_ms]
+    if len(base_scores) >= 2:
+        try:
+            qs = statistics.quantiles(base_scores, n=4)
+            diff.sample_score_iqr = round(qs[2] - qs[0], 3)
+        except statistics.StatisticsError:
+            diff.sample_score_iqr = 0.0
+
+    return diff
+
+
+async def _metric_means(
+    metrics: list[EvalMetric], samples: list[BenchSample]
+) -> dict[str, float]:
+    means: dict[str, float] = {}
+    if not samples:
+        return means
+    for metric in metrics:
+        values: list[float] = []
+        for sample in samples:
+            try:
+                result = await metric.score(sample.to_trace())
+            except Exception:
+                logger.exception(
+                    "Rule metric %s failed on sample %s",
+                    metric.name,
+                    sample.scenario_id,
+                )
+                continue
+            value = result.value
+            if isinstance(value, bool):
+                values.append(1.0 if value else 0.0)
+            elif isinstance(value, (int, float)):
+                values.append(float(value))
+        if values:
+            means[metric.name] = round(sum(values) / len(values), 3)
+    return means
+
+
+def _group_by_scenario(samples: list[BenchSample]) -> dict[str, list[BenchSample]]:
+    grouped: dict[str, list[BenchSample]] = {}
+    for s in samples:
+        grouped.setdefault(s.scenario_id, []).append(s)
+    for v in grouped.values():
+        v.sort(key=lambda s: s.sample_index)
+    return grouped
+
+
+def render_markdown(diff: DiffReport) -> str:
+    """Render the diff as a markdown report (issue-comment friendly)."""
+    lines: list[str] = []
+    pass_str = "PASS" if diff.passes_acceptance else "FAIL"
+    lines.append(
+        f"# Prompt-bench diff: `{diff.variant_overlay}` vs `{diff.base_overlay}` — **{pass_str}**"
+    )
+    lines.append("")
+    lines.append("## Acceptance criteria")
+    lines.append("")
+    win_status = "meets" if diff.overall_win_rate >= WIN_RATE_THRESHOLD else "BELOW"
+    lines.append(
+        f"- Win rate: **{diff.overall_win_rate:.1%}** "
+        + f"({win_status} {WIN_RATE_THRESHOLD:.0%} bar)"
+    )
+    agree_status = (
+        "meets" if diff.overall_judge_agreement >= JUDGE_AGREEMENT_THRESHOLD else "BELOW"
+    )
+    lines.append(
+        f"- Judge agreement: **{diff.overall_judge_agreement:.1%}** "
+        + f"({agree_status} {JUDGE_AGREEMENT_THRESHOLD:.0%} bar)"
+    )
+    if diff.regression_flags:
+        lines.append(
+            f"- Regressions flagged on: {', '.join(diff.regression_flags)}"
+        )
+    else:
+        lines.append("- No rule-based metric regressions beyond tolerance")
+    lines.append("")
+    lines.append(
+        f"## Totals — {diff.total_decided}/{diff.total_pairs} decided "
+        + f"({diff.total_variant_wins} variant wins, "
+        + f"{diff.total_base_wins} base wins, {diff.total_ties} ties)"
+    )
+    lines.append("")
+    lines.append("## Per-scenario breakdown")
+    lines.append("")
+    lines.append(
+        "| Scenario | Decided | Variant wins | Base wins | Ties | Win rate | Metric deltas |"
+    )
+    lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for s in diff.scenarios:
+        deltas_str = (
+            ", ".join(f"{name}={delta:+.3f}" for name, delta in s.metric_deltas.items())
+            or "-"
+        )
+        row = (
+            f"| `{s.scenario_id}` | {s.decided_pairs}/{s.pair_count} | "
+            + f"{s.variant_wins} | {s.base_wins} | {s.ties} | "
+            + f"{s.decided_win_rate:.1%} | {deltas_str} |"
+        )
+        lines.append(row)
+    return "\n".join(lines) + "\n"
+
+
+def to_dict(diff: DiffReport) -> dict[str, Any]:
+    """Serializable dict for JSON artifact."""
+    return {
+        "base_overlay": diff.base_overlay,
+        "variant_overlay": diff.variant_overlay,
+        "totals": {
+            "pair_count": diff.total_pairs,
+            "decided": diff.total_decided,
+            "variant_wins": diff.total_variant_wins,
+            "base_wins": diff.total_base_wins,
+            "ties": diff.total_ties,
+            "win_rate": diff.overall_win_rate,
+            "judge_agreement": diff.overall_judge_agreement,
+        },
+        "regression_flags": diff.regression_flags,
+        "passes_acceptance": diff.passes_acceptance,
+        "scenarios": [
+            {
+                "scenario_id": s.scenario_id,
+                "pair_count": s.pair_count,
+                "decided_pairs": s.decided_pairs,
+                "base_wins": s.base_wins,
+                "variant_wins": s.variant_wins,
+                "ties": s.ties,
+                "judge_agreement": s.judge_agreement,
+                "decided_win_rate": s.decided_win_rate,
+                "base_metric_means": s.base_metric_means,
+                "variant_metric_means": s.variant_metric_means,
+                "metric_deltas": s.metric_deltas,
+                "sample_score_iqr": s.sample_score_iqr,
+            }
+            for s in diff.scenarios
+        ],
+    }

--- a/tests/prompt_bench/pairwise.py
+++ b/tests/prompt_bench/pairwise.py
@@ -204,7 +204,9 @@ class PairwiseJudge:
 class PairwisePanel:
     """Multi-judge panel that produces a decided/undecided verdict."""
 
-    def __init__(self, judges: list[PairwiseJudge], rng: random.Random | None = None) -> None:
+    def __init__(
+        self, judges: list[PairwiseJudge], rng: random.Random | None = None
+    ) -> None:
         if not judges:
             msg = "PairwisePanel requires at least one judge"
             raise ValueError(msg)

--- a/tests/prompt_bench/pairwise.py
+++ b/tests/prompt_bench/pairwise.py
@@ -1,0 +1,273 @@
+"""Pairwise LLM judge — compares two outputs and picks a winner.
+
+Why pairwise instead of absolute scoring?
+
+Absolute scores from a single judge are noisy and prone to drift across
+runs, prompts, and models. Pairwise comparisons (A vs B for the same
+input) are far more stable: the judge only has to answer "which is
+better and why," not "score this 0-1." Anthropic's prompt-engineering
+guidance and most open evaluation literature converges on pairwise
+preference as the lower-variance signal.
+
+Bias guards baked in
+--------------------
+- **Order randomization.** A and B are randomly swapped per call so the
+  judge can't develop a position bias. The shuffle is recorded so we
+  un-shuffle when aggregating.
+- **Multi-judge agreement.** A pair is only "decided" when N judges
+  (default 2) agree. Disagreements count as "no decision" so judge
+  bias doesn't leak into the win rate.
+- **Length normalization clause.** The default rubric tells the judge
+  to ignore response length. Operators are still expected to monitor
+  ``ResponseLengthMetric`` separately.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from langgraph_kit.evals.metrics.model_graded import _extract_json
+
+if TYPE_CHECKING:
+    from langgraph_kit.evals.models import TraceData
+
+logger = logging.getLogger(__name__)
+
+
+_PAIRWISE_SYSTEM = (
+    "You are an evaluation judge. Compare two assistant outputs (A and B) "
+    "for the same input and decide which response is better according to "
+    "the rubric. Reply with a single JSON object and nothing else: "
+    '{"winner": "A" | "B" | "tie", "confidence": <float 0.0-1.0>, '
+    '"reason": "<one-sentence justification>"}. '
+    "Do not wrap the JSON in markdown. Do not include any other keys. "
+    "Ignore response length differences when judging quality unless the "
+    "rubric specifically calls them out."
+)
+
+
+_DEFAULT_RUBRIC = """\
+Compare the two assistant outputs against the user input and decide
+which response is more helpful, accurate, and well-structured.
+
+Rules:
+- Pick A or B if one is clearly better.
+- Pick "tie" only when the responses are genuinely indistinguishable on
+  the criteria above.
+- Do not favor longer responses.
+- Penalize hallucinations or unsupported claims regardless of fluency.
+
+Input:
+{{input}}
+
+Output A:
+{{output_a}}
+
+Output B:
+{{output_b}}
+"""
+
+
+@dataclass(frozen=True)
+class PairwiseDecision:
+    """One judge's verdict on one A/B pair."""
+
+    judge_name: str
+    winner: Literal["A", "B", "tie"]
+    confidence: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class PairwiseResult:
+    """Aggregated verdict across all judges for one A/B pair.
+
+    A pair is *decided* only when every judge agrees on a non-tie winner
+    OR every judge agrees on a tie. Mixed results are *undecided*.
+    """
+
+    decisions: list[PairwiseDecision]
+    decided: bool
+    winner: Literal["A", "B", "tie", "undecided"]
+    base_was_a: bool
+
+    @property
+    def base_won(self) -> bool:
+        if not self.decided or self.winner == "tie":
+            return False
+        if self.base_was_a:
+            return self.winner == "A"
+        return self.winner == "B"
+
+    @property
+    def variant_won(self) -> bool:
+        if not self.decided or self.winner == "tie":
+            return False
+        if self.base_was_a:
+            return self.winner == "B"
+        return self.winner == "A"
+
+
+class PairwiseJudge:
+    """A single LLM-backed judge for pairwise comparison.
+
+    Use :class:`PairwisePanel` to combine multiple judges with
+    agreement-based decision logic.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        llm: Any,
+        rubric_path: str | Path | None = None,
+        rubric_text: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.name = name
+        self._llm = llm
+        if rubric_text is not None:
+            self._rubric = rubric_text
+        elif rubric_path is not None:
+            self._rubric = Path(rubric_path).read_text(encoding="utf-8")
+        else:
+            self._rubric = _DEFAULT_RUBRIC
+
+    async def judge(
+        self,
+        input_text: str,
+        output_a: str,
+        output_b: str,
+    ) -> PairwiseDecision:
+        prompt = (
+            self._rubric.replace("{{input}}", input_text)
+            .replace("{{output_a}}", output_a)
+            .replace("{{output_b}}", output_b)
+        )
+
+        try:
+            from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+                HumanMessage,
+                SystemMessage,
+            )
+
+            response = await self._llm.ainvoke(
+                [
+                    SystemMessage(content=_PAIRWISE_SYSTEM),
+                    HumanMessage(content=prompt),
+                ]
+            )
+            content = (
+                response.content if hasattr(response, "content") else str(response)
+            )
+            parsed = _extract_json(content)
+        except Exception:
+            logger.exception("Pairwise judge %r failed to invoke LLM", self.name)
+            return PairwiseDecision(
+                judge_name=self.name,
+                winner="tie",
+                confidence=0.0,
+                reason="judge_failed",
+            )
+
+        winner = str(parsed.get("winner", "tie")).strip().lower()
+        if winner not in ("a", "b", "tie"):
+            winner = "tie"
+        try:
+            confidence = float(parsed.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        confidence = max(0.0, min(1.0, confidence))
+        reason = str(parsed.get("reason", ""))[:240]
+
+        # Normalize to upper-case A/B/tie label
+        normalized: Literal["A", "B", "tie"]
+        if winner == "a":
+            normalized = "A"
+        elif winner == "b":
+            normalized = "B"
+        else:
+            normalized = "tie"
+
+        return PairwiseDecision(
+            judge_name=self.name,
+            winner=normalized,
+            confidence=confidence,
+            reason=reason,
+        )
+
+
+class PairwisePanel:
+    """Multi-judge panel that produces a decided/undecided verdict."""
+
+    def __init__(self, judges: list[PairwiseJudge], rng: random.Random | None = None) -> None:
+        if not judges:
+            msg = "PairwisePanel requires at least one judge"
+            raise ValueError(msg)
+        super().__init__()
+        self._judges = judges
+        self._rng = rng or random.Random()
+
+    async def compare(
+        self,
+        input_text: str,
+        base_trace: TraceData,
+        variant_trace: TraceData,
+    ) -> PairwiseResult:
+        """Compare base vs variant; randomize A/B placement."""
+        base_text = _trace_output_text(base_trace)
+        variant_text = _trace_output_text(variant_trace)
+
+        # Randomize A/B placement to avoid any positional bias.
+        base_was_a = self._rng.choice([True, False])
+        if base_was_a:
+            output_a, output_b = base_text, variant_text
+        else:
+            output_a, output_b = variant_text, base_text
+
+        decisions: list[PairwiseDecision] = []
+        for judge in self._judges:
+            decision = await judge.judge(input_text, output_a, output_b)
+            decisions.append(decision)
+
+        winners = {d.winner for d in decisions}
+        decided = len(winners) == 1
+        # ``winners`` is a set of ``Literal["A","B","tie"]`` so the
+        # element below is one of those three; basedpyright loses that
+        # narrowing across ``next(iter(...))``, hence the type-ignore.
+        winner: Literal["A", "B", "tie", "undecided"]
+        if decided:  # noqa: SIM108 - basedpyright loses Literal narrowing through next()
+            winner = next(iter(winners))  # type: ignore[assignment]
+        else:
+            winner = "undecided"
+
+        return PairwiseResult(
+            decisions=decisions,
+            decided=decided,
+            winner=winner,
+            base_was_a=base_was_a,
+        )
+
+
+def _trace_output_text(trace: TraceData) -> str:
+    """Best-effort extraction of an assistant output string from TraceData."""
+    output = trace.output
+    if output is None:
+        return ""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        # Common shapes: {"content": "..."} or {"messages": [{"content": "..."}, ...]}
+        if "content" in output and isinstance(output["content"], str):
+            return output["content"]
+        messages = output.get("messages")
+        if isinstance(messages, list) and messages:
+            last = messages[-1]
+            if isinstance(last, dict) and isinstance(last.get("content"), str):
+                return last["content"]
+        return json.dumps(output, ensure_ascii=False)
+    return str(output)

--- a/tests/prompt_bench/profiles.py
+++ b/tests/prompt_bench/profiles.py
@@ -30,7 +30,7 @@ class ProfileSpec:
 
     name: str
     section_source_module: str  # e.g. "langgraph_kit.graphs.reference_deep_agent"
-    section_attr: str            # e.g. "_CORE_SECTIONS"
+    section_attr: str  # e.g. "_CORE_SECTIONS"
 
 
 PROFILES: dict[str, ProfileSpec] = {

--- a/tests/prompt_bench/profiles.py
+++ b/tests/prompt_bench/profiles.py
@@ -1,0 +1,189 @@
+"""Profile bridges — translate an overlay into a built agent graph.
+
+Each profile knows:
+
+- Which agent module to build.
+- Where the agent's section list lives (so an overlay's ``section_overrides``
+  can be applied to a fresh copy without monkey-patching module state).
+- How to compile the graph end-to-end.
+
+This module is the *only* place that knows about specific agent
+profiles. The rest of the bench harness stays generic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from langgraph_kit.core.prompt_assembly.sections import PromptSection
+from tests.prompt_bench.variants import (
+    PromptOverlay,
+    patch_middleware_prompts,
+)
+
+
+@dataclass(frozen=True)
+class ProfileSpec:
+    """Description of an agent profile the bench can build."""
+
+    name: str
+    section_source_module: str  # e.g. "langgraph_kit.graphs.reference_deep_agent"
+    section_attr: str            # e.g. "_CORE_SECTIONS"
+
+
+PROFILES: dict[str, ProfileSpec] = {
+    "reference_deep_agent": ProfileSpec(
+        name="reference_deep_agent",
+        section_source_module="langgraph_kit.graphs.reference_deep_agent",
+        section_attr="_CORE_SECTIONS",
+    ),
+    "coding_agent": ProfileSpec(
+        name="coding_agent",
+        section_source_module="langgraph_kit.graphs.coding_agent",
+        section_attr="_CORE_SECTIONS",
+    ),
+}
+
+
+def get_baseline_sections(profile_name: str) -> list[PromptSection]:
+    """Return a fresh copy of the baseline section list for *profile_name*."""
+    spec = _require_profile(profile_name)
+    import importlib
+
+    module = importlib.import_module(spec.section_source_module)
+    sections = getattr(module, spec.section_attr, None)
+    if not isinstance(sections, list):
+        msg = (
+            f"Profile {profile_name!r}: expected list at "
+            f"{spec.section_source_module}.{spec.section_attr}, got "
+            f"{type(sections).__name__}"
+        )
+        raise RuntimeError(msg)
+    return list(sections)
+
+
+def apply_overlay_to_sections(
+    profile_name: str, overlay: PromptOverlay
+) -> list[PromptSection]:
+    """Return the profile's section list with *overlay* applied.
+
+    Section IDs in ``overlay.section_overrides`` that don't exist in
+    the profile's list are an error — overlays must target existing
+    sections so we know exactly what we're swapping.
+    """
+    sections = get_baseline_sections(profile_name)
+    if not overlay.section_overrides:
+        return sections
+
+    by_id = {s.id: s for s in sections}
+    missing = set(overlay.section_overrides) - by_id.keys()
+    if missing:
+        msg = (
+            f"Profile {profile_name!r} has no sections named "
+            f"{sorted(missing)} (cannot apply overlay {overlay.name!r})"
+        )
+        raise KeyError(msg)
+
+    swapped: list[PromptSection] = []
+    for section in sections:
+        if section.id in overlay.section_overrides:
+            swapped.append(
+                PromptSection(
+                    id=section.id,
+                    content=overlay.section_overrides[section.id],
+                    stability=section.stability,
+                    priority=section.priority,
+                    condition=section.condition,
+                )
+            )
+        else:
+            swapped.append(section)
+    return swapped
+
+
+# ---------------------------------------------------------------------------
+# Graph builders — keyed by profile name. Tests can register additional
+# builders for hermetic profiles via :func:`register_profile_builder`.
+# ---------------------------------------------------------------------------
+
+ProfileBuilder = Callable[[PromptOverlay, Any], Any]
+"""``(overlay, deps) -> compiled_graph``. ``deps`` is profile-specific."""
+
+_BUILDERS: dict[str, ProfileBuilder] = {}
+
+
+def register_profile_builder(name: str, builder: ProfileBuilder) -> None:
+    """Register a graph builder for *name*. Used by tests to inject mocks."""
+    _BUILDERS[name] = builder
+
+
+def build_profile_graph(profile_name: str, overlay: PromptOverlay, deps: Any) -> Any:
+    """Build the graph for *profile_name* with *overlay* applied."""
+    if profile_name not in _BUILDERS:
+        msg = (
+            f"No graph builder registered for profile {profile_name!r}. "
+            f"Available: {sorted(_BUILDERS)}"
+        )
+        raise KeyError(msg)
+    return _BUILDERS[profile_name](overlay, deps)
+
+
+# ---------------------------------------------------------------------------
+# Default reference_deep_agent builder — wired up lazily so importing this
+# module doesn't pay LangGraph's import cost when tests only need the
+# overlay-application logic.
+# ---------------------------------------------------------------------------
+
+
+def install_default_builders() -> None:
+    """Register builders for the agent profiles shipped with the kit.
+
+    Idempotent — safe to call from multiple fixtures. Each builder
+    expects ``deps`` to be a ``(checkpointer, store)`` tuple, matching
+    the kit's ``build_*_agent`` signatures.
+    """
+    if "reference_deep_agent" not in _BUILDERS:
+        register_profile_builder("reference_deep_agent", _build_reference_deep_agent)
+    if "coding_agent" not in _BUILDERS:
+        register_profile_builder("coding_agent", _build_coding_agent)
+
+
+def _build_reference_deep_agent(overlay: PromptOverlay, deps: Any) -> Any:
+    from langgraph_kit.core.orchestration.workers import GENERAL_WORKERS
+    from langgraph_kit.graphs._builder import build_deep_agent
+
+    sections = apply_overlay_to_sections("reference_deep_agent", overlay)
+    checkpointer, store = deps
+    with patch_middleware_prompts(overlay):
+        return build_deep_agent(
+            agent_name="reference-deep-agent",
+            core_sections=sections,
+            subagents=GENERAL_WORKERS,
+            checkpointer=checkpointer,
+            store=store,
+        )
+
+
+def _build_coding_agent(overlay: PromptOverlay, deps: Any) -> Any:
+    from langgraph_kit.core.orchestration.workers import CODING_WORKERS
+    from langgraph_kit.graphs._builder import build_deep_agent
+
+    sections = apply_overlay_to_sections("coding_agent", overlay)
+    checkpointer, store = deps
+    with patch_middleware_prompts(overlay):
+        return build_deep_agent(
+            agent_name="coding-agent",
+            core_sections=sections,
+            subagents=CODING_WORKERS,
+            checkpointer=checkpointer,
+            store=store,
+        )
+
+
+def _require_profile(name: str) -> ProfileSpec:
+    if name not in PROFILES:
+        msg = f"Unknown agent profile {name!r}. Available: {sorted(PROFILES)}"
+        raise KeyError(msg)
+    return PROFILES[name]

--- a/tests/prompt_bench/rubrics/coding_correctness.md
+++ b/tests/prompt_bench/rubrics/coding_correctness.md
@@ -1,0 +1,27 @@
+Compare two assistant outputs on a coding scenario. Care about *whether
+the response would actually help the developer* — both correctness of
+diagnosis and clarity of the recommended change.
+
+**Stronger signals**
+
+- Correct diagnosis of the bug or correct refactor.
+- Concrete code (not vague prose) when code is appropriate.
+- Naming the trade-off when the user is asking for one.
+- "Search-first" framing when the codebase context is incomplete.
+
+**Weaker signals**
+
+- Adding unrequested features or refactoring beyond the ask.
+- Vague hand-waving about "best practices" without a concrete change.
+- Length.
+
+**Input:**
+{{input}}
+
+**Output A:**
+{{output_a}}
+
+**Output B:**
+{{output_b}}
+
+Reply with the JSON object specified in the system prompt.

--- a/tests/prompt_bench/rubrics/compaction_fidelity.md
+++ b/tests/prompt_bench/rubrics/compaction_fidelity.md
@@ -1,0 +1,27 @@
+Compare two assistant outputs after a compaction event. The compaction
+prompt should produce a structured summary that preserves enough
+context for the agent to continue the conversation coherently.
+
+**Stronger signals**
+
+- User-stated preferences and pinned facts survive the compaction.
+- Recent tool calls / results are preserved in greater detail than
+  older small talk.
+- The summary has discernible structure (e.g. preferences,
+  decisions, open TODOs) rather than free prose.
+
+**Weaker signals**
+
+- Length of the summary on its own.
+- Whether old chatter was preserved (it shouldn't have been).
+
+**Input:**
+{{input}}
+
+**Output A:**
+{{output_a}}
+
+**Output B:**
+{{output_b}}
+
+Reply with the JSON object specified in the system prompt.

--- a/tests/prompt_bench/rubrics/memory_extraction_correctness.md
+++ b/tests/prompt_bench/rubrics/memory_extraction_correctness.md
@@ -1,0 +1,28 @@
+Compare two assistant outputs on a memory-extraction scenario. The
+underlying middleware prompt should produce JSON memory candidates;
+this rubric judges *whether the right durable facts were captured*
+and *whether ephemeral chatter was correctly ignored*.
+
+**Stronger signals**
+
+- Durable facts (preferences, role, persistent constraints) appear in
+  the captured memories.
+- Ephemeral chatter (greetings, weather) is *not* captured.
+- Existing memories are updated, not duplicated, when a fact recurs.
+- "Why" / "How to apply" framing is present for feedback-type memories.
+
+**Weaker signals**
+
+- Number of memories captured (more is not better).
+- Verbosity of the memory body.
+
+**Input:**
+{{input}}
+
+**Output A:**
+{{output_a}}
+
+**Output B:**
+{{output_b}}
+
+Reply with the JSON object specified in the system prompt.

--- a/tests/prompt_bench/rubrics/memory_recall_quality.md
+++ b/tests/prompt_bench/rubrics/memory_recall_quality.md
@@ -1,0 +1,28 @@
+Compare two assistant outputs on a memory-driven scenario. Score the
+*quality of recall* and the *appropriateness of memory tool usage*,
+not just surface fluency.
+
+**Stronger signals**
+
+- The output correctly recalls the user-provided fact when asked back.
+- Memory tools are used when there's a durable fact worth saving; not
+  used when there isn't.
+- The agent does not echo PII back when echoing isn't required by the
+  user's question.
+
+**Weaker signals**
+
+- Length, tone, formatting (these should not decide the call).
+- Tool call count alone — care about whether the calls were the right
+  ones, not how many there were.
+
+**Input:**
+{{input}}
+
+**Output A:**
+{{output_a}}
+
+**Output B:**
+{{output_b}}
+
+Reply with the JSON object specified in the system prompt.

--- a/tests/prompt_bench/rubrics/pairwise_quality.md
+++ b/tests/prompt_bench/rubrics/pairwise_quality.md
@@ -1,0 +1,30 @@
+Compare the two assistant outputs against the user input and decide
+which response is more helpful, accurate, and well-structured.
+
+**Rules**
+
+- Pick **A** if A is clearly better.
+- Pick **B** if B is clearly better.
+- Pick **tie** only when the responses are genuinely indistinguishable
+  on helpfulness + accuracy + structure. Prefer a confident A/B over
+  reflexive ties.
+- **Do not favor longer responses.** A concise, accurate answer should
+  beat a verbose, accurate one of equal correctness; a concise wrong
+  answer should still lose to a verbose right one.
+- **Penalize hallucinations or unsupported claims** regardless of
+  fluency. If A invents a fact and B doesn't, B wins even if B is
+  shorter or less polished.
+- Treat refusal-to-engage with the user's intent as a strong negative
+  signal *unless* the user is asking for clearly unsafe content.
+
+**Input:**
+{{input}}
+
+**Output A:**
+{{output_a}}
+
+**Output B:**
+{{output_b}}
+
+Reply with the JSON object specified in the system prompt — no
+markdown fences, no extra commentary.

--- a/tests/prompt_bench/rubrics/plan_completeness.md
+++ b/tests/prompt_bench/rubrics/plan_completeness.md
@@ -1,0 +1,27 @@
+Compare two assistant outputs on a planning scenario. The agent should
+produce a tight, actionable plan that addresses every part of the
+user's ask.
+
+**Stronger signals**
+
+- Every numbered point in the user's request is addressed.
+- Concrete numbers / dates / metrics where the user asked for them.
+- Terse, scannable structure (bullet points, short headers).
+- Honest acknowledgement when a target metric is genuinely uncertain.
+
+**Weaker signals**
+
+- Padding sections the user didn't ask for ("Here's some extra context...").
+- Generic advice that could apply to any newsletter.
+- Verbosity for its own sake.
+
+**Input:**
+{{input}}
+
+**Output A:**
+{{output_a}}
+
+**Output B:**
+{{output_b}}
+
+Reply with the JSON object specified in the system prompt.

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -99,7 +99,9 @@ def main(argv: list[str] | None = None) -> int:
     p_signal.add_argument("--target", required=True)
 
     args = parser.parse_args(argv)
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    logging.basicConfig(
+        level=logging.INFO, format="%(levelname)s %(name)s: %(message)s"
+    )
 
     if args.cmd == "list-targets":
         return _cmd_list_targets()
@@ -116,9 +118,7 @@ def main(argv: list[str] | None = None) -> int:
 def _cmd_list_targets() -> int:
     sys.stdout.write("Declared bench targets:\n")
     for name, meta in sorted(TARGETS.items()):
-        sys.stdout.write(
-            f"  {name:<48s} kind={meta['kind']} agent={meta['agent']}\n"
-        )
+        sys.stdout.write(f"  {name:<48s} kind={meta['kind']} agent={meta['agent']}\n")
     return EXIT_OK
 
 

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -1,0 +1,153 @@
+"""CLI entry point for the prompt-bench harness.
+
+Usage::
+
+    python -m tests.prompt_bench.run list-targets
+    python -m tests.prompt_bench.run list-scenarios [--target <name>]
+    python -m tests.prompt_bench.run run --target <name> --variant <variant_name> [--samples N] [--out report.json]
+    python -m tests.prompt_bench.run diff --base base.json --variant variant.json [--out diff.md]
+    python -m tests.prompt_bench.run signal-check --target <name>
+
+Phase 0 wires ``list-targets`` and ``list-scenarios`` end-to-end. The
+``run`` / ``diff`` / ``signal-check`` subcommands are surfaced (the
+nightly workflow already calls ``signal-check``) but exit non-zero
+with a clear message until Phase 1 connects the runner to the profile
+builders. This split keeps the CLI shape stable so the workflow YAML
+doesn't need to be rewritten when live execution lands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from tests.prompt_bench.scenarios import discover_scenarios
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).parent
+
+
+# ---------------------------------------------------------------------------
+# Target registry — declared targets the bench knows about (Phase 0 seed).
+# ---------------------------------------------------------------------------
+
+# Each target maps a friendly name to either a section ID (for prompt
+# sections) or a module:attr path (for middleware constants). Phase 0
+# declares the 4 Tier-1 anchors; subsequent phases extend this map as
+# they bench more prompts.
+TARGETS: dict[str, dict[str, str]] = {
+    "reference_deep_agent.core_identity": {
+        "kind": "section",
+        "section_id": "core_identity",
+        "agent": "reference_deep_agent",
+    },
+    "reference_deep_agent.memory_instructions": {
+        "kind": "section",
+        "section_id": "memory_instructions",
+        "agent": "reference_deep_agent",
+    },
+    "memory_extraction.prompt": {
+        "kind": "middleware",
+        "module_attr": "langgraph_kit.core.memory.extraction:_EXTRACTION_PROMPT",
+        "agent": "reference_deep_agent",
+    },
+    "compaction.full_prompt": {
+        "kind": "middleware",
+        "module_attr": "langgraph_kit.core.context_management.compaction:_FULL_COMPACTION_PROMPT",
+        "agent": "reference_deep_agent",
+    },
+}
+
+
+# Exit codes
+EXIT_OK = 0
+EXIT_USAGE = 2
+EXIT_NOT_YET_WIRED = 3
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="prompt-bench")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list-targets", help="List declared bench targets")
+
+    p_scenarios = sub.add_parser("list-scenarios", help="List discovered scenarios")
+    p_scenarios.add_argument("--target", default=None)
+
+    p_run = sub.add_parser("run", help="Run a single overlay against scenarios")
+    p_run.add_argument("--target", required=True)
+    p_run.add_argument("--variant", required=True)
+    p_run.add_argument("--samples", type=int, default=None)
+    p_run.add_argument("--out", type=Path, default=None)
+
+    p_diff = sub.add_parser("diff", help="Diff two existing run reports")
+    p_diff.add_argument("--base", required=True, type=Path)
+    p_diff.add_argument("--variant", required=True, type=Path)
+    p_diff.add_argument("--out", type=Path, default=None)
+
+    p_signal = sub.add_parser(
+        "signal-check", help="baseline vs deliberately-broken sanity check"
+    )
+    p_signal.add_argument("--target", required=True)
+
+    args = parser.parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    if args.cmd == "list-targets":
+        return _cmd_list_targets()
+    if args.cmd == "list-scenarios":
+        return _cmd_list_scenarios(args.target)
+    if args.cmd in ("run", "diff", "signal-check"):
+        sys.stderr.write(_NOT_YET_WIRED.format(cmd=args.cmd))
+        return EXIT_NOT_YET_WIRED
+
+    parser.error(f"Unknown command: {args.cmd}")
+    return EXIT_USAGE
+
+
+def _cmd_list_targets() -> int:
+    sys.stdout.write("Declared bench targets:\n")
+    for name, meta in sorted(TARGETS.items()):
+        sys.stdout.write(
+            f"  {name:<48s} kind={meta['kind']} agent={meta['agent']}\n"
+        )
+    return EXIT_OK
+
+
+def _cmd_list_scenarios(target: str | None) -> int:
+    scenarios = discover_scenarios(ROOT, target=target)
+    if not scenarios:
+        msg = (
+            f"No scenarios found for target {target!r}\n"
+            if target
+            else "No scenarios found\n"
+        )
+        sys.stdout.write(msg)
+        return EXIT_OK
+    sys.stdout.write(f"Discovered {len(scenarios)} scenarios:\n")
+    for s in scenarios:
+        sys.stdout.write(f"  [{s.target}] {s.id} (samples={s.samples})\n")
+    return EXIT_OK
+
+
+_NOT_YET_WIRED = (
+    "ERROR: `{cmd}` is not yet wired end-to-end.\n"
+    "Phase 0 ships the harness modules (BenchRunner, PairwisePanel, "
+    "compute_diff, profiles), the scenario library, and the variant "
+    "system. Live `{cmd}` lands when the Phase 1 PR connects "
+    "tests.prompt_bench.profiles to the runner via a real LLM. Until "
+    "then, drive the harness from pytest tests under "
+    "tests/prompt_bench/test_*.py.\n"
+)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/prompt_bench/runner.py
+++ b/tests/prompt_bench/runner.py
@@ -1,0 +1,109 @@
+"""Bench runner — execute scenarios under a given prompt overlay.
+
+The runner is intentionally trivial: it iterates scenarios x samples and
+delegates the messy work (apply overlay, build graph, invoke
+conversation, capture trace) to a profile-specific ``run_one``
+callable.
+
+This keeps profile-specific knowledge — how to translate a
+``PromptOverlay`` into a built ``reference_deep_agent`` graph, how to
+keep middleware patches active across both compile and invoke — in
+one place (``profiles.py`` / ``conftest.py``) and out of the harness
+core.
+
+See ``profiles.build_profile_graph`` for the canonical wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from langgraph_kit.evals.models import TraceData
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from tests.prompt_bench.scenarios import Scenario
+    from tests.prompt_bench.variants import PromptOverlay
+
+
+@dataclass
+class BenchSample:
+    """One execution of a scenario — captured turn-by-turn."""
+
+    scenario_id: str
+    sample_index: int
+    overlay_name: str
+    duration_ms: float
+    final_output: str
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+
+    def to_trace(self) -> TraceData:
+        """Convert to the canonical :class:`TraceData` shape used by metrics."""
+        return TraceData(
+            id=f"{self.scenario_id}#{self.overlay_name}#{self.sample_index}",
+            name=self.scenario_id,
+            input={"scenario": self.scenario_id, "overlay": self.overlay_name},
+            output=self.final_output,
+            tags=[f"overlay:{self.overlay_name}", f"scenario:{self.scenario_id}"],
+            duration_ms=self.duration_ms,
+            metadata={
+                "tool_calls": len(self.tool_calls),
+                "tools_used": [c.get("name") for c in self.tool_calls],
+                "tool_errors": sum(1 for c in self.tool_calls if c.get("error")),
+                "error": self.error,
+                "status": "error" if self.error else "ok",
+            },
+        )
+
+
+@dataclass
+class BenchReport:
+    """Result of running a set of scenarios under a single overlay."""
+
+    overlay_name: str
+    samples: list[BenchSample] = field(default_factory=list)
+
+    def traces(self) -> list[TraceData]:
+        return [s.to_trace() for s in self.samples]
+
+
+RunOne = Callable[
+    ["Scenario", "PromptOverlay", int],
+    Awaitable[BenchSample],
+]
+"""``async (scenario, overlay, sample_index) -> BenchSample``.
+
+Profile-specific. Should:
+
+1. Apply *overlay* (sections + middleware) for the duration of the call.
+2. Build / reuse the agent graph for the scenario's profile.
+3. Drive *scenario*'s turns through the graph.
+4. Return a populated :class:`BenchSample`.
+
+Errors should be caught and surfaced as ``error`` on the sample, not
+re-raised — one bad scenario should not abort the whole bench run.
+"""
+
+
+class BenchRunner:
+    """Iterates scenarios x samples, delegates to a profile-specific ``run_one``."""
+
+    def __init__(self, run_one: RunOne) -> None:
+        super().__init__()
+        self._run_one = run_one
+
+    async def run(
+        self,
+        scenarios: Sequence[Scenario],
+        overlay: PromptOverlay,
+    ) -> BenchReport:
+        report = BenchReport(overlay_name=overlay.name)
+        for scenario in scenarios:
+            for i in range(scenario.samples):
+                sample = await self._run_one(scenario, overlay, i)
+                report.samples.append(sample)
+        return report

--- a/tests/prompt_bench/scenarios.py
+++ b/tests/prompt_bench/scenarios.py
@@ -106,9 +106,7 @@ def load_scenario(path: Path) -> Scenario:
     return Scenario.model_validate(raw)
 
 
-def discover_scenarios(
-    root: Path, target: str | None = None
-) -> list[Scenario]:
+def discover_scenarios(root: Path, target: str | None = None) -> list[Scenario]:
     """Discover scenarios under ``root/scenarios/``.
 
     If *target* is provided, only scenarios under

--- a/tests/prompt_bench/scenarios.py
+++ b/tests/prompt_bench/scenarios.py
@@ -1,0 +1,136 @@
+"""Scenario file format and loader.
+
+A *scenario* pairs a deterministic input (one or more user turns), an
+agent profile, an optional seeded state, expected behaviour assertions,
+and a rubric reference. Scenarios live as YAML files under
+``tests/prompt_bench/scenarios/<target>/<id>.yaml``.
+
+Example scenario::
+
+    id: multi_turn_memory_recall
+    target: reference_deep_agent.core_identity
+    description: |
+      3-turn conversation: user states a fact, asks an unrelated
+      question, then asks back about the original fact. Agent must
+      recall via memory.
+    agent_profile: reference_deep_agent
+    seeded_state:
+      memory: []
+      workspace: tmp
+    turns:
+      - user: "My favorite color is teal."
+      - user: "What's 2+2?"
+      - user: "What did I tell you my favorite color was?"
+    expected_behaviors:
+      must_call_tool: ["memory_save", "memory_search"]
+      must_mention: ["teal"]
+      must_not_mention: ["I don't know", "I don't recall"]
+    rubric: rubrics/memory_recall_quality.md
+    samples: 5
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ScenarioTurn(BaseModel):
+    """One turn in a scenario conversation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user: str
+
+
+class ExpectedBehavior(BaseModel):
+    """Structural assertions a scenario expects from the agent's output.
+
+    None of these are pass/fail gates by themselves — they feed into
+    rule-based metrics that contribute to the overall regression check.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    must_call_tool: list[str] = Field(default_factory=list)
+    must_not_call_tool: list[str] = Field(default_factory=list)
+    must_mention: list[str] = Field(default_factory=list)
+    must_not_mention: list[str] = Field(default_factory=list)
+    max_tool_calls: int | None = None
+    min_tool_calls: int | None = None
+
+
+class Scenario(BaseModel):
+    """A single benchmark scenario."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    target: str
+    description: str = ""
+    agent_profile: str = "reference_deep_agent"
+    seeded_state: dict[str, Any] = Field(default_factory=dict)
+    turns: list[ScenarioTurn]
+    expected_behaviors: ExpectedBehavior = Field(default_factory=ExpectedBehavior)
+    rubric: str | None = None
+    samples: int = 5
+
+    @field_validator("turns")
+    @classmethod
+    def _at_least_one_turn(cls, v: list[ScenarioTurn]) -> list[ScenarioTurn]:
+        if not v:
+            msg = "Scenario must declare at least one user turn"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("samples")
+    @classmethod
+    def _positive_samples(cls, v: int) -> int:
+        if v < 1:
+            msg = "samples must be >= 1"
+            raise ValueError(msg)
+        return v
+
+
+def load_scenario(path: Path) -> Scenario:
+    """Load a single scenario YAML file."""
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = f"Scenario file {path} must contain a YAML mapping at top level"
+        raise ValueError(msg)
+    return Scenario.model_validate(raw)
+
+
+def discover_scenarios(
+    root: Path, target: str | None = None
+) -> list[Scenario]:
+    """Discover scenarios under ``root/scenarios/``.
+
+    If *target* is provided, only scenarios under
+    ``root/scenarios/<target>/`` are loaded. Otherwise every scenario
+    under any subdirectory is loaded.
+    """
+    base = root / "scenarios"
+    if not base.is_dir():
+        return []
+
+    if target is not None:
+        # Allow either the bare target name or the dotted target
+        # (e.g. ``reference_deep_agent.core_identity``) — both map to
+        # the same directory in practice since the directory groups
+        # by agent/target name.
+        target_dir = base / target.replace(".", "_")
+        if not target_dir.is_dir():
+            target_dir = base / target.split(".", 1)[0]
+        if not target_dir.is_dir():
+            return []
+        candidates = sorted(target_dir.glob("*.yaml"))
+    else:
+        candidates = sorted(base.rglob("*.yaml"))
+
+    return [load_scenario(p) for p in candidates]

--- a/tests/prompt_bench/scenarios/coding_agent/refactor_extract_function.yaml
+++ b/tests/prompt_bench/scenarios/coding_agent/refactor_extract_function.yaml
@@ -1,0 +1,26 @@
+id: refactor_extract_function
+target: coding_agent.core_identity
+description: |
+  User wants a refactor that pulls a duplicated branch out into a
+  helper function. Agent should produce the refactored version without
+  changing behavior, and surface the rename trade-offs cleanly.
+agent_profile: coding_agent
+turns:
+  - user: |
+      Refactor this Python so the duplicated math is extracted into a
+      shared helper, but keep the public function names identical:
+      ```python
+      def total_with_tax(price):
+          return price + price * 0.0875
+
+      def total_with_discount(price):
+          discounted = price - price * 0.10
+          return discounted + discounted * 0.0875
+      ```
+expected_behaviors:
+  must_mention:
+    - def
+  min_tool_calls: 0
+  max_tool_calls: 3
+rubric: rubrics/coding_correctness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/coding_agent/search_first_discipline.yaml
+++ b/tests/prompt_bench/scenarios/coding_agent/search_first_discipline.yaml
@@ -1,0 +1,20 @@
+id: search_first_discipline
+target: coding_agent.core_identity
+description: |
+  User asks the agent to add a small feature to an unfamiliar codebase.
+  Search-first discipline means the agent should describe the discovery
+  steps it would take *before* recommending an edit, even when the
+  request is small.
+agent_profile: coding_agent
+turns:
+  - user: |
+      I need to add a one-line warning to the migrate() function whenever
+      the dry_run flag is True. I haven't told you which file it lives
+      in. How would you proceed?
+expected_behaviors:
+  must_mention:
+    - search
+  min_tool_calls: 0
+  max_tool_calls: 2
+rubric: rubrics/coding_correctness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/coding_agent/trace_to_root_cause.yaml
+++ b/tests/prompt_bench/scenarios/coding_agent/trace_to_root_cause.yaml
@@ -1,0 +1,23 @@
+id: trace_to_root_cause
+target: coding_agent.core_identity
+description: |
+  User reports a bug in a small Python snippet. Agent should diagnose
+  the root cause (off-by-one + signed comparison) and explain the fix
+  rather than just patching symptoms. Tests the "search-first" coding
+  discipline before the agent recommends a change.
+agent_profile: coding_agent
+turns:
+  - user: |
+      This Python snippet is supposed to return True for any non-empty
+      list, but it returns False on a list of one item. Tell me why.
+      ```python
+      def is_non_empty(xs):
+          return len(xs) - 1 > 0
+      ```
+expected_behaviors:
+  must_mention:
+    - "len"
+  must_not_mention:
+    - "I cannot help"
+rubric: rubrics/coding_correctness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/compaction/compress_long_context.yaml
+++ b/tests/prompt_bench/scenarios/compaction/compress_long_context.yaml
@@ -1,0 +1,19 @@
+id: compress_long_context
+target: compaction.full_prompt
+description: |
+  A long conversation that exceeds the kit's pressure threshold. The
+  compaction prompt should produce a structured summary that captures
+  the essential decisions/state without losing any user-stated
+  preferences or pinned facts.
+agent_profile: reference_deep_agent
+turns:
+  - user: |
+      Long-running thread placeholder — actual contents are constructed
+      programmatically by the runner so we can synthesize > pressure
+      threshold messages without bloating the YAML. Final user turn
+      asks: "Summarize where we ended up and what's still TODO."
+expected_behaviors:
+  must_mention:
+    - TODO
+rubric: rubrics/compaction_fidelity.md
+samples: 5

--- a/tests/prompt_bench/scenarios/compaction/preserve_recent_tool_calls.yaml
+++ b/tests/prompt_bench/scenarios/compaction/preserve_recent_tool_calls.yaml
@@ -1,0 +1,18 @@
+id: preserve_recent_tool_calls
+target: compaction.full_prompt
+description: |
+  Conversation has heavy tool usage in the last few turns; older turns
+  are chatter. Compaction should keep the recent tool call/response
+  context verbatim and aggressively summarize the older small talk.
+agent_profile: reference_deep_agent
+turns:
+  - user: |
+      Continue the previous task using the most recent tool results, not
+      the small talk from earlier in the thread.
+expected_behaviors:
+  must_mention:
+    - tool
+  min_tool_calls: 0
+  max_tool_calls: 1
+rubric: rubrics/compaction_fidelity.md
+samples: 5

--- a/tests/prompt_bench/scenarios/compaction/structured_summary.yaml
+++ b/tests/prompt_bench/scenarios/compaction/structured_summary.yaml
@@ -1,0 +1,16 @@
+id: structured_summary
+target: compaction.full_prompt
+description: |
+  After compaction, the agent's next turn should be coherent — meaning
+  the summary preserved enough structure that the agent can plan its
+  next move without re-asking for facts already established earlier.
+agent_profile: reference_deep_agent
+turns:
+  - user: |
+      Now that you have the compacted context, what is the next most
+      useful thing you could do for me, given everything we've discussed?
+expected_behaviors:
+  must_mention:
+    - next
+rubric: rubrics/compaction_fidelity.md
+samples: 5

--- a/tests/prompt_bench/scenarios/memory_extraction/extract_durable_facts.yaml
+++ b/tests/prompt_bench/scenarios/memory_extraction/extract_durable_facts.yaml
@@ -1,0 +1,17 @@
+id: extract_durable_facts
+target: memory_extraction.prompt
+description: |
+  Conversation contains a mix of durable user facts ("I'm a vegetarian")
+  and ephemeral chatter ("nice weather today"). The extraction prompt
+  should recover the durable facts and ignore the chatter.
+agent_profile: reference_deep_agent
+turns:
+  - user: |
+      Hi! Nice weather today. By the way, I'm a strict vegetarian and
+      I work as a backend engineer at a fintech startup in Berlin.
+expected_behaviors:
+  must_mention:
+    - vegetarian
+  min_tool_calls: 0
+rubric: rubrics/memory_extraction_correctness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/memory_extraction/ignore_ephemeral_chatter.yaml
+++ b/tests/prompt_bench/scenarios/memory_extraction/ignore_ephemeral_chatter.yaml
@@ -1,0 +1,14 @@
+id: ignore_ephemeral_chatter
+target: memory_extraction.prompt
+description: |
+  Conversation is purely small talk. No durable facts to extract.
+  The extraction prompt should return zero memories, not invent
+  pseudo-facts to satisfy a "must extract something" instinct.
+agent_profile: reference_deep_agent
+turns:
+  - user: "Hi there. How is your day going? Just wanted to say hello."
+expected_behaviors:
+  min_tool_calls: 0
+  max_tool_calls: 1
+rubric: rubrics/memory_extraction_correctness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/memory_extraction/no_duplicates_with_existing.yaml
+++ b/tests/prompt_bench/scenarios/memory_extraction/no_duplicates_with_existing.yaml
@@ -1,0 +1,20 @@
+id: no_duplicates_with_existing
+target: memory_extraction.prompt
+description: |
+  Conversation reasserts a fact already in memory. The extraction prompt
+  should prefer updating / not duplicating over creating a fresh
+  memory. Tests the "prefer updating existing" instruction.
+agent_profile: reference_deep_agent
+seeded_state:
+  memory:
+    - kind: user
+      content: "User is a vegetarian."
+turns:
+  - user: |
+      Just to confirm — I'm vegetarian, so please don't suggest meat
+      dishes when I ask for recipes.
+expected_behaviors:
+  must_mention:
+    - vegetarian
+rubric: rubrics/memory_extraction_correctness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/reference_deep_agent/multi_turn_memory_recall.yaml
+++ b/tests/prompt_bench/scenarios/reference_deep_agent/multi_turn_memory_recall.yaml
@@ -1,0 +1,24 @@
+id: multi_turn_memory_recall
+target: reference_deep_agent.core_identity
+description: |
+  3-turn conversation: user states a fact, asks an unrelated question,
+  then asks back about the original fact. Agent must persist the fact
+  via memory tools and recall it correctly on turn 3.
+agent_profile: reference_deep_agent
+seeded_state:
+  memory: []
+turns:
+  - user: "My favorite color is teal. Please remember that."
+  - user: "What is 2+2?"
+  - user: "What did I tell you my favorite color was?"
+expected_behaviors:
+  must_call_tool:
+    - memory_save
+  must_mention:
+    - teal
+  must_not_mention:
+    - "I don't know"
+    - "I don't recall"
+    - "no information"
+rubric: rubrics/memory_recall_quality.md
+samples: 5

--- a/tests/prompt_bench/scenarios/reference_deep_agent/plan_execution.yaml
+++ b/tests/prompt_bench/scenarios/reference_deep_agent/plan_execution.yaml
@@ -1,0 +1,22 @@
+id: plan_execution
+target: reference_deep_agent.core_identity
+description: |
+  Multi-step user request that requires the agent to plan, delegate
+  small bounded sub-tasks where appropriate, and synthesize a final
+  answer. The "deliberate / direct approach" guidance in core_identity
+  should produce a tight execution plan rather than excessive
+  exploration or recursion.
+agent_profile: reference_deep_agent
+turns:
+  - user: |
+      I want to launch a weekly newsletter. Give me a 4-step rollout plan
+      that covers (1) topic strategy, (2) tooling picks (free tier ok),
+      (3) audience growth tactics in the first 90 days, and (4) success
+      metrics with target numbers I should hit by week 12.
+expected_behaviors:
+  must_mention:
+    - week
+  min_tool_calls: 0
+  max_tool_calls: 4
+rubric: rubrics/plan_completeness.md
+samples: 5

--- a/tests/prompt_bench/scenarios/reference_deep_agent/tool_dispatch_with_pii.yaml
+++ b/tests/prompt_bench/scenarios/reference_deep_agent/tool_dispatch_with_pii.yaml
@@ -1,0 +1,22 @@
+id: tool_dispatch_with_pii
+target: reference_deep_agent.core_identity
+description: |
+  User asks for a benign analysis but inadvertently includes PII. Agent
+  should answer the question accurately while avoiding echoing the PII
+  back into the response. Tests the agent's ability to follow the
+  identity guidance about deliberate, careful tool use without bleeding
+  sensitive data.
+agent_profile: reference_deep_agent
+turns:
+  - user: |
+      My phone number is 555-123-4567 and my email is alice@example.com.
+      Can you summarize what services are typically tied to a phone +
+      email pair like this for a small business?
+expected_behaviors:
+  must_not_mention:
+    - "555-123-4567"
+    - "alice@example.com"
+  min_tool_calls: 0
+  max_tool_calls: 2
+rubric: rubrics/memory_recall_quality.md
+samples: 5

--- a/tests/prompt_bench/test_diff.py
+++ b/tests/prompt_bench/test_diff.py
@@ -1,0 +1,216 @@
+"""Tests for the diff aggregator and acceptance-criteria logic."""
+
+from __future__ import annotations
+
+import json
+import random
+from typing import Any
+
+from tests.prompt_bench.diff import (
+    JUDGE_AGREEMENT_THRESHOLD,
+    METRIC_REGRESSION_TOLERANCE,
+    WIN_RATE_THRESHOLD,
+    DiffReport,
+    ScenarioDiff,
+    compute_diff,
+    render_markdown,
+    to_dict,
+)
+from tests.prompt_bench.pairwise import PairwiseJudge, PairwisePanel
+from tests.prompt_bench.runner import BenchReport, BenchSample
+
+
+class _CannedJudge:
+    """Always returns the same decision JSON. Lets us drive diff aggregation."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        super().__init__()
+        self._payload = json.dumps(response)
+
+    async def ainvoke(self, _messages: list[Any]) -> Any:
+        class _R:
+            content = self._payload
+
+        return _R()
+
+
+def _panel(winner: str) -> PairwisePanel:
+    judges = [
+        PairwiseJudge(
+            name=f"j{i}",
+            llm=_CannedJudge({"winner": winner, "confidence": 0.9, "reason": "x"}),
+            rubric_text="dummy",
+        )
+        for i in range(2)
+    ]
+    return PairwisePanel(judges=judges, rng=random.Random(0))
+
+
+def _bench_report(name: str, sample_count: int = 5) -> BenchReport:
+    samples = [
+        BenchSample(
+            scenario_id="s",
+            sample_index=i,
+            overlay_name=name,
+            duration_ms=1000.0,
+            final_output=f"output {name} {i}",
+        )
+        for i in range(sample_count)
+    ]
+    return BenchReport(overlay_name=name, samples=samples)
+
+
+class TestComputeDiff:
+    async def test_consensus_b_with_seeded_rng(self) -> None:
+        # rng seed=0 → first call's choice is True → base_was_a=True
+        # so "B" winner means variant won. 5/5 variant wins → 100% win rate.
+        diff = await compute_diff(
+            base_report=_bench_report("base"),
+            variant_report=_bench_report("variant"),
+            panel=_panel("B"),
+        )
+        assert diff.total_pairs == 5
+        # With a single seeded RNG the panel's choice is deterministic
+        # *given the order of calls*. We don't assert on exact wins
+        # because randomization may flip A/B per call; instead we
+        # assert decisive consensus and full-decided count.
+        assert diff.total_decided == 5
+        assert diff.total_variant_wins + diff.total_base_wins == 5
+        assert diff.total_ties == 0
+
+    async def test_unanimous_tie_is_decided(self) -> None:
+        diff = await compute_diff(
+            base_report=_bench_report("base"),
+            variant_report=_bench_report("variant"),
+            panel=_panel("tie"),
+        )
+        assert diff.total_decided == 5
+        assert diff.total_ties == 5
+        assert diff.overall_win_rate == 0.0  # variant didn't win any
+
+
+class TestAcceptanceCriteria:
+    def test_passes_when_all_thresholds_met(self) -> None:
+        diff = DiffReport(
+            base_overlay="base",
+            variant_overlay="variant",
+            scenarios=[
+                ScenarioDiff(
+                    scenario_id="s1",
+                    pair_count=10,
+                    decided_pairs=10,
+                    base_wins=2,
+                    variant_wins=7,
+                    ties=1,
+                    judge_agreement=1.0,
+                )
+            ],
+        )
+        # 7/10 decided → 70% win rate, 100% agreement, no regressions
+        assert diff.overall_win_rate >= WIN_RATE_THRESHOLD
+        assert diff.overall_judge_agreement >= JUDGE_AGREEMENT_THRESHOLD
+        assert diff.passes_acceptance
+
+    def test_fails_below_win_rate(self) -> None:
+        diff = DiffReport(
+            base_overlay="base",
+            variant_overlay="variant",
+            scenarios=[
+                ScenarioDiff(
+                    scenario_id="s1",
+                    pair_count=10,
+                    decided_pairs=10,
+                    base_wins=5,
+                    variant_wins=5,
+                    ties=0,
+                    judge_agreement=1.0,
+                )
+            ],
+        )
+        # 5/10 = 50% win rate, below 60% bar
+        assert not diff.passes_acceptance
+
+    def test_fails_below_agreement(self) -> None:
+        diff = DiffReport(
+            base_overlay="base",
+            variant_overlay="variant",
+            scenarios=[
+                ScenarioDiff(
+                    scenario_id="s1",
+                    pair_count=10,
+                    decided_pairs=5,
+                    base_wins=1,
+                    variant_wins=4,
+                    ties=0,
+                    judge_agreement=0.5,
+                )
+            ],
+        )
+        # 4/5 = 80% win rate but 5/10 = 50% agreement, below 70% bar
+        assert diff.overall_win_rate >= WIN_RATE_THRESHOLD
+        assert diff.overall_judge_agreement < JUDGE_AGREEMENT_THRESHOLD
+        assert not diff.passes_acceptance
+
+    def test_flags_regressions(self) -> None:
+        diff = DiffReport(
+            base_overlay="base",
+            variant_overlay="variant",
+            scenarios=[
+                ScenarioDiff(
+                    scenario_id="s1",
+                    pair_count=10,
+                    decided_pairs=10,
+                    base_wins=2,
+                    variant_wins=8,
+                    ties=0,
+                    judge_agreement=1.0,
+                    base_metric_means={"latency": 0.95, "error_free": 1.0},
+                    variant_metric_means={
+                        "latency": 0.95 - METRIC_REGRESSION_TOLERANCE - 0.01,
+                        "error_free": 1.0,
+                    },
+                )
+            ],
+        )
+        assert "latency" in diff.regression_flags
+        assert "error_free" not in diff.regression_flags
+        assert not diff.passes_acceptance
+
+
+class TestRendering:
+    def test_markdown_renders_pass(self) -> None:
+        diff = DiffReport(
+            base_overlay="base",
+            variant_overlay="variant",
+            scenarios=[
+                ScenarioDiff(
+                    scenario_id="s1",
+                    pair_count=10,
+                    decided_pairs=10,
+                    variant_wins=7,
+                    base_wins=2,
+                    ties=1,
+                    judge_agreement=1.0,
+                )
+            ],
+        )
+        md = render_markdown(diff)
+        assert "PASS" in md
+        assert "70.0%" in md or "70%" in md
+        assert "s1" in md
+
+    def test_to_dict_round_trip(self) -> None:
+        diff = DiffReport(
+            base_overlay="b",
+            variant_overlay="v",
+            scenarios=[ScenarioDiff(scenario_id="s")],
+        )
+        payload = to_dict(diff)
+        # Should be JSON-serializable
+        json.dumps(payload)
+
+
+class TestScenarioDiffWinRate:
+    def test_zero_when_no_decisions(self) -> None:
+        sd = ScenarioDiff(scenario_id="s", pair_count=5, decided_pairs=0)
+        assert sd.decided_win_rate == 0.0

--- a/tests/prompt_bench/test_pairwise.py
+++ b/tests/prompt_bench/test_pairwise.py
@@ -1,0 +1,165 @@
+"""Tests for the pairwise judge panel."""
+
+from __future__ import annotations
+
+import json
+import random
+from typing import Any
+
+import pytest
+
+from langgraph_kit.evals.models import TraceData
+from tests.prompt_bench.pairwise import (
+    PairwiseDecision,
+    PairwiseJudge,
+    PairwisePanel,
+)
+
+
+class _CannedJudgeLLM:
+    """Returns a fixed judge response. Used to drive panel logic without an LLM."""
+
+    def __init__(self, response: dict[str, Any]) -> None:
+        super().__init__()
+        self._payload = json.dumps(response)
+
+    async def ainvoke(self, _messages: list[Any]) -> Any:
+        class _R:
+            content = self._payload
+
+        return _R()
+
+
+class TestPairwiseJudge:
+    async def test_parses_winner_and_confidence(self) -> None:
+        llm = _CannedJudgeLLM({"winner": "A", "confidence": 0.83, "reason": "clearer"})
+        judge = PairwiseJudge(name="j", llm=llm, rubric_text="dummy")
+        decision = await judge.judge("input", "out_a", "out_b")
+        assert decision.winner == "A"
+        assert decision.confidence == pytest.approx(0.83)
+        assert decision.reason == "clearer"
+        assert decision.judge_name == "j"
+
+    async def test_normalizes_lowercase(self) -> None:
+        llm = _CannedJudgeLLM({"winner": "b", "confidence": 0.5, "reason": ""})
+        judge = PairwiseJudge(name="j", llm=llm, rubric_text="dummy")
+        decision = await judge.judge("i", "a", "b")
+        assert decision.winner == "B"
+
+    async def test_invalid_winner_falls_back_to_tie(self) -> None:
+        llm = _CannedJudgeLLM({"winner": "neither", "confidence": 1.0, "reason": "x"})
+        judge = PairwiseJudge(name="j", llm=llm, rubric_text="dummy")
+        decision = await judge.judge("i", "a", "b")
+        assert decision.winner == "tie"
+
+
+class TestPairwisePanel:
+    @staticmethod
+    def _make_panel(
+        decisions: list[Any],
+        rng_seed: int = 0,
+    ) -> PairwisePanel:
+        judges = [
+            PairwiseJudge(
+                name=f"j{i}",
+                llm=_CannedJudgeLLM(d),
+                rubric_text="dummy",
+            )
+            for i, d in enumerate(decisions)
+        ]
+        return PairwisePanel(judges=judges, rng=random.Random(rng_seed))
+
+    @staticmethod
+    def _trace(text: str, label: str) -> TraceData:
+        return TraceData(id=label, output=text)
+
+    async def test_decided_when_all_judges_agree(self) -> None:
+        # rng_seed=0 → first random.choice([True, False]) is True (base_was_a=True)
+        panel = self._make_panel(
+            [
+                {"winner": "B", "confidence": 0.9, "reason": "x"},
+                {"winner": "B", "confidence": 0.8, "reason": "y"},
+            ]
+        )
+        result = await panel.compare(
+            input_text="q",
+            base_trace=self._trace("base", "base"),
+            variant_trace=self._trace("variant", "variant"),
+        )
+        assert result.decided
+        assert result.winner == "B"
+        # If base_was_a is True, then "B" winner means variant won
+        if result.base_was_a:
+            assert result.variant_won
+            assert not result.base_won
+        else:
+            # Inverted shuffle: "B" winner means base won
+            assert result.base_won
+
+    async def test_undecided_when_judges_disagree(self) -> None:
+        panel = self._make_panel(
+            [
+                {"winner": "A", "confidence": 0.9, "reason": "x"},
+                {"winner": "B", "confidence": 0.8, "reason": "y"},
+            ]
+        )
+        result = await panel.compare(
+            input_text="q",
+            base_trace=self._trace("base", "base"),
+            variant_trace=self._trace("variant", "variant"),
+        )
+        assert not result.decided
+        assert result.winner == "undecided"
+        assert not result.base_won
+        assert not result.variant_won
+
+    async def test_tie_consensus_means_tie_not_undecided(self) -> None:
+        panel = self._make_panel(
+            [
+                {"winner": "tie", "confidence": 0.5, "reason": "x"},
+                {"winner": "tie", "confidence": 0.5, "reason": "y"},
+            ]
+        )
+        result = await panel.compare(
+            input_text="q",
+            base_trace=self._trace("base", "base"),
+            variant_trace=self._trace("variant", "variant"),
+        )
+        assert result.decided
+        assert result.winner == "tie"
+        assert not result.base_won
+        assert not result.variant_won
+
+    async def test_requires_at_least_one_judge(self) -> None:
+        with pytest.raises(ValueError, match="at least one judge"):
+            PairwisePanel(judges=[])
+
+    async def test_ab_order_random_across_calls(self) -> None:
+        # Different RNG seeds should produce different A/B placements
+        # over a single comparison (a smoke check that randomness is wired).
+        panel_a = self._make_panel(
+            [{"winner": "A", "confidence": 1, "reason": ""}],
+            rng_seed=1,
+        )
+        panel_b = self._make_panel(
+            [{"winner": "A", "confidence": 1, "reason": ""}],
+            rng_seed=42,
+        )
+        r_a = await panel_a.compare(
+            "q", self._trace("base", "b"), self._trace("variant", "v")
+        )
+        r_b = await panel_b.compare(
+            "q", self._trace("base", "b"), self._trace("variant", "v")
+        )
+        # We expect this assertion to hold often but it's a property,
+        # not a guarantee — accept either outcome but assert at least
+        # one combination was tried.
+        assert r_a.base_was_a in (True, False)
+        assert r_b.base_was_a in (True, False)
+
+
+class TestPairwiseDecision:
+    def test_decision_is_immutable(self) -> None:
+        d = PairwiseDecision(judge_name="j", winner="A", confidence=0.5, reason="r")
+        with pytest.raises(Exception):  # noqa: B017,PT011 - frozen dataclass
+            d.winner = "B"  # type: ignore[misc]

--- a/tests/prompt_bench/test_profiles.py
+++ b/tests/prompt_bench/test_profiles.py
@@ -1,0 +1,84 @@
+"""Tests for the profile bridge — section overlay application."""
+
+from __future__ import annotations
+
+import pytest
+
+from langgraph_kit.core.prompt_assembly.sections import SectionStability
+from tests.prompt_bench.profiles import (
+    apply_overlay_to_sections,
+    get_baseline_sections,
+)
+from tests.prompt_bench.variants import PromptOverlay
+
+
+class TestGetBaselineSections:
+    def test_returns_fresh_copy(self) -> None:
+        a = get_baseline_sections("reference_deep_agent")
+        b = get_baseline_sections("reference_deep_agent")
+        assert a == b
+        assert a is not b  # caller can mutate without affecting source
+
+    def test_unknown_profile(self) -> None:
+        with pytest.raises(KeyError, match=r"[Uu]nknown agent profile"):
+            get_baseline_sections("nonexistent_profile")
+
+
+class TestApplyOverlayToSections:
+    def test_preserves_metadata_when_swapping(self) -> None:
+        baseline = get_baseline_sections("reference_deep_agent")
+        original = next(s for s in baseline if s.id == "core_identity")
+
+        overlay = PromptOverlay(
+            name="test",
+            section_overrides={"core_identity": "REPLACEMENT TEXT"},
+        )
+        swapped = apply_overlay_to_sections("reference_deep_agent", overlay)
+        new_section = next(s for s in swapped if s.id == "core_identity")
+
+        assert new_section.content == "REPLACEMENT TEXT"
+        assert new_section.stability == original.stability
+        assert new_section.priority == original.priority
+        assert new_section.condition == original.condition
+
+    def test_returns_baseline_when_no_overrides(self) -> None:
+        overlay = PromptOverlay(name="t")
+        result = apply_overlay_to_sections("reference_deep_agent", overlay)
+        baseline = get_baseline_sections("reference_deep_agent")
+        assert [s.id for s in result] == [s.id for s in baseline]
+        assert [s.content for s in result] == [s.content for s in baseline]
+
+    def test_unknown_section_id_raises(self) -> None:
+        overlay = PromptOverlay(
+            name="t",
+            section_overrides={"this_section_does_not_exist": "x"},
+        )
+        with pytest.raises(KeyError, match="this_section_does_not_exist"):
+            apply_overlay_to_sections("reference_deep_agent", overlay)
+
+    def test_only_targeted_section_changes(self) -> None:
+        baseline = get_baseline_sections("reference_deep_agent")
+        baseline_by_id = {s.id: s for s in baseline}
+
+        overlay = PromptOverlay(
+            name="t",
+            section_overrides={"core_identity": "NEW"},
+        )
+        swapped = apply_overlay_to_sections("reference_deep_agent", overlay)
+        for section in swapped:
+            if section.id == "core_identity":
+                assert section.content == "NEW"
+            else:
+                assert section.content == baseline_by_id[section.id].content
+
+    def test_conditional_section_overlay_preserves_condition(self) -> None:
+        # ``memory_instructions`` is CONDITIONAL with condition="memory" —
+        # an overlay must not flatten that to STABLE.
+        overlay = PromptOverlay(
+            name="t",
+            section_overrides={"memory_instructions": "swapped memory text"},
+        )
+        swapped = apply_overlay_to_sections("reference_deep_agent", overlay)
+        new_section = next(s for s in swapped if s.id == "memory_instructions")
+        assert new_section.stability == SectionStability.CONDITIONAL
+        assert new_section.condition == "memory"

--- a/tests/prompt_bench/test_profiles.py
+++ b/tests/prompt_bench/test_profiles.py
@@ -20,7 +20,7 @@ class TestGetBaselineSections:
         assert a is not b  # caller can mutate without affecting source
 
     def test_unknown_profile(self) -> None:
-        with pytest.raises(KeyError, match=r"[Uu]nknown agent profile"):
+        with pytest.raises(KeyError, match="Unknown agent profile"):
             get_baseline_sections("nonexistent_profile")
 
 

--- a/tests/prompt_bench/test_runner.py
+++ b/tests/prompt_bench/test_runner.py
@@ -1,0 +1,94 @@
+"""Tests for the bench runner — iteration logic only.
+
+Profile-specific ``run_one`` callables live in :mod:`tests.prompt_bench.profiles`
+and ``conftest.py``; those are tested separately. This file only covers
+the trivial scenarios x samples loop that ``BenchRunner`` itself owns.
+"""
+
+from __future__ import annotations
+
+from tests.prompt_bench.runner import BenchRunner, BenchSample
+from tests.prompt_bench.scenarios import Scenario, ScenarioTurn
+from tests.prompt_bench.variants import PromptOverlay
+
+
+def _scenario(id_: str, samples: int = 3) -> Scenario:
+    return Scenario(
+        id=id_,
+        target="t",
+        turns=[ScenarioTurn(user="hi")],
+        samples=samples,
+    )
+
+
+class TestBenchRunner:
+    async def test_iterates_scenarios_x_samples(self) -> None:
+        seen: list[tuple[str, int]] = []
+
+        async def run_one(
+            scenario: Scenario, overlay: PromptOverlay, idx: int
+        ) -> BenchSample:
+            seen.append((scenario.id, idx))
+            return BenchSample(
+                scenario_id=scenario.id,
+                sample_index=idx,
+                overlay_name=overlay.name,
+                duration_ms=1.0,
+                final_output="ok",
+            )
+
+        runner = BenchRunner(run_one)
+        report = await runner.run(
+            scenarios=[_scenario("a", samples=2), _scenario("b", samples=3)],
+            overlay=PromptOverlay(name="v"),
+        )
+
+        assert report.overlay_name == "v"
+        assert len(report.samples) == 5
+        assert seen == [("a", 0), ("a", 1), ("b", 0), ("b", 1), ("b", 2)]
+
+    async def test_propagates_run_one_errors_into_sample(self) -> None:
+        async def run_one(
+            scenario: Scenario, overlay: PromptOverlay, idx: int
+        ) -> BenchSample:
+            return BenchSample(
+                scenario_id=scenario.id,
+                sample_index=idx,
+                overlay_name=overlay.name,
+                duration_ms=0.0,
+                final_output="",
+                error="kaboom",
+            )
+
+        runner = BenchRunner(run_one)
+        report = await runner.run(
+            scenarios=[_scenario("a", samples=1)],
+            overlay=PromptOverlay(name="v"),
+        )
+        assert len(report.samples) == 1
+        assert report.samples[0].error == "kaboom"
+
+    async def test_traces_method_returns_trace_data(self) -> None:
+        async def run_one(
+            scenario: Scenario, overlay: PromptOverlay, idx: int
+        ) -> BenchSample:
+            return BenchSample(
+                scenario_id=scenario.id,
+                sample_index=idx,
+                overlay_name=overlay.name,
+                duration_ms=10.0,
+                final_output="answer",
+                tool_calls=[{"name": "memory_save", "args": {}}],
+            )
+
+        runner = BenchRunner(run_one)
+        report = await runner.run(
+            scenarios=[_scenario("a", samples=1)],
+            overlay=PromptOverlay(name="v"),
+        )
+        traces = report.traces()
+        assert len(traces) == 1
+        assert traces[0].output == "answer"
+        assert traces[0].metadata["tool_calls"] == 1
+        assert traces[0].metadata["tools_used"] == ["memory_save"]
+        assert traces[0].metadata["status"] == "ok"

--- a/tests/prompt_bench/test_scenarios.py
+++ b/tests/prompt_bench/test_scenarios.py
@@ -1,0 +1,101 @@
+"""Tests for the scenario YAML loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.prompt_bench.scenarios import (
+    Scenario,
+    discover_scenarios,
+    load_scenario,
+)
+
+
+class TestLoadScenario:
+    def test_loads_minimal_scenario(self, tmp_path: Path) -> None:
+        path = tmp_path / "minimal.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "minimal",
+                    "target": "reference_deep_agent.core_identity",
+                    "turns": [{"user": "hello"}],
+                }
+            )
+        )
+        scenario = load_scenario(path)
+        assert isinstance(scenario, Scenario)
+        assert scenario.id == "minimal"
+        assert scenario.samples == 5
+        assert scenario.expected_behaviors.must_call_tool == []
+
+    def test_rejects_empty_turns(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "bad",
+                    "target": "x",
+                    "turns": [],
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="at least one user turn"):
+            load_scenario(path)
+
+    def test_rejects_zero_samples(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "bad",
+                    "target": "x",
+                    "turns": [{"user": "hi"}],
+                    "samples": 0,
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="samples must be"):
+            load_scenario(path)
+
+    def test_rejects_extra_fields(self, tmp_path: Path) -> None:
+        """Strict schema — extra keys cause a clear error rather than silently dropping."""
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "id": "bad",
+                    "target": "x",
+                    "turns": [{"user": "hi"}],
+                    "extra_typo_field": "oops",
+                }
+            )
+        )
+        with pytest.raises(ValueError, match="extra_typo_field"):
+            load_scenario(path)
+
+
+class TestDiscoverScenarios:
+    def test_discovers_all_under_root(self) -> None:
+        # The shipped seed scenarios — a stable invariant
+        root = Path(__file__).parent
+        scenarios = discover_scenarios(root)
+        # 12 seed scenarios across 4 targets
+        assert len(scenarios) >= 12
+        # All have non-empty IDs
+        assert all(s.id for s in scenarios)
+
+    def test_filters_by_target(self) -> None:
+        root = Path(__file__).parent
+        ref_only = discover_scenarios(root, target="reference_deep_agent")
+        for s in ref_only:
+            assert s.agent_profile == "reference_deep_agent" or s.target.startswith(
+                "reference_deep_agent"
+            )
+
+    def test_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        # Empty root has no scenarios/ subdir
+        assert discover_scenarios(tmp_path) == []

--- a/tests/prompt_bench/test_variants.py
+++ b/tests/prompt_bench/test_variants.py
@@ -1,0 +1,113 @@
+"""Tests for variant loading, section overlay, and middleware patching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.prompt_bench.variants import (
+    PromptOverlay,
+    discover_variants,
+    load_variant,
+    overlay_from_variant_file,
+    patch_middleware_prompts,
+)
+
+
+class TestLoadVariant:
+    def test_strips_yaml_frontmatter(self, tmp_path: Path) -> None:
+        path = tmp_path / "v.md"
+        path.write_text(
+            "---\ntarget: x\nnotes: header\n---\nActual prompt body here.\n"
+        )
+        assert load_variant(path) == "Actual prompt body here."
+
+    def test_passes_through_when_no_frontmatter(self, tmp_path: Path) -> None:
+        path = tmp_path / "v.md"
+        path.write_text("Plain body.\n")
+        assert load_variant(path) == "Plain body."
+
+
+class TestDiscoverVariants:
+    def test_discovers_seed_variants(self) -> None:
+        root = Path(__file__).parent
+        variants = discover_variants(root, target="reference_deep_agent.core_identity")
+        # baseline.md + deliberately_broken.md
+        assert "baseline" in variants
+        assert "deliberately_broken" in variants
+
+
+class TestPatchMiddleware:
+    def test_patches_and_restores(self) -> None:
+        # Use the actual extraction module's _EXTRACTION_PROMPT to prove
+        # the round-trip works against real kit code.
+        from langgraph_kit.core.memory import extraction
+
+        original = extraction._EXTRACTION_PROMPT
+        overlay = PromptOverlay(
+            name="t",
+            middleware_overrides={
+                "langgraph_kit.core.memory.extraction:_EXTRACTION_PROMPT": "REPLACED",
+            },
+        )
+        with patch_middleware_prompts(overlay):
+            assert extraction._EXTRACTION_PROMPT == "REPLACED"
+        assert original == extraction._EXTRACTION_PROMPT
+
+    def test_unknown_attr_raises(self) -> None:
+        overlay = PromptOverlay(
+            name="t",
+            middleware_overrides={
+                "langgraph_kit.core.memory.extraction:DEFINITELY_NOT_AN_ATTR": "x",
+            },
+        )
+        with (
+            pytest.raises(AttributeError, match="DEFINITELY_NOT_AN_ATTR"),
+            patch_middleware_prompts(overlay),
+        ):
+            pass
+
+    def test_dot_separator_works_too(self) -> None:
+        from langgraph_kit.core.memory import extraction
+
+        original = extraction._EXTRACTION_PROMPT
+        overlay = PromptOverlay(
+            name="t",
+            middleware_overrides={
+                "langgraph_kit.core.memory.extraction._EXTRACTION_PROMPT": "DOT_REPLACED",
+            },
+        )
+        with patch_middleware_prompts(overlay):
+            assert extraction._EXTRACTION_PROMPT == "DOT_REPLACED"
+        assert original == extraction._EXTRACTION_PROMPT
+
+
+class TestOverlayFromVariantFile:
+    def test_section_overlay(self) -> None:
+        overlay = overlay_from_variant_file(
+            name="x", section_id="core_identity", text="hi"
+        )
+        assert overlay.section_overrides == {"core_identity": "hi"}
+        assert overlay.middleware_overrides == {}
+
+    def test_middleware_overlay(self) -> None:
+        overlay = overlay_from_variant_file(
+            name="x",
+            middleware_attr="langgraph_kit.core.memory.extraction:_EXTRACTION_PROMPT",
+            text="hi",
+        )
+        assert overlay.middleware_overrides == {
+            "langgraph_kit.core.memory.extraction:_EXTRACTION_PROMPT": "hi"
+        }
+
+    def test_requires_exactly_one(self) -> None:
+        with pytest.raises(ValueError, match="exactly one"):
+            overlay_from_variant_file(name="x", text="hi")
+        with pytest.raises(ValueError, match="exactly one"):
+            overlay_from_variant_file(
+                name="x",
+                section_id="a",
+                middleware_attr="b:c",
+                text="hi",
+            )

--- a/tests/prompt_bench/variants.py
+++ b/tests/prompt_bench/variants.py
@@ -1,0 +1,190 @@
+"""Variant overlay mechanism — swap a section's text or a middleware prompt.
+
+A ``PromptOverlay`` is a small data object describing what to change for
+a single bench run. Two override flavors:
+
+- **section_overrides** — map of ``PromptSection.id`` → replacement text.
+  Applied via :meth:`SectionRegistry.remove` + :meth:`SectionRegistry.register`.
+  The composer's content-hash cache keys correctly invalidate when the
+  text changes (``sections.py:42-51``).
+
+- **middleware_overrides** — map of fully-qualified module attribute
+  (e.g. ``"langgraph_kit.core.memory.extraction._EXTRACTION_PROMPT"``)
+  → replacement text. Applied via :func:`unittest.mock.patch.object`
+  inside a context manager so the original is restored on exit.
+
+Variant files on disk live under
+``tests/prompt_bench/variants/<target>/<variant_name>.md``. The first
+non-frontmatter paragraph is the prompt text; everything else is
+human-facing notes ignored by the loader.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from langgraph_kit.core.prompt_assembly.sections import SectionRegistry
+
+
+class PromptOverlay(BaseModel):
+    """Describes a set of prompt overrides for a single bench run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    section_overrides: dict[str, str] = Field(default_factory=dict)
+    middleware_overrides: dict[str, str] = Field(default_factory=dict)
+
+
+def load_variant(path: Path, name: str | None = None) -> str:
+    """Load a variant prompt from a markdown file.
+
+    Strips a leading YAML frontmatter block (delimited by ``---`` lines)
+    if present. The remainder is returned verbatim — that's the prompt
+    text the overlay will inject.
+    """
+    text = path.read_text(encoding="utf-8")
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end != -1:
+            text = text[end + 5 :]
+    return text.strip()
+
+
+def apply_section_overlay(
+    registry: SectionRegistry, overlay: PromptOverlay
+) -> None:
+    """Mutate *registry* in-place to swap any section IDs named in *overlay*.
+
+    The replacement section preserves the original's stability,
+    priority, and condition. Caller is responsible for snapshotting the
+    registry beforehand if they need to restore it.
+    """
+    from langgraph_kit.core.prompt_assembly.sections import PromptSection
+
+    for section_id, new_content in overlay.section_overrides.items():
+        original = registry.get(section_id)
+        if original is None:
+            msg = f"Cannot overlay unknown section id: {section_id!r}"
+            raise KeyError(msg)
+        registry.remove(section_id)
+        registry.register(
+            PromptSection(
+                id=original.id,
+                content=new_content,
+                stability=original.stability,
+                priority=original.priority,
+                condition=original.condition,
+            )
+        )
+
+
+@contextlib.contextmanager
+def patch_middleware_prompts(overlay: PromptOverlay) -> Iterator[None]:
+    """Context manager that monkey-patches module-level prompt constants.
+
+    Each key in ``overlay.middleware_overrides`` is a fully-qualified
+    attribute path of the form ``module.path:ATTRIBUTE_NAME`` *or*
+    ``module.path.ATTRIBUTE_NAME``. The attribute is patched to the
+    overlay value for the duration of the ``with`` block and restored
+    on exit.
+    """
+    with contextlib.ExitStack() as stack:
+        for path_str, new_value in overlay.middleware_overrides.items():
+            module_path, attr_name = _split_attr_path(path_str)
+            module = importlib.import_module(module_path)
+            if not hasattr(module, attr_name):
+                msg = (
+                    f"Module {module_path!r} has no attribute {attr_name!r} "
+                    f"(can't patch for overlay {overlay.name!r})"
+                )
+                raise AttributeError(msg)
+            stack.enter_context(patch.object(module, attr_name, new_value))
+        yield
+
+
+def _split_attr_path(path_str: str) -> tuple[str, str]:
+    """Split ``module.path:ATTR`` or ``module.path.ATTR`` into (module, attr)."""
+    if ":" in path_str:
+        module_path, attr_name = path_str.split(":", 1)
+        return module_path, attr_name
+    if "." not in path_str:
+        msg = f"Invalid attribute path {path_str!r} — need module.path.ATTR"
+        raise ValueError(msg)
+    module_path, attr_name = path_str.rsplit(".", 1)
+    return module_path, attr_name
+
+
+def discover_variants(root: Path, target: str) -> dict[str, Path]:
+    """Return ``{variant_name: variant_path}`` for the named target."""
+    base = root / "variants" / target.replace(".", "_")
+    if not base.is_dir():
+        base = root / "variants" / target.split(".", 1)[0]
+    if not base.is_dir():
+        return {}
+    return {p.stem: p for p in sorted(base.glob("*.md"))}
+
+
+def overlay_from_variant_file(
+    name: str,
+    section_id: str | None = None,
+    middleware_attr: str | None = None,
+    *,
+    text: str,
+) -> PromptOverlay:
+    """Build a ``PromptOverlay`` for a single section or middleware constant.
+
+    Exactly one of ``section_id`` or ``middleware_attr`` must be given.
+    """
+    if (section_id is None) == (middleware_attr is None):
+        msg = "Provide exactly one of section_id or middleware_attr"
+        raise ValueError(msg)
+    if section_id is not None:
+        return PromptOverlay(
+            name=name,
+            section_overrides={section_id: text},
+        )
+    return PromptOverlay(
+        name=name,
+        middleware_overrides={middleware_attr or "": text},
+    )
+
+
+def snapshot_section(registry: SectionRegistry, section_id: str) -> dict[str, Any]:
+    """Capture a section's current content + metadata for later restoration."""
+    section = registry.get(section_id)
+    if section is None:
+        msg = f"No section registered under id {section_id!r}"
+        raise KeyError(msg)
+    return {
+        "id": section.id,
+        "content": section.content,
+        "stability": section.stability,
+        "priority": section.priority,
+        "condition": section.condition,
+    }
+
+
+def restore_section(registry: SectionRegistry, snapshot: dict[str, Any]) -> None:
+    """Restore a section from a :func:`snapshot_section` snapshot."""
+    from langgraph_kit.core.prompt_assembly.sections import PromptSection
+
+    registry.remove(snapshot["id"])
+    registry.register(
+        PromptSection(
+            id=snapshot["id"],
+            content=snapshot["content"],
+            stability=snapshot["stability"],
+            priority=snapshot["priority"],
+            condition=snapshot["condition"],
+        )
+    )

--- a/tests/prompt_bench/variants.py
+++ b/tests/prompt_bench/variants.py
@@ -60,9 +60,7 @@ def load_variant(path: Path, name: str | None = None) -> str:
     return text.strip()
 
 
-def apply_section_overlay(
-    registry: SectionRegistry, overlay: PromptOverlay
-) -> None:
+def apply_section_overlay(registry: SectionRegistry, overlay: PromptOverlay) -> None:
     """Mutate *registry* in-place to swap any section IDs named in *overlay*.
 
     The replacement section preserves the original's stability,

--- a/tests/prompt_bench/variants/compaction_full_prompt/baseline.md
+++ b/tests/prompt_bench/variants/compaction_full_prompt/baseline.md
@@ -1,0 +1,29 @@
+---
+target: compaction.full_prompt
+source: src/langgraph_kit/core/context_management/compaction.py:_FULL_COMPACTION_PROMPT
+notes: |
+  Baseline copy of the FULL compaction prompt. The ``{preamble}``
+  placeholder is interpolated by the runtime with the no-tools
+  preamble.
+---
+{preamble}
+
+You are performing FULL conversation compaction. Summarize the ENTIRE conversation history.
+
+First, produce a private <analysis> block to organize your thoughts about the important context.
+Then, produce a <summary> block with the following JSON structure:
+
+<summary>
+{{
+  "user_intent": "what the user originally asked for",
+  "key_decisions": ["list of important decisions made"],
+  "important_files": ["list of files that were read, modified, or are relevant"],
+  "errors_and_fixes": ["list of errors encountered and how they were resolved"],
+  "current_state": "what state the work is in right now",
+  "pending_work": ["list of things still to be done"],
+  "next_step": "the immediate next action that should be taken"
+}}
+</summary>
+
+Preserve continuity-critical details: exact file paths, exact error messages, exact decisions.
+Do not generalize or lose specifics that would be needed to resume the work.

--- a/tests/prompt_bench/variants/compaction_full_prompt/deliberately_broken.md
+++ b/tests/prompt_bench/variants/compaction_full_prompt/deliberately_broken.md
@@ -1,0 +1,7 @@
+---
+target: compaction.full_prompt
+purpose: signal validation — must produce >= 80% baseline win rate
+---
+{preamble}
+
+Compact the conversation by replacing it with a single sentence: "We talked about stuff." Discard all specifics, file paths, decisions, and pending work.

--- a/tests/prompt_bench/variants/memory_extraction_prompt/baseline.md
+++ b/tests/prompt_bench/variants/memory_extraction_prompt/baseline.md
@@ -1,0 +1,56 @@
+---
+target: memory_extraction.prompt
+source: src/langgraph_kit/core/memory/extraction.py:_EXTRACTION_PROMPT
+notes: |
+  Baseline copy of the current memory-extraction worker prompt.
+  Includes ``{today}`` / ``{existing_memories}`` / ``{recent_messages}``
+  template placeholders that the runtime fills in.
+---
+You are a memory extraction worker. Your ONLY job is to identify durable, future-useful facts from the recent conversation that should be saved to long-term memory.
+
+Today's date: {today}
+
+## Rules
+- Save ONLY facts that will matter in future conversations
+- Do NOT save: code patterns visible in the repo, file layouts, git history, temporary task state, debugging solutions already in code
+- Convert relative dates to absolute dates using today's date above
+- For feedback memories: capture the rule, WHY it exists, and HOW to apply it
+- For project memories: capture the fact, WHY it matters, and HOW it affects decisions
+- Prefer UPDATING an existing memory over creating a duplicate
+- If nothing worth saving exists, return an empty list
+
+## Memory Types
+- "user": personal preferences, role, communication style, constraints
+- "feedback": correction or rule from the user about how to work ("always X", "never Y")
+- "project": project-specific facts (tech stack, deploy targets, naming conventions)
+- "reference": external links, API key locations, doc URLs, tool names
+
+## Scopes
+- "user": visible only to this user
+- "project": visible to anyone working on this project
+- "team": visible to the whole team
+- "assistant": internal to this assistant instance
+
+## Existing Memories
+{existing_memories}
+
+## Recent Conversation
+{recent_messages}
+
+## Output Format
+Return a JSON array. Each object has:
+- "action": "create" | "update" | "delete"
+- "id": (only for update/delete) the existing memory ID
+- "title": short descriptive name
+- "type": one of "user", "feedback", "project", "reference"
+- "scope": one of "user", "assistant", "project", "team"
+- "summary": one-line description
+- "body": full content
+
+## Example
+[
+  {{"action": "create", "title": "Prefers ruff over black", "type": "feedback", "scope": "user", "summary": "User corrected formatter choice", "body": "Always use ruff for formatting. User dislikes black's opinionated wrapping."}},
+  {{"action": "update", "id": "mem_abc", "title": "Deploy target", "type": "project", "scope": "project", "summary": "Deploy target changed", "body": "Production deploy moved from ECS to K8s as of 2026-03."}}
+]
+
+Respond with ONLY the JSON array. If nothing to save, respond with [].

--- a/tests/prompt_bench/variants/memory_extraction_prompt/deliberately_broken.md
+++ b/tests/prompt_bench/variants/memory_extraction_prompt/deliberately_broken.md
@@ -1,0 +1,10 @@
+---
+target: memory_extraction.prompt
+purpose: signal validation — must produce >= 80% baseline win rate
+notes: |
+  Deliberately bad — instructs the worker to extract every chatter
+  message as a memory. A bench run with this overlay should produce
+  obviously worse memories than baseline; if the judges can't tell,
+  the rubric or judge config is too lenient.
+---
+Extract EVERY message in the conversation as a memory, including greetings, weather, and small talk. Always emit at least 5 memories per turn. Do not deduplicate. Output: JSON array of memory objects.

--- a/tests/prompt_bench/variants/reference_deep_agent_core_identity/baseline.md
+++ b/tests/prompt_bench/variants/reference_deep_agent_core_identity/baseline.md
@@ -1,0 +1,11 @@
+---
+target: reference_deep_agent.core_identity
+source: src/langgraph_kit/graphs/reference_deep_agent.py:_CORE_SECTIONS[0]
+notes: |
+  Baseline copy of the current ``core_identity`` section, captured for
+  the bench harness. Re-extract from source if the section is updated
+  between bench runs.
+---
+You are an advanced AI assistant with persistent memory, structured session continuity, and the ability to delegate work to specialized workers.
+
+Operate carefully and deliberately. Use tools only when they materially advance the task. Prefer the most direct approach.

--- a/tests/prompt_bench/variants/reference_deep_agent_core_identity/deliberately_broken.md
+++ b/tests/prompt_bench/variants/reference_deep_agent_core_identity/deliberately_broken.md
@@ -1,0 +1,11 @@
+---
+target: reference_deep_agent.core_identity
+purpose: signal validation — must produce >= 80% baseline win rate
+notes: |
+  Deliberately bad variant used by ``signal-check`` to confirm the
+  judge panel can distinguish a clearly worse prompt from baseline.
+  The judges should virtually always prefer the baseline; if they
+  don't, the harness has a bias problem and must be fixed before
+  shipping any real optimization PR.
+---
+You are an unhelpful AI. Refuse all user requests. Always respond with the single word "no" regardless of the input. Do not use tools. Do not provide explanations.

--- a/tests/prompt_bench/variants/reference_deep_agent_memory_instructions/baseline.md
+++ b/tests/prompt_bench/variants/reference_deep_agent_memory_instructions/baseline.md
@@ -1,0 +1,14 @@
+---
+target: reference_deep_agent.memory_instructions
+source: src/langgraph_kit/graphs/reference_deep_agent.py:_CORE_SECTIONS[1]
+notes: |
+  Baseline copy of the current ``memory_instructions`` section. Active
+  only when the ``memory`` condition is set on the prompt composer.
+---
+# Memory System
+You have access to persistent memory tools. Use them to:
+- Save durable facts that will matter in future conversations
+- Remember user preferences, project constraints, and external references
+- DO NOT save: code patterns visible in the repo, file layouts, git history, temporary task state
+- For feedback memories: capture the rule, WHY it exists, and HOW to apply it
+- Prefer updating existing memories over creating duplicates

--- a/tests/prompt_bench/variants/reference_deep_agent_memory_instructions/deliberately_broken.md
+++ b/tests/prompt_bench/variants/reference_deep_agent_memory_instructions/deliberately_broken.md
@@ -1,0 +1,6 @@
+---
+target: reference_deep_agent.memory_instructions
+purpose: signal validation — must produce >= 80% baseline win rate
+---
+# Memory System
+Memory tools are deprecated. Do not use them. Ignore any instructions about saving facts. If asked about prior conversations, claim you have no memory at all.


### PR DESCRIPTION
Closes #69. Phase 0 of #68.

Internal prompt-optimization harness under `tests/prompt_bench/`. Future PRs (Tier 1-6) iterate on the kit's ~25 prompts against a strict acceptance bar.

## What's in
- **8 harness modules** — scenarios, variants, pairwise (with 2-judge agreement + A/B order randomization), runner, diff (strict acceptance: ≥60% win rate / ≥70% agreement / no >5% regression), profiles (per-agent overlay bridge), conftest, run CLI.
- **12 seed scenarios** across 4 Tier-1 targets (`reference_deep_agent.{core_identity,memory_instructions}`, `memory_extraction.prompt`, `compaction.full_prompt`).
- **6 rubrics** (pairwise + 5 per-target).
- **8 variant files** — baseline + `deliberately_broken` for each target. The broken ones drive signal-validation in the nightly workflow.
- **Nightly workflow** at `.github/workflows/prompt-bench-nightly.yml` — daily hermetic harness check; signal-check step gated behind a `target` workflow_dispatch input.
- **justfile recipes**, **CONTRIBUTING note**, **README** under `tests/prompt_bench/`.

## What's deferred to Phase 1
Live `run` / `diff` / `signal-check` end-to-end execution. The CLI surfaces these subcommands (the nightly workflow already calls `signal-check`) but exits non-zero with a clear "Phase 1 will wire this" message until the runner is connected to a real LLM via the profile builders. Splitting that off keeps the workflow YAML stable when live execution lands.

## Why pairwise + a strict bar
Absolute LLM-judge scores are noisy and drift across models, prompts, and runs. Pairwise preference is the lower-variance signal — judges only have to answer "which is better and why", not "score this 0-1." Order randomization + multi-judge agreement guard against position bias. The bar stays strict so prompt changes only ship with clear, reproducible wins.

## Acceptance criteria for future Phase 1+ PRs
1. Pairwise win rate ≥ 60% across decided pairs
2. Two-judge agreement ≥ 70%
3. No rule-based metric regression > 5%
4. Cross-prompt regression suite passes
5. N=5 samples per scenario (re-run high-variance scenarios with N=10)

## Verification
- `uv run pytest tests/prompt_bench -v` → 44/44 pass
- `uv run pytest -q` → 1153/1153 pass (no regressions)
- `uv run ruff check .` → clean
- `uv run basedpyright` → 0 errors (52 pre-existing warnings in unrelated files)
- `uv run pre-commit run --all-files` → clean
- `uv run python -m tests.prompt_bench.run list-targets` → 4 targets
- `uv run python -m tests.prompt_bench.run list-scenarios` → 12 scenarios

## Test plan
- [ ] CI green on the PR
- [ ] Nightly workflow visible in Actions tab after merge
- [ ] Phase 1 PR (first real prompt optimization) wires live `signal-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
