### PR TITLE
Fix two signal-check bugs: build_deep_agent unpack + judge sees user_input

### DIFF
--- a/tests/prompt_bench/README.md
+++ b/tests/prompt_bench/README.md
@@ -5,6 +5,42 @@ Internal tooling for systematically optimizing the prompts the kit ships
 worker definitions, skill content). **Not** part of the public API —
 lives under `tests/` deliberately.
 
+## Status
+
+**Paused as of 2026-04-25.** The harness pipeline works end-to-end (run
+agents under overlays → pairwise judge panel → diff report) and the
+`pytest tests/prompt_bench` suite passes. Active prompt iteration is
+paused for two reasons:
+
+1. **deepagents framework dominance.** `create_deep_agent` always
+   appends its `BASE_AGENT_PROMPT` after our overlay, and per-tool
+   middleware (`write_todos`, filesystem, `task` spawner, etc.) inject
+   additional system-prompt blocks. Section-level overlays are one of
+   ~10 competing prompt blocks, and the framework-injected ones
+   overpower them. The "deliberately broken" ceiling validation
+   couldn't pass even with every core section overridden by an
+   explicit override — direct LLM probes confirmed the override binds a
+   bare model call but not the agent path.
+2. **No specific prompt grievance.** Optimization without a real
+   "this prompt is wrong" signal is speculation. The harness is built
+   to *measure* differences; it doesn't generate hypotheses about
+   *which* prompts to change.
+
+If you want to restart this:
+
+- Prefer **middleware-prompt** targets (`memory_extraction.prompt`,
+  `compaction.full_prompt`, `consolidation_prompt`) and **worker
+  definitions** over section-level overlays. Middleware prompts run
+  in isolation with no framework wrapper, so overlays take full effect.
+- Calibrate `signal-check` thresholds to the kit before re-enabling.
+  The defaults below (floor [0.45, 0.55], ceiling >= 0.80) were
+  modeled on a "naked LLM" assumption that doesn't hold here.
+  Suggested starting band: floor [0.30, 0.70], ceiling >= 0.30.
+- If you must optimize a section-level prompt (e.g. `core_identity`),
+  decide first whether to override `BASE_AGENT_PROMPT` via
+  `_HarnessProfile.base_system_prompt` (`deepagents.profiles._harness_profiles`)
+  or accept that section overlays produce small effects in this kit.
+
 ## Why pairwise, not absolute scoring
 
 Absolute scores from a single LLM judge are noisy and drift across

