### PR TITLE
Migrate prompt-bench to OpenAI-compatible env vars; strip CI signal-check

### DIFF
--- a/.github/workflows/prompt-bench-nightly.yml
+++ b/.github/workflows/prompt-bench-nightly.yml
@@ -7,11 +7,12 @@ on:
     # tracker burst.
     - cron: "30 7 * * *"
   workflow_dispatch:
-    inputs:
-      target:
-        description: "Optional bench target for signal-check (e.g. reference_deep_agent.core_identity)"
-        required: false
-        default: ""
+
+# Hermetic only. Real-LLM runs (signal-check, prompt iteration) are
+# triggered manually from a dev workstation with the operator's local
+# .env (``LLM_BASE_URL`` / ``LLM_API_KEY`` / ``LLM_MODEL``). We keep
+# the bench out of CI's automatic-spend path so iteration credit
+# costs stay visible to the human running them.
 
 jobs:
   prompt-bench-harness:
@@ -39,23 +40,6 @@ jobs:
       - name: Discover targets
         run: uv run python -m tests.prompt_bench.run list-targets
 
-      # Phase 0.5 wired live signal-check end-to-end. The step runs only
-      # when ``target`` is dispatched (the daily cron path skips it to
-      # avoid burning credits on every harness check). Failure surfaces
-      # as a workflow warning + the auto-issue step below.
-      - name: Signal validation
-        if: ${{ inputs.target != '' }}
-        env:
-          AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
-          PROMPT_BENCH_LLM: real
-        run: |
-          set -euo pipefail
-          if [ -z "${AGENT_LLM_API_KEY}" ]; then
-            echo "::error::AGENT_LLM_API_KEY secret is not set on this repo. Configure it before dispatching signal-check."
-            exit 1
-          fi
-          uv run python -m tests.prompt_bench.run signal-check --target "${{ inputs.target }}"
-
       - name: Open issue on failure
         if: failure()
         uses: actions/github-script@v8
@@ -73,7 +57,7 @@ jobs:
               `- Scenario YAML schema regression`,
               `- Profile section list moved or renamed (e.g. _CORE_SECTIONS)`,
               ``,
