### PR TITLE
feat(visualization): static print_graph() helper (#21 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Static graph visualization.** New
+  `langgraph_kit.core.visualization.print_graph(graph, *, format=...,
+  expand_subgraphs=False)` returns Mermaid (default) or ASCII markup
+  for a compiled agent's structure. Thin wrapper over LangChain
+  Core's `Graph.draw_mermaid` / `draw_ascii` that adds: a single
+  kit-level entry point so callers don't have to memorize
+  `graph.get_graph().draw_mermaid()`; a `TypeError` with helpful
+  message when an uncompiled `StateGraph` is passed (common
+  mistake); an `expand_subgraphs` flag that maps to LangGraph's
+  `xray` for orchestration-heavy agents. ASCII output requires
+  `grandalf` at runtime (raises `ImportError` from LangChain Core
+  if unavailable). Live execution overlay (highlighting the
+  currently-running node via SSE) is tracked as a separate
+  follow-up. Closes part of
+  [#21](https://github.com/allada-homelab/langgraph-kit/issues/21).
+
 - **Multi-agent communication primitives.** Two new Store-backed
   modules under `langgraph_kit.core.orchestration`. `AgentWorkspace`
   is a typed Pydantic document with optimistic-concurrency `apatch`

--- a/src/langgraph_kit/core/visualization/__init__.py
+++ b/src/langgraph_kit/core/visualization/__init__.py
@@ -1,0 +1,16 @@
+"""Static visualization helpers for compiled agent graphs.
+
+Currently exposes :func:`print_graph` for rendering a
+``CompiledStateGraph``'s structure as Mermaid (default) or ASCII.
+Future work: live overlay of currently-executing nodes via SSE
+(tracked separately).
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.core.visualization.graph_render import (
+    GraphFormat,
+    print_graph,
+)
+
+__all__ = ["GraphFormat", "print_graph"]

--- a/src/langgraph_kit/core/visualization/graph_render.py
+++ b/src/langgraph_kit/core/visualization/graph_render.py
@@ -1,0 +1,116 @@
+"""Render a compiled LangGraph agent's static structure.
+
+The kit already ships trace-replay rendering
+(``langgraph_kit.core.tracing.mermaid``); this module is the
+*structure* counterpart — what does the graph *look like* before
+it runs, independent of any one execution.
+
+Usage::
+
+    from langgraph_kit.core.visualization import print_graph
+
+    graph = build_my_agent(checkpointer, store)
+    mermaid = print_graph(graph)
+    print(mermaid)  # paste into MkDocs / GitHub / mermaid.live
+
+    # ASCII (requires grandalf — install via langgraph-kit[viz] or grandalf):
+    print(print_graph(graph, format="ascii"))
+
+The actual rendering is delegated to LangChain Core's
+``Graph.draw_mermaid`` / ``Graph.draw_ascii`` (which the kit already
+takes as a transitive dependency); this wrapper adds:
+
+1. A consistent kit-level entry point so callers don't have to
+   memorize ``graph.get_graph().draw_mermaid()``.
+2. Validation that the input *is* a compiled graph (clear error
+   instead of an opaque ``AttributeError`` when someone passes the
+   uncompiled ``StateGraph``).
+3. An ``expand_subgraphs`` knob that maps to LangGraph's ``xray``
+   subgraph-introspection flag — useful for orchestration-heavy
+   agents where the supervisor's structure is opaque without it.
+
+Live execution overlay (``__node_entered__`` / ``__node_exited__``
+SSE events) is tracked as a separate follow-up; this PR ships the
+static side only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+GraphFormat = Literal["mermaid", "ascii"]
+"""Output formats accepted by :func:`print_graph`.
+
+* ``"mermaid"`` — text suitable for GitHub / MkDocs Mermaid blocks
+  and `mermaid.live <https://mermaid.live>`_. No extra dependency.
+* ``"ascii"`` — plaintext box-and-arrow rendering. Requires
+  ``grandalf`` at runtime (LangChain Core delegates to it). Install
+  via ``pip install grandalf`` or the kit's optional ``viz`` extra
+  if/when one is added — for now it's expected to be installed
+  alongside any tooling that wants ASCII output.
+"""
+
+
+def print_graph(
+    graph: Any,
+    *,
+    format: GraphFormat = "mermaid",  # noqa: A002 - "format" is the natural keyword for output format
+    expand_subgraphs: bool = False,
+    with_styles: bool = True,
+) -> str:
+    """Render *graph*'s static structure and return the markup.
+
+    Parameters
+    ----------
+    graph:
+        A LangGraph ``CompiledStateGraph`` (or anything else with a
+        ``get_graph()`` method that returns a LangChain Core
+        ``Graph``). The kit's ``build_*_agent`` functions return
+        compatible objects.
+    format:
+        See :data:`GraphFormat`.
+    expand_subgraphs:
+        Pass ``True`` to recurse into compiled subgraphs (LangGraph's
+        ``xray=True``). Useful for supervisor / orchestration agents
+        where the top-level node hides delegation structure. Defaults
+        to ``False`` so a "what does this agent look like?" rendering
+        stays small.
+    with_styles:
+        ``mermaid`` only — toggles the default node-coloring CSS
+        injected by LangChain Core. Pass ``False`` when embedding in
+        a context that supplies its own theme. Ignored for ASCII.
+
+    Returns
+    -------
+    str
+        The markup. ``"flowchart TD"`` (Mermaid) or a multi-line
+        box-and-arrow ASCII drawing.
+
+    Raises
+    ------
+    TypeError
+        If *graph* lacks a ``get_graph`` method — almost certainly
+        means an uncompiled ``StateGraph`` was passed instead of the
+        compiled output.
+    ValueError
+        If *format* isn't one of :data:`GraphFormat`'s values.
+    """
+    if not hasattr(graph, "get_graph"):
+        msg = (
+            f"print_graph expected a compiled graph (with .get_graph()); "
+            f"got {type(graph).__name__}. Did you forget to call .compile()?"
+        )
+        raise TypeError(msg)
+
+    drawable = graph.get_graph(xray=expand_subgraphs)
+
+    if format == "mermaid":
+        return drawable.draw_mermaid(with_styles=with_styles)
+    if format == "ascii":
+        return drawable.draw_ascii()
+
+    msg = f"Unsupported format {format!r}; expected one of: mermaid, ascii"
+    raise ValueError(msg)
+
+
+__all__ = ["GraphFormat", "print_graph"]

--- a/tests/test_visualization_graph_render.py
+++ b/tests/test_visualization_graph_render.py
@@ -1,0 +1,163 @@
+"""Tests for ``langgraph_kit.core.visualization.print_graph`` (issue #21 v1)."""
+
+# NOTE: intentionally does NOT use ``from __future__ import annotations`` —
+# LangGraph's ``StateGraph`` evaluates the TypedDict's ``Annotated`` field
+# at runtime via ``typing.get_type_hints()``, which needs live type objects
+# (matches the same constraint already documented in
+# ``tests/test_replay_runner.py``).
+
+from typing import Annotated, Any
+
+import pytest
+from langgraph.checkpoint.memory import (  # pyright: ignore[reportMissingImports]
+    InMemorySaver,
+)
+from langgraph.graph import (  # pyright: ignore[reportMissingModuleSource]
+    END,
+    START,
+    StateGraph,
+)
+from langgraph.graph.message import (  # pyright: ignore[reportMissingModuleSource]
+    add_messages,
+)
+from typing_extensions import TypedDict
+
+from langgraph_kit.core.visualization import print_graph
+
+
+class _SimpleState(TypedDict):
+    messages: Annotated[list[Any], add_messages]
+
+
+def _build_simple_graph() -> Any:
+    """Two-node toy graph: START -> alpha -> beta -> END."""
+
+    async def alpha(state: dict, _config: Any) -> dict:
+        return {"messages": []}
+
+    async def beta(state: dict, _config: Any) -> dict:
+        return {"messages": []}
+
+    builder = StateGraph(_SimpleState)
+    builder.add_node("alpha", alpha)  # pyright: ignore[reportArgumentType]
+    builder.add_node("beta", beta)  # pyright: ignore[reportArgumentType]
+    builder.add_edge(START, "alpha")
+    builder.add_edge("alpha", "beta")
+    builder.add_edge("beta", END)
+    return builder.compile(checkpointer=InMemorySaver())
+
+
+# ---------------------------------------------------------------------------
+# Happy path — Mermaid
+# ---------------------------------------------------------------------------
+
+
+class TestPrintGraphMermaid:
+    def test_returns_mermaid_flowchart_for_simple_graph(self) -> None:
+        graph = _build_simple_graph()
+        markup = print_graph(graph)
+        # Modern LangChain Core wraps the diagram in a Mermaid YAML
+        # frontmatter (``---\nconfig:\n...---``) followed by the
+        # ``graph TD`` / ``flowchart TD`` block. Either prefix means
+        # we got Mermaid markup.
+        assert "graph TD" in markup or "flowchart TD" in markup, markup[:80]
+        # Both node names should appear in the output.
+        assert "alpha" in markup
+        assert "beta" in markup
+
+    def test_includes_styles_by_default(self) -> None:
+        """``with_styles=True`` emits the default node-coloring CSS."""
+        graph = _build_simple_graph()
+        styled = print_graph(graph)
+        unstyled = print_graph(graph, with_styles=False)
+        # Styled output should be longer (extra ``classDef`` / ``class``
+        # lines from LangChain Core's default styling).
+        assert len(styled) > len(unstyled)
+
+    def test_explicit_format_mermaid_works(self) -> None:
+        graph = _build_simple_graph()
+        explicit = print_graph(graph, format="mermaid")
+        default = print_graph(graph)
+        assert explicit == default
+
+
+# ---------------------------------------------------------------------------
+# Happy path — ASCII (skipped if grandalf isn't installed)
+# ---------------------------------------------------------------------------
+
+
+class TestPrintGraphAscii:
+    def test_renders_ascii_when_grandalf_available(self) -> None:
+        pytest.importorskip("grandalf")
+        graph = _build_simple_graph()
+        markup = print_graph(graph, format="ascii")
+        # ASCII renderings include node names verbatim.
+        assert "alpha" in markup
+        assert "beta" in markup
+
+
+# ---------------------------------------------------------------------------
+# Validation / error paths
+# ---------------------------------------------------------------------------
+
+
+class TestPrintGraphValidation:
+    def test_uncompiled_graph_raises_typeerror_with_helpful_message(self) -> None:
+        """Passing a ``StateGraph`` (not its ``.compile()`` output) is a common mistake."""
+        builder = StateGraph(_SimpleState)
+        builder.add_edge(START, END)
+        # Don't call .compile(); pass the builder directly.
+        with pytest.raises(TypeError, match=r"forget to call \.compile"):
+            print_graph(builder)
+
+    def test_unknown_format_raises_valueerror(self) -> None:
+        graph = _build_simple_graph()
+        with pytest.raises(ValueError, match="Unsupported format"):
+            print_graph(graph, format="dot")  # type: ignore[arg-type]
+
+    def test_non_graphlike_object_raises_typeerror(self) -> None:
+        with pytest.raises(TypeError, match=r"\.compile"):
+            print_graph(object())
+
+
+# ---------------------------------------------------------------------------
+# expand_subgraphs flag
+# ---------------------------------------------------------------------------
+
+
+class TestPrintGraphSubgraphs:
+    def test_expand_subgraphs_calls_get_graph_with_xray(self) -> None:
+        """Verify the kwarg gets translated correctly to LangGraph's xray flag."""
+        # Use a minimal stand-in instead of a real subgraph since constructing one
+        # adds a lot of boilerplate; just spy on the get_graph kwargs.
+        captured: dict[str, Any] = {}
+
+        class FakeDrawable:
+            def draw_mermaid(self, *, with_styles: bool = True) -> str:
+                _ = with_styles
+                return "graph TD\n  A --> B\n"
+
+        class FakeGraph:
+            def get_graph(self, xray: bool = False) -> FakeDrawable:
+                captured["xray"] = xray
+                return FakeDrawable()
+
+        markup = print_graph(FakeGraph(), expand_subgraphs=True)
+        assert "graph TD" in markup
+        assert captured["xray"] is True
+
+    def test_expand_subgraphs_default_false(self) -> None:
+        captured: dict[str, Any] = {}
+
+        class FakeDrawable:
+            def draw_mermaid(self, *, with_styles: bool = True) -> str:
+                _ = with_styles
+                return "graph TD\n"
+
+        class FakeGraph:
+            def get_graph(self, xray: bool = False) -> FakeDrawable:
+                captured["xray"] = xray
+                return FakeDrawable()
+
+        print_graph(FakeGraph())
+        assert captured["xray"] is False


### PR DESCRIPTION
## Summary

Adds the static-structure half of issue #21. Live overlay (highlighting the currently-executing node via SSE) is tracked as a separate follow-up — that part needs SSE plumbing decisions and a sample HTML viewer; static rendering is independently useful right now (docs, debugging, "what does this agent look like?").

Closes part of #21.

## What lands

```python
from langgraph_kit.core.visualization import print_graph

graph = build_my_agent(checkpointer, store)
print(print_graph(graph))                                # Mermaid (default)
print(print_graph(graph, format="ascii"))                # ASCII (needs `grandalf`)
print(print_graph(graph, expand_subgraphs=True))         # xray subgraphs
print(print_graph(graph, with_styles=False))             # no default Mermaid CSS
```

- Default `format="mermaid"` works without extras (LangChain Core ships `Graph.draw_mermaid`).
- `format="ascii"` requires `grandalf` at runtime; the kit doesn't add it as a hard dep.
- `expand_subgraphs=True` maps to LangGraph's `xray` flag so supervisor / orchestration agents can be introspected past the top-level wrapper node.

## Why a wrapper instead of telling people to use `draw_mermaid()`

Three small but real wins:

1. **Single kit-level entry point** — callers don't have to memorize `graph.get_graph().draw_mermaid(with_styles=True)`.
2. **Helpful `TypeError`** when someone passes an uncompiled `StateGraph` (the common mistake) instead of an opaque `AttributeError`.
3. **Future-proofing** — the planned live-overlay PR has somewhere to attach without API churn.

The wrapper itself is ~20 lines; the value is in the entry-point shape, not the implementation.

## Verification

- `uv run pytest` → **1263 / 1263 pass + 1 skip** (grandalf optional). +8 new tests.
- `uv run ruff check .` clean, `uv run ruff format --check .` clean (after running `ruff format .` upfront — same lesson as PR #84), `uv run basedpyright` 0 errors.

### 8 new tests

- Mermaid happy path renders `graph TD` / `flowchart TD` with both node names visible.
- `with_styles=True` produces longer markup than `False` (LangChain Core's `classDef` styling).
- Explicit `format="mermaid"` matches default.
- ASCII path renders both node names — gated on `grandalf` importable via `pytest.importorskip`.
- Uncompiled `StateGraph` raises `TypeError` with helpful "forget to call .compile" message.
- Unknown format raises `ValueError` with the supported list.
- Non-graph object raises `TypeError` (no `.get_graph` attr).
- `expand_subgraphs=True` translates to `xray=True` on `get_graph` (verified via spy fake; default is `xray=False`).

## Deferred (out of scope)

- **Live execution overlay** (`__node_entered__` / `__node_exited__` SSE events plus a sample HTML viewer that toggles a CSS class on the active node). Tracked separately — needs SSE event-shape decisions that don't belong in the static rendering PR.
- **Sequence-mode child-rendering "bug"** mentioned in the original issue plan — investigated and the recursion at `mermaid.py:51` already drains children for LLM/tool spans; only nested *chain* spans are skipped, which is current intended behavior. If a clearer acceptance criterion surfaces, file a separate issue.
- **CLI `langgraph-kit graph <agent-id>`** subcommand. Tiny wrapper around `print_graph`; defer until someone needs it.

## Test plan

- [x] Full test suite passes (1263 / 1263)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format, basedpyright all clean
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
