### PR TITLE
feat(contrib): webhook trigger surface (#19 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Webhook trigger surface.** New `langgraph_kit.contrib.webhook`
+  module turns inbound HTTP webhooks into agent runs. Define a
+  `WebhookSpec(id, agent_id, secret, payload_template)`, register it
+  with a `WebhookRegistry`, mount the FastAPI router via
+  `create_webhook_router(registry, graph_resolver=...)`. The route
+  HMAC-SHA256-validates the request body against `secret` (GitHub
+  `X-Hub-Signature-256` convention by default; override per-spec for
+  Stripe, etc.), renders `payload_template` against the parsed JSON
+  body, and invokes the resolved agent on a fresh
+  `webhook-{id}-{uuid}` thread. HMAC validation is mandatory by
+  design — no anonymous-fire mode. `compute_signature` and
+  `verify_signature` are exported as pure helpers for senders writing
+  test fixtures. Cron-style scheduled triggers and Store-condition
+  watchers are tracked separately as follow-up issues. Closes part of
+  [#19](https://github.com/allada-homelab/langgraph-kit/issues/19).
+
 - **Prompt versioning + run-level version tagging.** `PromptSection`
   gains a free-form `version: str` field (default `"1"`,
   caller-controlled — not a content hash) and `SectionRegistry` now

--- a/src/langgraph_kit/contrib/webhook.py
+++ b/src/langgraph_kit/contrib/webhook.py
@@ -1,0 +1,306 @@
+"""Webhook trigger surface — invoke an agent from an HTTP webhook payload.
+
+A webhook spec ties a public webhook ID to an agent, a shared secret
+(for HMAC validation), and a payload template that renders the
+incoming JSON body into the user-message text the agent will see.
+
+Usage::
+
+    from langgraph_kit.contrib.webhook import (
+        WebhookSpec, WebhookRegistry, create_webhook_router,
+    )
+
+    registry = WebhookRegistry()
+    registry.register(WebhookSpec(
+        id="stripe-payment",
+        agent_id="payments-agent",
+        secret="whsec_xyz",
+        payload_template="A new payment arrived: {amount} {currency} from {customer_email}",
+    ))
+
+    app.include_router(
+        create_webhook_router(registry, graph_resolver=my_graph_lookup),
+        prefix="/api/v1",
+    )
+
+The router exposes ``POST /webhooks/{webhook_id}`` and:
+
+1. Looks up the spec; 404 if unknown.
+2. Validates the HMAC-SHA256 signature in ``signature_header`` against
+   the raw request body; 401 on mismatch or missing header.
+3. Renders ``payload_template`` against the parsed JSON body; 422 if a
+   placeholder isn't present in the payload.
+4. Invokes the resolved agent via ``graph.ainvoke`` with the rendered
+   text as the single user message and ``configurable.thread_id`` set
+   to a webhook-prefixed UUID.
+5. Returns ``{"thread_id": ..., "agent_id": ...}`` on success.
+
+Scope (issue #19 v1):
+
+- Webhook trigger only. Cron / Store-condition watchers are tracked
+  separately (see issue body for the full plan).
+- HMAC validation is mandatory — there's no "no-signature" mode by
+  design. A webhook that anyone on the internet can fire is a
+  trivially-abusable agent invocation surface.
+- Idempotency / dedup is the caller's responsibility; document a
+  request-id header convention in your webhook spec.
+"""
+
+# NOTE: intentionally does NOT use ``from __future__ import annotations`` —
+# FastAPI inspects route signatures via ``typing.get_type_hints()``,
+# which fails on string annotations whose names are only resolvable in
+# the route factory's closure (``Request`` is imported lazily inside
+# ``create_webhook_router``). See ``contrib/fastapi.py`` for the same
+# constraint elsewhere in the kit.
+
+import hashlib
+import hmac
+import logging
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from fastapi import APIRouter
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_SIGNATURE_HEADER = "X-Hub-Signature-256"
+"""Default header name for the HMAC signature.
+
+Matches GitHub's webhook convention so existing webhook-sender libraries
+work out of the box. Override per spec when integrating a service that
+uses a different header (Stripe → ``Stripe-Signature``, etc.).
+"""
+
+_SIGNATURE_PREFIX = "sha256="
+"""Expected prefix on the signature header value (GitHub convention).
+
+The header value is ``sha256=<hex digest>``. We strip the prefix before
+constant-time-compare; missing prefix → mismatch (don't try to be
+clever about format detection).
+"""
+
+
+class WebhookSpec(BaseModel):
+    """Configuration for one webhook endpoint.
+
+    Frozen because the registry uses (id) as a stable key — mutating an
+    in-flight spec would let a webhook fire against a different agent
+    than the one registered, with no audit trail.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    """Public path component for the webhook URL (``/webhooks/{id}``).
+
+    Treat as semi-secret — a leaked id plus a leaked secret allows
+    arbitrary agent invocations. Don't put PII or anything guessable
+    here.
+    """
+
+    agent_id: str
+    """Which registered agent the webhook fires against."""
+
+    secret: str
+    """Shared secret used to compute the expected HMAC-SHA256 over the
+    raw request body. The router compares this against the value in
+    ``signature_header`` using :func:`hmac.compare_digest`.
+
+    Rotate by re-registering the spec with a new secret; old senders
+    will start failing immediately (by design — silent grace periods
+    are how secret leaks become persistent).
+    """
+
+    payload_template: str = "{event}"
+    """``str.format``-style template rendered against the parsed JSON
+    body. The rendered string becomes the user message handed to the
+    agent. Default ``"{event}"`` expects a top-level ``event`` field;
+    override per-spec for richer rendering.
+
+    Placeholders that aren't present in the payload yield HTTP 422.
+    """
+
+    signature_header: str = _DEFAULT_SIGNATURE_HEADER
+    """HTTP header name carrying the HMAC signature.
+
+    Defaults to GitHub's convention; override per-service. Header
+    matching is case-insensitive (FastAPI normalizes headers).
+    """
+
+
+class WebhookRegistry:
+    """In-process registry of :class:`WebhookSpec` instances.
+
+    Persistence is intentionally out of scope for v1 — the registry is
+    initialized at FastAPI startup with whatever specs the app cares
+    about. Multi-worker deployments should construct the same set in
+    each worker (or shard by webhook id).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._specs: dict[str, WebhookSpec] = {}
+
+    def register(self, spec: WebhookSpec) -> None:
+        """Register *spec*. Re-registering an existing id replaces it."""
+        self._specs[spec.id] = spec
+
+    def get(self, webhook_id: str) -> WebhookSpec | None:
+        return self._specs.get(webhook_id)
+
+    def remove(self, webhook_id: str) -> None:
+        self._specs.pop(webhook_id, None)
+
+    def list_ids(self) -> list[str]:
+        return list(self._specs.keys())
+
+
+# ---------------------------------------------------------------------------
+# Signature + templating primitives (broken out so tests can exercise them
+# without spinning up a FastAPI app).
+# ---------------------------------------------------------------------------
+
+
+def compute_signature(secret: str, body: bytes) -> str:
+    """Return the canonical ``sha256=<hex>`` signature for *body*.
+
+    Pure helper — no I/O, no FastAPI deps. Useful for senders writing
+    test fixtures and for the router's verify path.
+    """
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"{_SIGNATURE_PREFIX}{digest}"
+
+
+def verify_signature(secret: str, body: bytes, header_value: str | None) -> bool:
+    """Constant-time-verify *header_value* against the expected HMAC of *body*.
+
+    Returns ``False`` for any of: missing header, missing prefix,
+    digest mismatch. Never raises — callers translate the boolean to
+    HTTP status.
+    """
+    if not header_value or not header_value.startswith(_SIGNATURE_PREFIX):
+        return False
+    expected = compute_signature(secret, body)
+    return hmac.compare_digest(expected, header_value)
+
+
+def render_payload(template: str, payload: dict[str, Any]) -> str:
+    """Render *template* with *payload* via ``str.format``.
+
+    Raises ``KeyError`` if a placeholder isn't present in the payload —
+    the router catches this and returns HTTP 422 with the missing key
+    in the detail. Avoid f-string-style nested attribute access in
+    templates; if the payload is nested, flatten it before passing in.
+    """
+    return template.format(**payload)
+
+
+# ---------------------------------------------------------------------------
+# FastAPI router factory.
+# ---------------------------------------------------------------------------
+
+
+def create_webhook_router(
+    registry: WebhookRegistry,
+    *,
+    graph_resolver: Callable[[str], Any],
+    prefix: str = "/webhooks",
+) -> "APIRouter":
+    # graph_resolver is ``(agent_id: str) -> compiled graph``. The
+    # router calls ``graph.ainvoke({"messages": [HumanMessage(...)]})``
+    # against the returned object, so anything that quacks like a
+    # LangGraph compiled graph works (real graph, mock for tests, etc.).
+
+    """Build a FastAPI router that turns webhook hits into agent runs.
+
+    Imports FastAPI lazily so the wider kit can be imported without it
+    (the rest of ``contrib/`` follows the same pattern).
+    """
+    from fastapi import APIRouter, HTTPException, Request, status
+    from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+        HumanMessage,
+    )
+
+    router = APIRouter(prefix=prefix, tags=["webhooks"])
+
+    @router.post("/{webhook_id}")
+    async def fire_webhook(webhook_id: str, request: Request) -> dict[str, str]:
+        spec = registry.get(webhook_id)
+        if spec is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Unknown webhook id: {webhook_id!r}",
+            )
+
+        body = await request.body()
+        provided_signature = request.headers.get(spec.signature_header)
+        if not verify_signature(spec.secret, body, provided_signature):
+            # Don't echo the expected signature in the error — that'd
+            # turn the 401 path into an oracle for forging signatures.
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or missing webhook signature",
+            )
+
+        try:
+            payload = await request.json()
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Webhook body is not valid JSON: {exc}",
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Webhook body must be a JSON object at the top level",
+            )
+
+        try:
+            rendered = render_payload(spec.payload_template, payload)
+        except KeyError as exc:
+            raise HTTPException(
+                # ``HTTP_422_UNPROCESSABLE_ENTITY`` was renamed in
+                # Starlette to ``HTTP_422_UNPROCESSABLE_CONTENT``; use
+                # the literal so we work across versions without
+                # tripping the deprecation warning under
+                # ``filterwarnings = ["error"]`` in pyproject.
+                status_code=422,
+                detail=(
+                    f"Webhook payload missing template placeholder: {exc.args[0]!r}"
+                ),
+            ) from exc
+
+        graph = graph_resolver(spec.agent_id)
+        thread_id = f"webhook-{spec.id}-{uuid.uuid4().hex[:12]}"
+        config = {"configurable": {"thread_id": thread_id}}
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content=rendered)]},
+            config=config,
+        )
+        logger.info(
+            "Webhook fired",
+            extra={
+                "webhook_id": spec.id,
+                "agent_id": spec.agent_id,
+                "thread_id": thread_id,
+            },
+        )
+        return {"thread_id": thread_id, "agent_id": spec.agent_id}
+
+    return router
+
+
+__all__ = [
+    "WebhookRegistry",
+    "WebhookSpec",
+    "compute_signature",
+    "create_webhook_router",
+    "render_payload",
+    "verify_signature",
+]

