### PR TITLE
Fix prompt-bench signal-check fail-fast in stub mode + secret check

### DIFF
--- a/.github/workflows/prompt-bench-nightly.yml
+++ b/.github/workflows/prompt-bench-nightly.yml
@@ -39,23 +39,22 @@ jobs:
       - name: Discover targets
         run: uv run python -m tests.prompt_bench.run list-targets
 
-      # Phase 0 ships the harness modules + scenarios + diff API but
-      # defers live signal-check (baseline-vs-baseline + baseline-vs-
-      # deliberately-broken) to Phase 1, which wires the run.py CLI to
-      # the profile builders. The placeholder step below lights up once
-      # the CLI's `signal-check` exits 0 instead of 3.
-      - name: Signal validation (Phase 1+)
+      # Phase 0.5 wired live signal-check end-to-end. The step runs only
+      # when ``target`` is dispatched (the daily cron path skips it to
+      # avoid burning credits on every harness check). Failure surfaces
+      # as a workflow warning + the auto-issue step below.
+      - name: Signal validation
         if: ${{ inputs.target != '' }}
         env:
           AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
           PROMPT_BENCH_LLM: real
         run: |
           set -euo pipefail
-          if uv run python -m tests.prompt_bench.run signal-check --target "${{ inputs.target }}"; then
-            echo "Signal-check passed."
-          else
-            echo "::warning::signal-check exited non-zero; Phase 0 surfaces this command but does not yet wire end-to-end execution."
+          if [ -z "${AGENT_LLM_API_KEY}" ]; then
+            echo "::error::AGENT_LLM_API_KEY secret is not set on this repo. Configure it before dispatching signal-check."
+            exit 1
           fi
+          uv run python -m tests.prompt_bench.run signal-check --target "${{ inputs.target }}"
 
       - name: Open issue on failure
         if: failure()

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -260,6 +260,15 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
         sys.stderr.write(f"Unknown target {target!r}\n")
         return EXIT_USAGE
 
+    if not _real_llm_enabled():
+        sys.stderr.write(
+            "signal-check requires a real LLM. Set both PROMPT_BENCH_LLM=real "
+            f"and {_API_KEY_ENV}=<key> before running.\n"
+            f"Current: PROMPT_BENCH_LLM={os.environ.get(_LLM_MODE_ENV, '<unset>')!r}, "
+            f"{_API_KEY_ENV}={'set' if os.environ.get(_API_KEY_ENV) else '<unset>'}\n"
+        )
+        return EXIT_USAGE
+
     target_meta = TARGETS[target]
     variants = discover_variants(ROOT, target)
     for required in ("baseline", "deliberately_broken"):


### PR DESCRIPTION
The first dispatched run of `prompt-bench-nightly` with `target=reference_deep_agent.core_identity` completed in 21s with stub mode active — `_real_llm_enabled()` returned False even though `PROMPT_BENCH_LLM=real` was set. Either the `AGENT_LLM_API_KEY` secret isn't configured on this repo, or it expanded to empty. The CLI fell back to `_StubExecutorLLM` and produced `AttributeError: '_StubExecutorLLM' object has no attribute 'partition'` per sample, then exited with a meaningless `signal-check: FAIL`.

## Two fixes

1. **`_cmd_signal_check` refuses to run unless real-LLM mode is active.** Clear error message identifies which env var is missing.
2. **The workflow's `Signal validation` step explicitly checks the secret** is non-empty and fails with a `::error::` annotation if not. Strips the stale "Phase 0 surfaces this command but does not yet wire end-to-end execution" text I left in by mistake.

## Required follow-up

Confirm `AGENT_LLM_API_KEY` is configured as a repo secret. After this lands, dispatch the workflow again with the same `target` input — if the secret is set the signal check will run for real (15-30 min, ~\$5 budget); if not, the workflow fails fast with a clear error.

## Verification

- `uv run pytest tests/prompt_bench -q` → 57/57 pass
- Manual: `PROMPT_BENCH_LLM=stub uv run python -m tests.prompt_bench.run signal-check --target reference_deep_agent.core_identity` → exits 2 with the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)