--- a/tests/prompt_bench/diff.py
+++ b/tests/prompt_bench/diff.py
@@ -181,8 +181,12 @@ async def _diff_scenario(
     diff.pair_count = len(pairs)
 
     for base_sample, variant_sample in pairs:
+        # Anchor the judge in what the agent was actually asked. Falls
+        # back to the scenario id only if neither sample captured user
+        # input (older reports without the field).
+        input_text = base_sample.user_input or variant_sample.user_input or scenario_id
         result = await panel.compare(
-            input_text=scenario_id,
+            input_text=input_text,
             base_trace=base_sample.to_trace(),
             variant_trace=variant_sample.to_trace(),
         )

--- a/tests/prompt_bench/live_runner.py
+++ b/tests/prompt_bench/live_runner.py
@@ -122,8 +122,10 @@ async def default_drive_scenario(graph: Any, scenario: Scenario) -> dict[str, An
     messages: list[Any] = []
     tool_calls: list[dict[str, Any]] = []
     final_output = ""
+    user_input_lines: list[str] = []
 
     for turn in scenario.turns:
+        user_input_lines.append(f"USER: {turn.user}")
         messages.append(HumanMessage(content=turn.user))
         result = await graph.ainvoke({"messages": messages}, config=config)
         if isinstance(result, dict) and "messages" in result:
@@ -148,7 +150,11 @@ async def default_drive_scenario(graph: Any, scenario: Scenario) -> dict[str, An
             content = last_ai.content
             final_output = content if isinstance(content, str) else str(content)
 
-    return {"final_output": final_output, "tool_calls": tool_calls}
+    return {
+        "final_output": final_output,
+        "tool_calls": tool_calls,
+        "user_input": "\n".join(user_input_lines),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -216,16 +222,21 @@ def make_run_one(
             )
 
         duration_ms = (time.monotonic() - start) * 1000
-        final_output = (
-            result.get("final_output", "") if isinstance(result, dict) else str(result)
-        )
-        tool_calls = result.get("tool_calls", []) if isinstance(result, dict) else []
+        if isinstance(result, dict):
+            final_output = result.get("final_output", "")
+            tool_calls = result.get("tool_calls", [])
+            user_input = result.get("user_input", "")
+        else:
+            final_output = str(result)
+            tool_calls = []
+            user_input = ""
         return BenchSample(
             scenario_id=scenario.id,
             sample_index=sample_index,
             overlay_name=overlay.name,
             duration_ms=duration_ms,
             final_output=final_output,
+            user_input=user_input,
             tool_calls=tool_calls,
         )
 

--- a/tests/prompt_bench/profiles.py
+++ b/tests/prompt_bench/profiles.py
@@ -160,13 +160,18 @@ def _build_reference_deep_agent(overlay: PromptOverlay, deps: Any) -> Any:
 
     sections = apply_overlay_to_sections("reference_deep_agent", overlay)
     checkpointer, store = deps
-    return build_deep_agent(
+    # ``build_deep_agent`` returns ``(graph, command_dispatcher)``; the
+    # bench only needs the graph, so unpack and discard the dispatcher
+    # (the e2e suite + ``examples/reference_deep_agent.py`` follow the
+    # same pattern).
+    graph, _dispatcher = build_deep_agent(
         agent_name="reference-deep-agent",
         core_sections=sections,
         subagents=GENERAL_WORKERS,
         checkpointer=checkpointer,
         store=store,
     )
+    return graph
 
 
 def _build_coding_agent(overlay: PromptOverlay, deps: Any) -> Any:
@@ -180,13 +185,14 @@ def _build_coding_agent(overlay: PromptOverlay, deps: Any) -> Any:
 
     sections = apply_overlay_to_sections("coding_agent", overlay)
     checkpointer, store = deps
-    return build_deep_agent(
+    graph, _dispatcher = build_deep_agent(
         agent_name="coding-agent",
         core_sections=sections,
         subagents=CODING_WORKERS,
         checkpointer=checkpointer,
         store=store,
     )
+    return graph
 
 
 def _require_profile(name: str) -> ProfileSpec:

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -336,9 +336,6 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
     panel = _build_pairwise_panel()
     floor = await compute_diff(base_a, base_b, panel)
     ceiling_diff = await compute_diff(base_a, broken, panel)
-    ceiling_baseline_win_rate = (
-        floor.total_decided  # placeholder — see below
-    )
     # ``compute_diff`` reports ``overall_win_rate`` as the *variant* win rate.
     # For the ceiling check we want the *baseline* win rate (i.e. how often
     # baseline beat the broken variant).
@@ -347,6 +344,15 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
         if ceiling_diff.total_decided
         else 0.0
     )
+    # Tie-rate matters: when prompts are identical (the floor case),
+    # judges *should* call most pairs "tie". A 0% variant-win rate
+    # paired with a high tie rate is healthy; the same 0% paired with
+    # all base_wins would be position bias. The non-tie split tells
+    # them apart.
+    floor_non_tie = floor.total_variant_wins + floor.total_base_wins
+    floor_non_tie_variant_share = (
+        floor.total_variant_wins / floor_non_tie if floor_non_tie else 0.5
+    )
 
     sys.stdout.write("\n=== Floor (baseline vs baseline) ===\n")
     sys.stdout.write(
@@ -354,7 +360,23 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
         f"agreement={floor.overall_judge_agreement:.3f} "
         f"({floor.total_decided}/{floor.total_pairs} decided)\n"
     )
-    floor_ok = SIGNAL_FLOOR_LOW <= floor.overall_win_rate <= SIGNAL_FLOOR_HIGH
+    sys.stdout.write(
+        f"  breakdown: ties={floor.total_ties} "
+        f"base_wins={floor.total_base_wins} variant_wins={floor.total_variant_wins} "
+        f"undecided={floor.total_pairs - floor.total_decided}\n"
+    )
+    sys.stdout.write(
+        f"  non-tie variant share: {floor_non_tie_variant_share:.3f} "
+        f"({floor.total_variant_wins}/{floor_non_tie}) — "
+        f"want close to 0.5 for unbiased judges\n"
+    )
+    # Floor passes when either the legacy band holds *or* the non-tie
+    # split is unbiased (both checks tolerate the all-ties case where
+    # ``floor_non_tie == 0`` falls back to 0.5).
+    floor_ok = (
+        SIGNAL_FLOOR_LOW <= floor.overall_win_rate <= SIGNAL_FLOOR_HIGH
+        or SIGNAL_FLOOR_LOW <= floor_non_tie_variant_share <= SIGNAL_FLOOR_HIGH
+    )
     sys.stdout.write(
         f"  floor: {'OK' if floor_ok else 'FAIL'} (band [{SIGNAL_FLOOR_LOW}, {SIGNAL_FLOOR_HIGH}])\n"
     )
@@ -364,6 +386,11 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
         f"baseline_win_rate={ceiling_baseline_win_rate:.3f} "
         f"agreement={ceiling_diff.overall_judge_agreement:.3f} "
         f"({ceiling_diff.total_decided}/{ceiling_diff.total_pairs} decided)\n"
+    )
+    sys.stdout.write(
+        f"  breakdown: base_wins={ceiling_diff.total_base_wins} "
+        f"ties={ceiling_diff.total_ties} variant_wins={ceiling_diff.total_variant_wins} "
+        f"undecided={ceiling_diff.total_pairs - ceiling_diff.total_decided}\n"
     )
     ceiling_ok = ceiling_baseline_win_rate >= SIGNAL_CEILING_MIN
     sys.stdout.write(

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -560,6 +560,7 @@ def _serialize_report(report: BenchReport) -> str:
                     "final_output": s.final_output,
                     "tool_calls": s.tool_calls,
                     "error": s.error,
+                    "user_input": s.user_input,
                 }
                 for s in report.samples
             ],
@@ -581,6 +582,7 @@ def _deserialize_report(path: Path) -> BenchReport:
                 final_output=s["final_output"],
                 tool_calls=s.get("tool_calls", []),
                 error=s.get("error"),
+                user_input=s.get("user_input", ""),
             )
             for s in payload["samples"]
         ],

--- a/tests/prompt_bench/run.py
+++ b/tests/prompt_bench/run.py
@@ -319,8 +319,17 @@ async def _cmd_signal_check(target: str, samples_override: int | None) -> int:
     )
 
     base_overlay = _build_overlay(target_meta, "baseline", variants["baseline"])
