### PR TITLE
chore(ci): stop labeler auto-tagging 'docs' on every CHANGELOG PR

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,14 +2,21 @@ docs:
   - all:
     - changed-files:
       - any-glob-to-any-file:
-        - '**/*.md'
+        # Match true documentation surfaces. CHANGELOG.md is intentionally
+        # excluded — it's updated alongside feature/fix PRs by convention,
+        # so matching it would auto-add ``docs`` to every functional PR
+        # and trip the "exactly 1 label" rule in check-labels.
+        - 'README.md'
+        - 'CONTRIBUTING.md'
         - 'docs/**'
         - 'mkdocs.yml'
+        - 'docs/**/*.md'
       - all-globs-to-all-files:
         - '!.github/**'
         - '!scripts/**'
         - '!.gitignore'
         - '!.pre-commit-config.yaml'
+        - '!CHANGELOG.md'
 
 internal:
   - all:


### PR DESCRIPTION
## Summary

Tightens the `docs` labeler rule so it stops auto-applying to every functional PR that touches `CHANGELOG.md`.

## The recurring nuisance

Every recent PR (#75, #77, #79, #80) needed a manual `docs` label removal + `check-labels` workflow rerun before merge. Root cause:

- `.github/labeler.yml` matches `docs` on `**/*.md` — too broad.
- Every functional PR updates `CHANGELOG.md` per project convention.
- Labeler also preserved the manually-set `feature`/`internal` label.
- Two labels on a PR trips `check-labels`' "exactly 1 of breaking/security/feature/bug/refactor/upgrade/docs/internal" rule.

## Fix

Two-part:

1. **Tighten the `any-glob-to-any-file` list** to true documentation surfaces only — `README.md`, `CONTRIBUTING.md`, `docs/**`, `docs/**/*.md`, `mkdocs.yml`. `**/*.md` was too broad — it caught every changelog plus the variant `baseline.md` files shipped with the prompt-bench harness.
2. **Add `!CHANGELOG.md` to `all-globs-to-all-files`** as belt-and-braces — even if a future glob accidentally matches CHANGELOG, the negation ensures the rule only fires on PRs that touch nothing *but* docs.

Internal label rule unchanged.

## Test plan

- [x] CI passes (the new `chore` label or `internal` should attach automatically; verify on this PR)
- [ ] Merge
- [ ] Subsequent feature PRs no longer get auto-tagged `docs` on top of their primary label

🤖 Generated with [Claude Code](https://claude.com/claude-code)