-              `Run \`uv run pytest tests/prompt_bench -v\` locally to reproduce.`,
+              `Run \`just prompt-bench-test\` locally to reproduce.`,
             ].join('\n');
             await github.rest.issues.create({
               owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,12 +99,14 @@ Iteration loop:
 2. **Drop a candidate** at `tests/prompt_bench/variants/<target>/<variant_name>.md`.
    Frontmatter (notes, dimension changed) is stripped; everything below
    is the prompt text the overlay injects.
-3. **Run the harness** (Phase 1 onwards — hermetic check works today via
-   `just prompt-bench-test`):
+3. **Run the harness.** Hermetic check via `just prompt-bench-test`.
+   For real-LLM iteration, populate `.env` with
+   `LLM_BASE_URL` / `LLM_API_KEY` / `LLM_MODEL` (any
+   OpenAI-compatible endpoint) and run:
    ```bash
-   PROMPT_BENCH_LLM=real AGENT_LLM_API_KEY=... \
-     uv run python -m tests.prompt_bench.run run \
-       --target <target> --variant <variant_name>
+   set -a && source .env && set +a
+   uv run python -m tests.prompt_bench.run run \
+     --target <target> --variant <variant_name>
    ```
 4. **Diff** baseline vs variant; the markdown report goes in the PR.
 5. **Strict acceptance bar** — a change ships only when:

--- a/tests/prompt_bench/.env.example
+++ b/tests/prompt_bench/.env.example
@@ -1,0 +1,14 @@
+# Copy to <repo-root>/.env and edit. The bench uses these for live runs;
+# omit any of the three required vars to fall back to stub mode.
+
+# OpenAI-compatible chat endpoint (any proxy that speaks /v1/chat/completions).
+LLM_BASE_URL=http://10.69.1.169:8690/v1
+LLM_API_KEY=placeholder
+LLM_MODEL=large-default:agent
+
+# Optional per-role overrides. Pin a different upstream model (or
+# different family) for executor / judges if your proxy supports it.
+# Leave unset to use LLM_MODEL for every role.
+# BENCH_EXECUTOR_MODEL=large-default:agent
+# BENCH_JUDGE_MODEL_A=large-default:judge-strong
+# BENCH_JUDGE_MODEL_B=large-default:judge-cheap

--- a/tests/prompt_bench/README.md
+++ b/tests/prompt_bench/README.md
@@ -46,8 +46,8 @@ tests/prompt_bench/
 ├── profiles.py      Per-agent overlay-application bridges
 ├── diff.py          DiffReport + acceptance-criteria evaluation
 ├── scenarios.py     Scenario YAML schema + loader
-├── conftest.py      Pytest fixtures (mocked LLM by default; real LLM
-│                    when PROMPT_BENCH_LLM=real and AGENT_LLM_API_KEY)
+├── conftest.py      Pytest fixtures (stub by default; ChatOpenAI when
+│                    LLM_BASE_URL/LLM_API_KEY/LLM_MODEL are all set)
 ├── run.py           CLI entry: list-targets, list-scenarios, ...
 ├── scenarios/<target>/*.yaml      Scenario library, grows over time
 ├── rubrics/*.md                   Pairwise + per-target rubrics
@@ -76,15 +76,17 @@ guidance:
    frontmatter block (notes, rationale, dimension changed) — the
    loader strips it. Everything below the frontmatter is the prompt
    text the overlay will inject.
-3. **Run the bench.** Once the live `run`/`diff` CLI lands (Phase 1),
-   it'll be:
+3. **Run the bench.** With `LLM_BASE_URL` / `LLM_API_KEY` /
+   `LLM_MODEL` populated in `.env`:
 
    ```bash
-   PROMPT_BENCH_LLM=real AGENT_LLM_API_KEY=... \
-     python -m tests.prompt_bench.run run --target reference_deep_agent.core_identity --variant my_candidate
+   set -a && source .env && set +a
+   uv run python -m tests.prompt_bench.run run \
+     --target reference_deep_agent.core_identity --variant my_candidate \
+     --out /tmp/variant.json
    ```
 
-   For now the bench is exercised via the pytest harness and the
+   The bench can also be exercised via the pytest harness (stub mode) and the
    nightly workflow.
 4. **Diff.** `python -m tests.prompt_bench.run diff --base base.json --variant variant.json --out diff.md`
 5. **Open a PR** with the variant file, the diff report (markdown),
@@ -109,19 +111,32 @@ Optional: `seeded_state`, `expected_behaviors`, `description`.
 Default mode is **hermetic** — `bench_llm` is a deterministic stub.
 Use this for:
 
-- Unit-testing harness logic (`pytest tests/prompt_bench/`)
+- Unit-testing harness logic (`just prompt-bench-test`)
 - CI's per-PR run (no API key required)
+- Wiring validation (does the loop crash?)
 
-**Real-LLM mode** is enabled by `PROMPT_BENCH_LLM=real` +
-`AGENT_LLM_API_KEY`. Use this for:
+**Real-LLM mode** activates when *all three* of these env vars are
+set; otherwise the harness silently falls back to stub mode:
 
-- Actual prompt-iteration cycles
-- The nightly CI workflow
-- Local validation before opening a PR
+```bash
+LLM_BASE_URL=http://10.69.1.169:8690/v1   # OpenAI-compatible /v1 endpoint
+LLM_API_KEY=placeholder                    # API key for the proxy
+LLM_MODEL=large-default:agent              # default model name routed by the proxy
+```
 
-The execution LLM defaults to `claude-sonnet-4-6` (quality matters);
-judges default to `claude-opus-4-7` and `claude-haiku-4-5`. Override
-in `conftest.py` if needed.
+Optional per-role model overrides — useful when judges should be a
+different model (or different family) than the executor:
+
+```bash
+BENCH_EXECUTOR_MODEL=...     # model under evaluation     (defaults to LLM_MODEL)
+BENCH_JUDGE_MODEL_A=...      # primary pairwise judge     (defaults to LLM_MODEL)
+BENCH_JUDGE_MODEL_B=...      # secondary pairwise judge   (defaults to LLM_MODEL)
+```
+
+`signal-check` refuses to run in stub mode (the numbers would be
+meaningless). Real prompt iteration only happens locally — the CI
+nightly is hermetic-only by design, so iteration cost stays visible
+to the human running it.
 
 ## Signal validation (run before optimizing real prompts)
 
@@ -134,6 +149,14 @@ trusted:
 2. **Ceiling:** baseline-vs-`deliberately_broken.md` produces a
    baseline win rate ≥ 80%. Lower → the judges aren't discriminating.
 
-Both are exercised by the nightly workflow. The `deliberately_broken.md`
-variants under `variants/<target>/` exist for this reason — do not
-delete them.
+To run signal-check locally:
+
+```bash
+# After populating .env with LLM_BASE_URL / LLM_API_KEY / LLM_MODEL
+set -a && source .env && set +a
+uv run python -m tests.prompt_bench.run signal-check \
+  --target reference_deep_agent.core_identity
+```
+
+The `deliberately_broken.md` variants under `variants/<target>/`
+exist for this reason — do not delete them.

--- a/tests/prompt_bench/conftest.py
+++ b/tests/prompt_bench/conftest.py
@@ -4,12 +4,14 @@ Lives at the package root (under ``tests/``) so unit tests can import
 fixtures with no ``--rootdir`` gymnastics. Provides:
 
 - ``bench_llm`` — chat model used for *agent execution*. Hermetic by
-  default (a deterministic stub that echoes the input). When
-  ``PROMPT_BENCH_LLM=real`` and ``AGENT_LLM_API_KEY`` is set, returns
-  a real Claude model pinned to ``DEFAULT_EXECUTION_MODEL``.
-- ``judge_llms`` — two-model panel for pairwise judging. Same hermetic
-  default; real mode pulls in a Claude judge + an external judge if
-  configured (otherwise two Claude judges with different temperature).
+  default (a deterministic stub). When ``LLM_BASE_URL`` /
+  ``LLM_API_KEY`` / ``LLM_MODEL`` are all set, returns a
+  ``ChatOpenAI`` pointed at the proxy, optionally pinned via
+  ``BENCH_EXECUTOR_MODEL``.
+- ``judge_llms`` — two-model panel for pairwise judging. Stub by
+  default; real mode reads ``BENCH_JUDGE_MODEL_A`` and
+  ``BENCH_JUDGE_MODEL_B`` (each falling back to ``LLM_MODEL`` if
+  unset).
 - ``bench_pairwise_panel`` — a :class:`PairwisePanel` wired up with
   ``judge_llms``.
 - ``mock_section_registry_factory`` — returns a fresh
@@ -32,25 +34,28 @@ if TYPE_CHECKING:
 
 
 # ---------------------------------------------------------------------------
-# Mode detection — separate env vars from the examples harness so the two
-# harnesses don't accidentally cross-talk (examples use scripted by default
-# even with PROMPT_BENCH_LLM=real, and vice versa).
+# Mode detection — uses the same OpenAI-compatible env vars as ``run.py``
+# (``LLM_BASE_URL`` / ``LLM_API_KEY`` / ``LLM_MODEL``). Real mode is active
+# only when all three are present; otherwise fixtures fall back to the
+# deterministic stub so unit tests don't accidentally hit a network.
 # ---------------------------------------------------------------------------
 
-_LLM_MODE_ENV = "PROMPT_BENCH_LLM"
-_API_KEY_ENV = "AGENT_LLM_API_KEY"
-
-# The model under evaluation (we want quality signal — Sonnet matters).
-DEFAULT_EXECUTION_MODEL = "claude-sonnet-4-6"
-# Judges should be capable but cheaper than the executor — Opus is the
-# default high-end judge; the second judge is OpenAI / Gemini if their
-# env vars are set, falling back to a second Claude with different temp.
-DEFAULT_JUDGE_MODEL_PRIMARY = "claude-opus-4-7"
-DEFAULT_JUDGE_MODEL_SECONDARY = "claude-haiku-4-5"
+_BASE_URL_ENV = "LLM_BASE_URL"
+_API_KEY_ENV = "LLM_API_KEY"
+_MODEL_ENV = "LLM_MODEL"
+_EXECUTOR_MODEL_ENV = "BENCH_EXECUTOR_MODEL"
+_JUDGE_A_MODEL_ENV = "BENCH_JUDGE_MODEL_A"
+_JUDGE_B_MODEL_ENV = "BENCH_JUDGE_MODEL_B"
 
 
 def _real_llm_enabled() -> bool:
-    return os.environ.get(_LLM_MODE_ENV, "stub").lower() == "real"
+    return all(
+        os.environ.get(name) for name in (_BASE_URL_ENV, _API_KEY_ENV, _MODEL_ENV)
+    )
+
+
+def _role_model(role_env: str) -> str:
+    return os.environ.get(role_env) or os.environ[_MODEL_ENV]
 
 
 # ---------------------------------------------------------------------------
@@ -111,21 +116,21 @@ def stub_llm_factory():
 def bench_llm() -> Any:
     """Chat model used for *agent execution* in scenarios.
 
-    Hermetic stub by default; switches to real Claude when
-    ``PROMPT_BENCH_LLM=real`` + ``AGENT_LLM_API_KEY`` are set.
+    Hermetic stub by default; switches to a real ``ChatOpenAI`` pointed
+    at ``LLM_BASE_URL`` when the three required env vars are all set.
     """
-    if _real_llm_enabled() and os.environ.get(_API_KEY_ENV):
-        return _build_real_chat_model(DEFAULT_EXECUTION_MODEL)
+    if _real_llm_enabled():
+        return _build_real_chat_model(_role_model(_EXECUTOR_MODEL_ENV))
     return _DeterministicStub()
 
 
 @pytest.fixture
 def judge_llms() -> list[Any]:
     """Two-model panel for pairwise judging (real or stub)."""
-    if _real_llm_enabled() and os.environ.get(_API_KEY_ENV):
+    if _real_llm_enabled():
         return [
-            _build_real_chat_model(DEFAULT_JUDGE_MODEL_PRIMARY),
-            _build_real_chat_model(DEFAULT_JUDGE_MODEL_SECONDARY),
+            _build_real_chat_model(_role_model(_JUDGE_A_MODEL_ENV)),
+            _build_real_chat_model(_role_model(_JUDGE_B_MODEL_ENV)),
         ]
     return [_DeterministicStub(), _DeterministicStub()]
 
@@ -159,27 +164,26 @@ def reference_section_registry_factory():
 # ---------------------------------------------------------------------------
 
 
-def _build_real_chat_model(model_id: str) -> Any:
-    """Build a real Anthropic chat model with the given model id.
+def _build_real_chat_model(model_name: str) -> Any:
+    """Return a ``ChatOpenAI`` pointed at ``LLM_BASE_URL``.
 
-    Matches what ``langgraph_kit.llm.build_llm`` would have produced,
-    but lets us pin different models for executor vs judges without
-    going through ``configure(AgentConfig(...))`` (which is global).
+    The bench targets OpenAI-compatible endpoints (any proxy that
+    speaks ``/v1/chat/completions``). Per-role model overrides go
+    through ``BENCH_EXECUTOR_MODEL`` / ``BENCH_JUDGE_MODEL_A`` /
+    ``BENCH_JUDGE_MODEL_B``; this function takes a resolved name.
     """
-    from langchain_anthropic import (  # pyright: ignore[reportMissingImports]
-        ChatAnthropic,
+    from langchain_openai import (  # pyright: ignore[reportMissingImports]
+        ChatOpenAI,
     )
 
-    # Pass via **kwargs so basedpyright's stricter stub doesn't flag the
-    # well-known runtime kwargs (``model``, ``max_tokens``, ``timeout``)
-    # as unrecognised — langchain_anthropic accepts them at runtime.
     kwargs: dict[str, Any] = {
-        "model": model_id,
+        "model": model_name,
         "api_key": os.environ[_API_KEY_ENV],
+        "base_url": os.environ[_BASE_URL_ENV],
         "max_tokens": 1024,
         "timeout": 60,
     }
-    return ChatAnthropic(**kwargs)  # pyright: ignore[reportCallIssue]
+    return ChatOpenAI(**kwargs)  # pyright: ignore[reportCallIssue]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -9,10 +9,24 @@ Usage::
     python -m tests.prompt_bench.run signal-check --target <name>
 
 Hermetic by default — uses a deterministic stub LLM so the harness
-loop runs end-to-end without an API key. Set ``PROMPT_BENCH_LLM=real``
-+ ``AGENT_LLM_API_KEY`` to use real models. Stub mode is meant for
-*wiring* validation; signal numbers from stub mode have no meaning
-beyond "did the loop crash?".
+loop runs end-to-end without a real model. The bench uses an
+**OpenAI-compatible** chat endpoint when these are all set::
+
+    LLM_BASE_URL    e.g. http://10.69.1.169:8690/v1 (any OpenAI-compat proxy)
+    LLM_API_KEY     api key for the proxy (often a placeholder for local)
+    LLM_MODEL       default model name routed through the proxy
+
+Optional per-role overrides — useful when judges need to be different
+models (or different families) than the executor::
+
+    BENCH_EXECUTOR_MODEL    model under evaluation     (defaults to LLM_MODEL)
+    BENCH_JUDGE_MODEL_A     primary pairwise judge     (defaults to LLM_MODEL)
+    BENCH_JUDGE_MODEL_B     secondary pairwise judge   (defaults to LLM_MODEL)
+
+If any of the three required vars (``LLM_BASE_URL``, ``LLM_API_KEY``,
+``LLM_MODEL``) is missing, the harness falls back to its deterministic
+stub. Stub-mode signal numbers have no meaning beyond "did the loop
+crash?". ``signal-check`` refuses to run in stub mode.
 """
 
 from __future__ import annotations
@@ -49,8 +63,18 @@ logger = logging.getLogger(__name__)
 
 ROOT = Path(__file__).parent
 
-_LLM_MODE_ENV = "PROMPT_BENCH_LLM"
-_API_KEY_ENV = "AGENT_LLM_API_KEY"
+# OpenAI-compatible chat endpoint (any proxy that speaks ``/v1/chat/completions``).
+# All three must be set for real-LLM mode; otherwise the harness uses its stub.
+_BASE_URL_ENV = "LLM_BASE_URL"
+_API_KEY_ENV = "LLM_API_KEY"
+_MODEL_ENV = "LLM_MODEL"
+
+# Optional per-role overrides — when a single proxy can route to multiple
+# upstream models, pin different ones for executor / judges. If unset,
+# every role uses ``LLM_MODEL``.
+_EXECUTOR_MODEL_ENV = "BENCH_EXECUTOR_MODEL"
+_JUDGE_A_MODEL_ENV = "BENCH_JUDGE_MODEL_A"
+_JUDGE_B_MODEL_ENV = "BENCH_JUDGE_MODEL_B"
 
 
 # ---------------------------------------------------------------------------
@@ -262,10 +286,11 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
 
     if not _real_llm_enabled():
         sys.stderr.write(
-            "signal-check requires a real LLM. Set both PROMPT_BENCH_LLM=real "
-            f"and {_API_KEY_ENV}=<key> before running.\n"
-            f"Current: PROMPT_BENCH_LLM={os.environ.get(_LLM_MODE_ENV, '<unset>')!r}, "
-            f"{_API_KEY_ENV}={'set' if os.environ.get(_API_KEY_ENV) else '<unset>'}\n"
+            "signal-check requires a real LLM. Set all three of "
+            f"{_BASE_URL_ENV}, {_API_KEY_ENV}, {_MODEL_ENV} before running.\n"
+            f"Current: {_BASE_URL_ENV}={'set' if os.environ.get(_BASE_URL_ENV) else '<unset>'}, "
+            f"{_API_KEY_ENV}={'set' if os.environ.get(_API_KEY_ENV) else '<unset>'}, "
+            f"{_MODEL_ENV}={os.environ.get(_MODEL_ENV, '<unset>')!r}\n"
         )
         return EXIT_USAGE
 
@@ -404,18 +429,20 @@ async def _execute_overlay(
 
 def _build_executor_llm() -> Any:
     if _real_llm_enabled():
-        return _build_real_chat_model("claude-sonnet-4-6")
+        return _build_real_chat_model(_role_model(_EXECUTOR_MODEL_ENV))
     return _StubExecutorLLM()
 
 
 def _build_pairwise_panel() -> PairwisePanel:
     if _real_llm_enabled():
+        model_a = _role_model(_JUDGE_A_MODEL_ENV)
+        model_b = _role_model(_JUDGE_B_MODEL_ENV)
         judges = [
             PairwiseJudge(
-                name="claude-opus", llm=_build_real_chat_model("claude-opus-4-7")
+                name=f"judge_a:{model_a}", llm=_build_real_chat_model(model_a)
             ),
             PairwiseJudge(
-                name="claude-haiku", llm=_build_real_chat_model("claude-haiku-4-5")
+                name=f"judge_b:{model_b}", llm=_build_real_chat_model(model_b)
             ),
         ]
     else:
@@ -431,23 +458,36 @@ def _build_pairwise_panel() -> PairwisePanel:
 
 
 def _real_llm_enabled() -> bool:
-    return os.environ.get(_LLM_MODE_ENV, "stub").lower() == "real" and bool(
-        os.environ.get(_API_KEY_ENV)
+    """Real mode is active iff base URL + key + default model are all set."""
+    return all(
+        os.environ.get(name) for name in (_BASE_URL_ENV, _API_KEY_ENV, _MODEL_ENV)
     )
 
 
-def _build_real_chat_model(model_id: str) -> Any:
-    from langchain_anthropic import (  # pyright: ignore[reportMissingImports]
-        ChatAnthropic,
+def _role_model(role_env: str) -> str:
+    """Pick the per-role model override, falling back to ``LLM_MODEL``."""
+    return os.environ.get(role_env) or os.environ[_MODEL_ENV]
+
+
+def _build_real_chat_model(model_name: str) -> Any:
+    """Return a ``ChatOpenAI`` pointed at the configured proxy.
+
+    The proxy must speak the OpenAI ``/v1/chat/completions`` shape;
+    most local LLM servers (vLLM, llama-server, LiteLLM proxy, etc.)
+    do, even when routing to non-OpenAI upstreams.
+    """
+    from langchain_openai import (  # pyright: ignore[reportMissingImports]
+        ChatOpenAI,
     )
 
     kwargs: dict[str, Any] = {
-        "model": model_id,
+        "model": model_name,
         "api_key": os.environ[_API_KEY_ENV],
+        "base_url": os.environ[_BASE_URL_ENV],
         "max_tokens": 1024,
         "timeout": 60,
     }
-    return ChatAnthropic(**kwargs)  # pyright: ignore[reportCallIssue]
+    return ChatOpenAI(**kwargs)  # pyright: ignore[reportCallIssue]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two related changes that turn the bench into a fully local-driven optimization tool — no autonomous LLM spend from CI.

## Env-var migration

The bench now uses an OpenAI-compatible chat endpoint (e.g. a local LiteLLM / vLLM proxy) instead of calling \`ChatAnthropic\` directly.

Real-LLM mode activates when **all three** are set:
\`\`\`bash
LLM_BASE_URL=http://10.69.1.169:8690/v1
LLM_API_KEY=placeholder
LLM_MODEL=large-default:agent
\`\`\`

Otherwise the harness silently falls back to its deterministic stub.

Optional per-role overrides — useful when judges should be a different upstream model than the executor:
\`\`\`bash
BENCH_EXECUTOR_MODEL=...
BENCH_JUDGE_MODEL_A=...
BENCH_JUDGE_MODEL_B=...
\`\`\`

Replaces the previous \`PROMPT_BENCH_LLM=real\` + \`AGENT_LLM_API_KEY\` + hard-coded Claude model names. \`.env.example\` ships under \`tests/prompt_bench/\`.

## CI workflow strip

Drops the \`Signal validation\` step + \`target\` workflow_dispatch input from \`prompt-bench-nightly.yml\`. Nightly is hermetic-only now (unit tests + CLI list commands). Real-LLM iteration (signal-check, prompt-A vs prompt-B) only happens locally with the operator's \`.env\` — keeps spend visible to the human running it.

## Verification

- \`uv run pytest tests/prompt_bench -q\` → 57/57 pass
- \`uv run pytest -q\` → 1166/1166 pass
- \`uv run ruff check .\` clean, \`uv run basedpyright\` 0 errors
- Stub mode: \`uv run python -m tests.prompt_bench.run signal-check --target reference_deep_agent.core_identity\` → exits 2 with the required-env-vars error

## Test plan

- [ ] Populate \`.env\` per \`tests/prompt_bench/.env.example\`
- [ ] \`set -a && source .env && set +a\` in the shell
- [ ] \`uv run python -m tests.prompt_bench.run signal-check --target reference_deep_agent.core_identity\` runs against the local proxy, ~15-30 min
- [ ] Confirm floor [0.45, 0.55], ceiling >= 0.80, judge agreement >= 0.70

🤖 Generated with [Claude Code](https://claude.com/claude-code)