--- a/tests/test_contrib_webhook.py
+++ b/tests/test_contrib_webhook.py
@@ -1,0 +1,346 @@
+"""Tests for ``langgraph_kit.contrib.webhook`` — issue #19 v1.
+
+Covers the pure helpers (``compute_signature`` / ``verify_signature`` /
+``render_payload``) and the FastAPI router end-to-end via TestClient
+with a mock graph in place of a real compiled LangGraph.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from langgraph_kit.contrib.webhook import (
+    WebhookRegistry,
+    WebhookSpec,
+    compute_signature,
+    create_webhook_router,
+    render_payload,
+    verify_signature,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraph:
+    """Records each ``ainvoke`` call so tests can assert on what was sent."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+
+    async def ainvoke(
+        self, input_data: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        self.calls.append((input_data, config))
+        return {"messages": []}
+
+
+def _build_app(
+    registry: WebhookRegistry, graphs: dict[str, _FakeGraph]
+) -> tuple[FastAPI, dict[str, _FakeGraph]]:
+    app = FastAPI()
+    app.include_router(
+        create_webhook_router(
+            registry, graph_resolver=lambda agent_id: graphs[agent_id]
+        )
+    )
+    return app, graphs
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper coverage (no FastAPI required).
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureHelpers:
+    def test_compute_signature_round_trip(self) -> None:
+        sig = compute_signature("secret", b'{"event":"x"}')
+        assert sig.startswith("sha256=")
+        # Same body → same signature (HMAC determinism).
+        assert sig == compute_signature("secret", b'{"event":"x"}')
+
+    def test_verify_signature_happy_path(self) -> None:
+        body = b'{"event":"x"}'
+        sig = compute_signature("secret", body)
+        assert verify_signature("secret", body, sig) is True
+
+    def test_verify_signature_wrong_secret_rejected(self) -> None:
+        body = b'{"event":"x"}'
+        sig = compute_signature("right", body)
+        assert verify_signature("wrong", body, sig) is False
+
+    def test_verify_signature_tampered_body_rejected(self) -> None:
+        sig = compute_signature("secret", b'{"event":"original"}')
+        assert verify_signature("secret", b'{"event":"tampered"}', sig) is False
+
+    def test_verify_signature_missing_header_rejected(self) -> None:
+        assert verify_signature("secret", b"body", None) is False
+        assert verify_signature("secret", b"body", "") is False
+
+    def test_verify_signature_missing_prefix_rejected(self) -> None:
+        body = b"body"
+        digest = compute_signature("secret", body).removeprefix("sha256=")
+        # Bare hex without the ``sha256=`` prefix should fail — we don't
+        # try to be clever about format detection.
+        assert verify_signature("secret", body, digest) is False
+
+
+class TestPayloadTemplating:
+    def test_render_payload_simple_substitution(self) -> None:
+        rendered = render_payload("Hello, {name}!", {"name": "Alice"})
+        assert rendered == "Hello, Alice!"
+
+    def test_render_payload_multiple_placeholders(self) -> None:
+        rendered = render_payload(
+            "{amount} {currency} from {customer_email}",
+            {"amount": 42, "currency": "USD", "customer_email": "a@b.co"},
+        )
+        assert rendered == "42 USD from a@b.co"
+
+    def test_render_payload_missing_key_raises(self) -> None:
+        with pytest.raises(KeyError):
+            render_payload("{missing}", {"present": "x"})
+
+    def test_render_payload_no_placeholders_passes_through(self) -> None:
+        # Templates that don't reference the payload at all are valid —
+        # useful for "fire on any event with this fixed message" specs.
+        assert render_payload("ping", {"unrelated": "x"}) == "ping"
+
+
+# ---------------------------------------------------------------------------
+# WebhookRegistry coverage.
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookRegistry:
+    def test_register_then_get_returns_spec(self) -> None:
+        registry = WebhookRegistry()
+        spec = WebhookSpec(id="x", agent_id="agent", secret="s")
+        registry.register(spec)
+        assert registry.get("x") is spec
+
+    def test_get_unknown_id_returns_none(self) -> None:
+        assert WebhookRegistry().get("missing") is None
+
+    def test_register_replaces_existing_id(self) -> None:
+        registry = WebhookRegistry()
+        registry.register(WebhookSpec(id="x", agent_id="a", secret="old"))
+        registry.register(WebhookSpec(id="x", agent_id="a", secret="new"))
+        spec = registry.get("x")
+        assert spec is not None
+        assert spec.secret == "new"  # noqa: S105 - test fixture, not a real secret
+
+    def test_remove_drops_spec(self) -> None:
+        registry = WebhookRegistry()
+        registry.register(WebhookSpec(id="x", agent_id="a", secret="s"))
+        registry.remove("x")
+        assert registry.get("x") is None
+
+    def test_list_ids(self) -> None:
+        registry = WebhookRegistry()
+        registry.register(WebhookSpec(id="a", agent_id="x", secret="s"))
+        registry.register(WebhookSpec(id="b", agent_id="x", secret="s"))
+        assert sorted(registry.list_ids()) == ["a", "b"]
+
+    def test_webhook_spec_is_frozen(self) -> None:
+        spec = WebhookSpec(id="x", agent_id="a", secret="s")
+        with pytest.raises(Exception):  # noqa: B017,PT011 - Pydantic raises ValidationError on frozen-set
+            spec.secret = "changed"  # type: ignore[misc]  # noqa: S105 - test fixture
+
+
+# ---------------------------------------------------------------------------
+# Router behavior end-to-end.
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookRouter:
+    @staticmethod
+    def _setup() -> tuple[TestClient, _FakeGraph, WebhookSpec]:
+        spec = WebhookSpec(
+            id="hook1",
+            agent_id="payment-agent",
+            secret="whsec_top_secret",
+            payload_template="payment {amount} {currency}",
+        )
+        registry = WebhookRegistry()
+        registry.register(spec)
+        graph = _FakeGraph()
+        app, _ = _build_app(registry, {"payment-agent": graph})
+        return TestClient(app), graph, spec
+
+    def test_valid_signature_invokes_agent_and_returns_thread_id(self) -> None:
+        client, graph, spec = self._setup()
+        body = json.dumps({"amount": 42, "currency": "USD"}).encode()
+        sig = compute_signature(spec.secret, body)
+
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                spec.signature_header: sig,
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        body_resp = resp.json()
+        assert body_resp["agent_id"] == "payment-agent"
+        assert body_resp["thread_id"].startswith(f"webhook-{spec.id}-")
+
+        # Agent received the rendered template, not the raw payload.
+        assert len(graph.calls) == 1
+        input_data, config = graph.calls[0]
+        msgs = input_data["messages"]
+        assert len(msgs) == 1
+        assert msgs[0].content == "payment 42 USD"
+        assert config is not None
+        assert config["configurable"]["thread_id"] == body_resp["thread_id"]
+
+    def test_invalid_signature_rejected_without_invoking_agent(self) -> None:
+        client, graph, spec = self._setup()
+        body = json.dumps({"amount": 42, "currency": "USD"}).encode()
+
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                spec.signature_header: "sha256=deadbeef",
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 401
+        # Critical: agent was NOT invoked on auth failure.
+        assert graph.calls == []
+
+    def test_missing_signature_header_rejected(self) -> None:
+        client, graph, spec = self._setup()
+        body = json.dumps({"amount": 42, "currency": "USD"}).encode()
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code == 401
+        assert graph.calls == []
+
+    def test_unknown_webhook_id_returns_404(self) -> None:
+        client, _, spec = self._setup()
+        body = b"{}"
+        resp = client.post(
+            "/webhooks/nonexistent",
+            content=body,
+            headers={spec.signature_header: compute_signature(spec.secret, body)},
+        )
+        assert resp.status_code == 404
+
+    def test_invalid_json_body_returns_400(self) -> None:
+        client, graph, spec = self._setup()
+        body = b"not json at all"
+        sig = compute_signature(spec.secret, body)
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                spec.signature_header: sig,
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 400
+        assert graph.calls == []
+
+    def test_non_object_json_body_returns_400(self) -> None:
+        """Top-level array / string / number payloads aren't supported."""
+        client, graph, spec = self._setup()
+        body = b'["not", "an", "object"]'
+        sig = compute_signature(spec.secret, body)
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                spec.signature_header: sig,
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 400
+        assert graph.calls == []
+
+    def test_template_missing_placeholder_returns_422(self) -> None:
+        client, graph, spec = self._setup()
+        # Missing 'amount' — template references {amount} and {currency}.
+        body = json.dumps({"currency": "USD"}).encode()
+        sig = compute_signature(spec.secret, body)
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                spec.signature_header: sig,
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 422
+        assert "amount" in resp.json()["detail"]
+        assert graph.calls == []
+
+    def test_custom_signature_header_honored(self) -> None:
+        """Specs can override ``signature_header`` for non-GitHub services."""
+        spec = WebhookSpec(
+            id="stripe-hook",
+            agent_id="agent",
+            secret="s",
+            payload_template="{event}",
+            signature_header="X-Stripe-Signature",
+        )
+        registry = WebhookRegistry()
+        registry.register(spec)
+        graph = _FakeGraph()
+        app, _ = _build_app(registry, {"agent": graph})
+        client = TestClient(app)
+
+        body = json.dumps({"event": "charge.succeeded"}).encode()
+        # Sending under the default header should fail (auth missing
+        # under the configured header name).
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                "X-Hub-Signature-256": compute_signature(spec.secret, body),
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 401
+
+        # Under the configured header name, it succeeds.
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={
+                spec.signature_header: compute_signature(spec.secret, body),
+                "content-type": "application/json",
+            },
+        )
+        assert resp.status_code == 200
+        assert len(graph.calls) == 1
+        assert graph.calls[0][0]["messages"][0].content == "charge.succeeded"
+
+    def test_thread_ids_are_unique_per_fire(self) -> None:
+        """Two consecutive fires get distinct thread ids."""
+        client, _graph, spec = self._setup()
+        body = json.dumps({"amount": 1, "currency": "USD"}).encode()
+        sig = compute_signature(spec.secret, body)
+        resp1 = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={spec.signature_header: sig, "content-type": "application/json"},
+        )
+        resp2 = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={spec.signature_header: sig, "content-type": "application/json"},
+        )
+        assert resp1.status_code == resp2.status_code == 200
+        assert resp1.json()["thread_id"] != resp2.json()["thread_id"]