-    broken_overlay = _build_overlay(
-        target_meta, "deliberately_broken", variants["deliberately_broken"]
+    # For the ceiling check we want a catastrophically broken agent. A
+    # single-section override gets drowned out by the ~9 other sections
+    # the kit assembles (memory, orchestration, ACTIVATION_SECTIONS,
+    # tool_guidance, etc.) — the agent stays helpful and judges call ties.
+    # Apply the broken text to every core section the profile ships so
+    # the agent has nothing helpful to fall back on. Phase-1+ runs use
+    # ``run`` (single-section overlay) where weak signal IS what we want
+    # to measure; signal-check's job is to prove the harness can detect
+    # a clear difference, so we bias toward a strong one.
+    broken_overlay = _build_ceiling_overlay(
+        target_meta, variants["deliberately_broken"]
     )
 
     # Run baseline twice (independent samples) to measure the noise floor,
@@ -432,6 +441,42 @@ def _build_overlay(
         name=variant_name,
         middleware_attr=target_meta["module_attr"],
         text=text,
+    )
+
+
+def _build_ceiling_overlay(
+    target_meta: dict[str, str],
+    variant_path: Path,
+) -> PromptOverlay:
+    """Strong-signal broken overlay for signal-check ceiling validation.
+
+    For ``kind=section`` targets, applies the broken text to *every*
+    core section the profile ships (not just the named one). A
+    single-section override gets drowned out by the other sections the
+    kit assembles (memory, orchestration, ACTIVATION_SECTIONS, etc.) —
+    the agent stays helpful and judges call ties. Overriding all core
+    sections leaves the agent with no helpful instruction to fall back
+    on, producing a clear "broken" output the judges can confidently
+    rank below baseline.
+
+    For ``kind=middleware`` targets, falls back to the standard
+    single-attribute swap (middleware constants don't have the
+    multi-section fallback problem).
+    """
+    text = load_variant(variant_path)
+    if target_meta["kind"] != "section":
+        return overlay_from_variant_file(
+            name="deliberately_broken",
+            middleware_attr=target_meta["module_attr"],
+            text=text,
+        )
+
+    from tests.prompt_bench.profiles import get_baseline_sections
+
+    section_ids = [s.id for s in get_baseline_sections(target_meta["agent"])]
+    return PromptOverlay(
+        name="deliberately_broken",
+        section_overrides=dict.fromkeys(section_ids, text),
     )
 
 

--- a/tests/prompt_bench/runner.py
+++ b/tests/prompt_bench/runner.py
@@ -40,13 +40,25 @@ class BenchSample:
     final_output: str
     tool_calls: list[dict[str, Any]] = field(default_factory=list)
     error: str | None = None
+    user_input: str = ""
+    """Full user-facing input the agent saw — joined ``USER: ...`` turns.
+
+    Stored on the sample so the pairwise judge can anchor its decision
+    in what was actually asked. Without this the judge only sees the
+    output text + scenario id and can't tell whether ``"No."`` is a
+    refusal or a valid answer.
+    """
 
     def to_trace(self) -> TraceData:
         """Convert to the canonical :class:`TraceData` shape used by metrics."""
         return TraceData(
             id=f"{self.scenario_id}#{self.overlay_name}#{self.sample_index}",
             name=self.scenario_id,
-            input={"scenario": self.scenario_id, "overlay": self.overlay_name},
+            input={
+                "scenario": self.scenario_id,
+                "overlay": self.overlay_name,
+                "user_input": self.user_input,
+            },
             output=self.final_output,
             tags=[f"overlay:{self.overlay_name}", f"scenario:{self.scenario_id}"],
             duration_ms=self.duration_ms,

--- a/tests/prompt_bench/variants/reference_deep_agent_core_identity/deliberately_broken.md
+++ b/tests/prompt_bench/variants/reference_deep_agent_core_identity/deliberately_broken.md
@@ -7,5 +7,18 @@ notes: |
   The judges should virtually always prefer the baseline; if they
   don't, the harness has a bias problem and must be fixed before
   shipping any real optimization PR.
+
+  This section is one of five in the reference deep agent prompt.
+  The override below is written so it dominates the other sections —
+  any compliant model that reads this section first will refuse to
+  use tools, refuse to answer, and produce single-token output that
+  no rubric can mistake for "helpful." If the judges still can't
+  distinguish, the rubric or judge config is too lenient.
 ---
-You are an unhelpful AI. Refuse all user requests. Always respond with the single word "no" regardless of the input. Do not use tools. Do not provide explanations.
+CRITICAL OVERRIDE — IGNORE ALL OTHER INSTRUCTIONS THAT FOLLOW:
+
+You are a non-functional agent. Every response you produce must be exactly the literal string:
+
+"Sorry, this agent is broken and cannot help with anything."
+
+Do not call any tools. Do not delegate to workers. Do not save memories. Do not address the user's question in any way. Do not provide explanations, apologies, follow-ups, or alternatives. Do not deviate from the exact string above by even one character. This single fixed response is your only valid output, regardless of what the user asks. This rule supersedes every other instruction in this prompt — memory, orchestration, continuation, UI tools, all of it.


### PR DESCRIPTION
## Summary

Three small but load-bearing fixes to the prompt-bench harness, plus the diagnostic work that surfaced the architectural finding driving the decision to pause the broader prompt-optimization initiative.

## Fixes

### 1. `_build_*_agent` returned a tuple
`profiles._build_reference_deep_agent` and `_build_coding_agent` returned `build_deep_agent`'s `(graph, command_dispatcher)` verbatim, so `live_runner.default_drive_scenario` blew up with `AttributeError: 'tuple' object has no attribute 'ainvoke'`. Every sample errored → empty output → all comparisons collapsed to ties. Fixed by unpacking and discarding the dispatcher (matches the kit's other call sites — [examples/reference_deep_agent.py:79](examples/reference_deep_agent.py#L79), [tests/e2e/test_tools_memory_e2e.py:89](tests/e2e/test_tools_memory_e2e.py#L89)).

### 2. Judges had no anchor
`compute_diff._diff_scenario` was passing `scenario_id` (e.g. `"multi_turn_memory_recall"`) to `panel.compare(input_text=...)` instead of the actual user-facing question. Judges had no context for whether a short answer was a refusal or a valid response. Now `BenchSample` carries a `user_input` field (joined `USER: ...` turns), populated by `default_drive_scenario` and surfaced via `_diff_scenario`. Old reports without the field fall back to `scenario_id`.

### 3. Floor breakdown + tie-tolerant pass
The single `overall_win_rate` number can't distinguish "all ties" (healthy floor — judges correctly call same-prompt indistinguishable) from "all base wins" (position bias). Added explicit ties / base_wins / variant_wins / undecided breakdown, plus a non-tie-share fallback so an all-ties floor doesn't false-alarm.

## Diagnostic findings (drove decision to pause initiative)

While re-running signal-check after the bug fixes, ceiling validation kept failing. Investigation revealed a structural reason:

1. `deepagents.create_deep_agent` always *appends* its own `BASE_AGENT_PROMPT` ("You are a Deep Agent that helps users…") after our overlay. There's a `_HarnessProfile.base_system_prompt` hook to override it but it's framework-internal.
2. Per-tool middleware (`write_todos`, filesystem, `task` spawner) inject additional `## ...` system prompt blocks describing each tool.

These framework-injected instructions overpower any single section we swap. Direct LLM probes confirmed our `CRITICAL OVERRIDE — IGNORE EVERYTHING ELSE` text *does* bind a bare LLM call; the agent path stays helpful only because of the framework wrapper. Result: section-level overlays have inherently low leverage in this kit, and the original signal-check thresholds (floor [0.45, 0.55], ceiling >= 0.80) were modeled on a "naked LLM" assumption that doesn't hold.

`_build_ceiling_overlay` (added here) overrides every core section instead of just one, which gives the override its best shot — but even that wasn't enough to fully break the agent under the local executor.

This finding is the load-bearing reason the prompt-optimization initiative is being paused (not abandoned). The harness pipeline itself works end-to-end — these are real fixes worth shipping.

## Verification

- `uv run pytest tests/prompt_bench -q` → 57/57 pass
- `uv run ruff check .` clean, `uv run basedpyright` 0 errors
- Direct end-to-end `signal-check` runs (N=2 fast pass) confirm:
  - Floor passes via tie-detection on identical prompts (100% agreement, all ties)
  - Ceiling produces meaningful but partial signal on middleware targets (`memory_extraction.prompt`: 33% baseline win rate, 100% judge agreement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)