### PR DESCRIPTION
## Summary

Inbound HTTP webhooks now turn into agent runs through a focused `langgraph_kit.contrib.webhook` module. Cron-style scheduled triggers and Store-condition watchers from the same issue are tracked separately — webhooks are independently useful and don't depend on a shared abstraction layer.

Closes part of #19.

## Public surface

```python
from langgraph_kit.contrib.webhook import (
    WebhookSpec, WebhookRegistry, create_webhook_router,
    compute_signature, verify_signature, render_payload,
)

registry = WebhookRegistry()
registry.register(WebhookSpec(
    id="stripe-payment",
    agent_id="payments-agent",
    secret="whsec_xyz",
    payload_template="A new payment arrived: {amount} {currency} from {customer_email}",
))

app.include_router(
    create_webhook_router(registry, graph_resolver=my_graph_lookup),
    prefix="/api/v1",
)
```

The router exposes `POST /webhooks/{webhook_id}` and:

1. **404** on unknown webhook id.
2. **HMAC-SHA256** validate the request body against `secret` (GitHub's `X-Hub-Signature-256` convention by default; override per-spec for Stripe etc.) — **401** on mismatch or missing.
3. Parse JSON body — **400** on invalid JSON or non-object payload.
4. Render `payload_template` with `str.format(**payload)` — **422** with the missing key on placeholder gap.
5. Invoke the resolved agent on a fresh `webhook-{id}-{uuid}` thread.
6. **200** with `{"thread_id": ..., "agent_id": ...}`.

## Design choices

- **HMAC mandatory.** No anonymous-fire mode. A webhook anyone on the internet can hit is a trivially-abusable agent invocation surface; specs without a secret aren't expressible.
- **Pure helpers exported.** `compute_signature` / `verify_signature` / `render_payload` are importable on their own — useful for senders writing test fixtures and for callers building alternative webhook surfaces (e.g. their own Starlette routes) without duplicating the crypto.
- **In-process registry.** Persistence is out of scope for v1. Multi-worker deployments construct the same set in each worker or shard by webhook id.
- **`graph_resolver` is a callable.** Decouples the webhook router from `contrib/fastapi.py` internals (`_graph_var` ContextVar is module-private). Pass `lambda agent_id: my_lookup(agent_id)` — works with the existing FastAPI helpers but doesn't require them.
- **No `from __future__ import annotations`** in the new module — FastAPI inspects route signatures via `typing.get_type_hints()`, which fails on string annotations whose names are only resolvable in the route factory's closure (`Request` is imported lazily). Same constraint as `contrib/fastapi.py`; documented in the module docstring.

## Verification

- `uv run pytest` → **1224 / 1224** (was 1199; +25 webhook tests).
- `uv run ruff check .` clean, `uv run ruff format --check .` clean, `uv run basedpyright` 0 errors.

### 25 new tests cover

**`TestSignatureHelpers`** (6) — compute determinism, verify happy path, wrong secret rejected, tampered body rejected, missing/empty header rejected, missing `sha256=` prefix rejected.

**`TestPayloadTemplating`** (4) — simple substitution, multi-placeholder, missing key raises `KeyError`, no-placeholder template passes through.

**`TestWebhookRegistry`** (6) — register/get, get unknown returns None, register replaces same id, remove drops spec, list_ids, WebhookSpec is frozen.

**`TestWebhookRouter`** (9) — valid signature → agent invoked with rendered template + thread_id returned; invalid signature → 401 + agent NOT invoked; missing signature → 401 + no invocation; unknown webhook → 404; invalid JSON body → 400; non-object JSON → 400; missing template placeholder → 422 with key in detail; custom `signature_header` honored; two consecutive fires get distinct thread ids.

## Deferred (out of scope)

- **Cron-style `ScheduledTrigger`** (apscheduler-based) and **Store-condition `StoreConditionWatcher`** from the original issue plan. Each is its own dependency / API decision; will land as follow-up PRs. Webhook is the highest-leverage of the three (no new dependency, no scheduler-process coordination).
- **Audit-entry recording** per fire — depends on issue #24.
- **Idempotency / dedup** — caller's responsibility; document a request-id header convention in your webhook spec.

## Test plan

- [x] Full test suite passes (1224 / 1224)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format, basedpyright all clean
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
