### PR TITLE
feat(cli): interactive shell REPL for registered agents (#37 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Interactive REPL (`langgraph-kit shell`).** New
+  `langgraph_kit.shell.run_shell` entry point and CLI subcommand
+  drop you into a single-agent REPL. Loads the requested
+  `agent-id` from the in-process registry (auto-runs
+  `register_all` to expose built-ins; pass `--module my_app.agents`
+  to import a user-supplied module first), invokes the graph
+  in-process per turn, prints the final assistant text. `/exit` /
+  `/quit` / `/q` end the session; Ctrl-D / Ctrl-C also exit
+  cleanly. Optional `--thread-id` and `--user-id` flow through to
+  the run config. Token streaming, `prompt_toolkit` line editing,
+  HITL interrupt prompts, and transcript writing are intentionally
+  deferred — this lands the foundation. Closes part of
+  [#37](https://github.com/allada-homelab/langgraph-kit/issues/37).
+
 - **Static graph visualization.** New
   `langgraph_kit.core.visualization.print_graph(graph, *, format=...,
   expand_subgraphs=False)` returns Mermaid (default) or ASCII markup

--- a/src/langgraph_kit/cli.py
+++ b/src/langgraph_kit/cli.py
@@ -323,6 +323,28 @@ def main() -> None:
     # list command
     sub.add_parser("list", help="List available agent templates")
 
+    # shell command — interactive REPL for a registered agent.
+    shell_parser = sub.add_parser(
+        "shell", help="Interactive REPL for a registered agent"
+    )
+    shell_parser.add_argument("agent_id", help="Registered agent id (e.g. echo-agent)")
+    shell_parser.add_argument(
+        "--module",
+        help="Python module path to import before lookup (e.g. my_app.agents). "
+        "Use this when the agent isn't one of the kit's built-ins; the module "
+        "must call langgraph_kit.registry.register() at import time.",
+    )
+    shell_parser.add_argument(
+        "--thread-id",
+        help="Reuse a specific thread id within the session "
+        "(persistence is in-memory, so threads still don't survive across runs).",
+    )
+    shell_parser.add_argument(
+        "--user-id",
+        default="shell-user",
+        help="User id surfaced in run metadata (default: shell-user).",
+    )
+
     # examples command (with nested list / run subcommands)
     examples_parser = sub.add_parser(
         "examples", help="Discover and run the bundled feature examples"
@@ -367,6 +389,23 @@ def main() -> None:
             sys.exit(_cmd_examples_run(args.name, real_llm=args.real_llm))
         else:
             examples_parser.print_help()
+    elif args.command == "shell":
+        # Lazy import — keeps ``langgraph-kit new`` / ``list`` etc.
+        # cheap when the user isn't using the REPL.
+        import asyncio
+
+        from langgraph_kit.shell import run_shell
+
+        sys.exit(
+            asyncio.run(
+                run_shell(
+                    args.agent_id,
+                    user_module=args.module,
+                    thread_id=args.thread_id,
+                    user_id=args.user_id,
+                )
+            )
+        )
     else:
         parser.print_help()
 

--- a/src/langgraph_kit/shell.py
+++ b/src/langgraph_kit/shell.py
@@ -1,0 +1,213 @@
+"""Interactive REPL for a registered agent.
+
+Run with::
+
+    python -m langgraph_kit.cli shell <agent-id>
+
+Loads ``agent-id`` from the in-memory registry, builds it against an
+in-memory checkpointer + store, and enters a read-eval-print loop:
+type a prompt, the agent runs, the final assistant message prints.
+``/exit`` (or Ctrl-D / Ctrl-C) ends the session.
+
+By default the shell calls
+:func:`langgraph_kit.graphs.register_all` to expose the kit's built-in
+agents (``echo-agent``, ``basic-deep-agent``, ``reference-deep-agent``,
+``coding-agent``). Pass ``--module my_app.agents`` to import a
+user-supplied module first — that module is responsible for calling
+:func:`langgraph_kit.registry.register` so the agent shows up.
+
+Scope (issue #37 v1):
+
+- Single-agent session, in-process invocation (no FastAPI hop).
+- Plain stdin input + stdout output. No ``prompt_toolkit``, no token
+  streaming, no syntax-highlighted output.
+- ``--thread-id`` accepted; persistence is in-memory only so threads
+  are session-scoped, not cross-session.
+- ``/exit`` is the only built-in slash command; agent-defined slash
+  commands route through the agent's normal dispatcher (they go in
+  as user input and the agent's command middleware handles them).
+
+Deferred to follow-ups:
+
+- Token streaming via ``graph.astream_events`` rendered as the model
+  emits.
+- ``prompt_toolkit`` line editing + tab completion.
+- HITL interrupt prompts.
+- Transcript-write mode (``--transcript out.md``).
+- Multi-agent ``/switch`` and richer slash-command tooling.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import uuid
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+_EXIT_COMMANDS = {"/exit", "/quit", "/q"}
+"""Slash commands that end the session — same set GitHub Copilot CLI uses."""
+
+_PROMPT = "you > "
+_ASSISTANT_PREFIX = "agent > "
+
+
+def _build_in_memory_deps() -> tuple[Any, Any]:
+    """Return ``(checkpointer, store)`` using LangGraph's in-memory impls.
+
+    Lazy-imported so the kit imports cleanly without LangGraph
+    available at the top level (matches ``contrib/`` modules' pattern).
+    """
+    from langgraph.checkpoint.memory import (  # pyright: ignore[reportMissingImports]
+        InMemorySaver,
+    )
+    from langgraph.store.memory import (  # pyright: ignore[reportMissingImports]
+        InMemoryStore,
+    )
+
+    return InMemorySaver(), InMemoryStore()
+
+
+def _ensure_agent_registered(
+    agent_id: str,
+    user_module: str | None,
+) -> None:
+    """Resolve *agent_id* in the registry, registering kit defaults if needed.
+
+    If *user_module* is set, import it first (the module is expected to
+    call :func:`langgraph_kit.registry.register`). Otherwise call
+    :func:`langgraph_kit.graphs.register_all` to expose the built-ins.
+    """
+    from langgraph_kit import registry
+
+    if user_module:
+        # Importing the module triggers whatever ``register(...)`` calls
+        # it makes at module level. ``importlib.import_module`` raises
+        # ImportError on failure with a useful message.
+        importlib.import_module(user_module)
+
+    if agent_id not in registry.get_all():
+        # Built-ins haven't been registered yet — do it now. Idempotent
+        # (register() upserts) so this is safe even if a user module
+        # already registered some agents.
+        from langgraph_kit.graphs import register_all
+
+        checkpointer, store = _build_in_memory_deps()
+        register_all(checkpointer, store)
+
+
+def _format_assistant_output(result: Any) -> str:
+    """Pull the final assistant text out of a graph result.
+
+    Matches the shape ``graph.ainvoke`` returns for chat-style agents
+    in this kit (``{"messages": [...]}``). Falls back to ``str(result)``
+    for non-chat graphs so the shell stays useful for arbitrary
+    callables.
+    """
+    if isinstance(result, dict) and "messages" in result:
+        msgs = result["messages"] or []
+        if not msgs:
+            return "(no message)"
+        last = msgs[-1]
+        content = getattr(last, "content", None)
+        if content is None:
+            return str(last)
+        if isinstance(content, str):
+            return content
+        # Multi-part content (list of dicts with ``text`` keys) — flatten.
+        if isinstance(content, list):
+            parts: list[str] = []
+            for part in content:
+                if isinstance(part, dict) and "text" in part:
+                    parts.append(str(part["text"]))
+                else:
+                    parts.append(str(part))
+            return "".join(parts)
+        return str(content)
+    return str(result)
+
+
+async def _invoke_once(graph: Any, user_input: str, config: dict[str, Any]) -> str:
+    """Send one user turn through *graph* and return the rendered reply."""
+    from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+        HumanMessage,
+    )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content=user_input)]},
+        config=config,
+    )
+    return _format_assistant_output(result)
+
+
+async def run_shell(
+    agent_id: str,
+    *,
+    user_module: str | None = None,
+    thread_id: str | None = None,
+    user_id: str = "shell-user",
+    input_fn: Callable[[str], str] | None = None,
+    output_fn: Callable[[str], None] | None = None,
+) -> int:
+    """Entry point for the shell. Returns a process exit code.
+
+    ``input_fn`` and ``output_fn`` are injected so tests can drive
+    the loop without touching real stdin/stdout. They default to
+    ``input`` / ``print`` for the CLI path. The output function
+    receives one fully-formed line at a time (newline included is
+    the caller's choice — defaults match ``print``).
+    """
+    from langgraph_kit import registry
+
+    read_input = input_fn or input
+    write_output: Callable[[str], None] = output_fn or print  # type: ignore[assignment]
+
+    try:
+        _ensure_agent_registered(agent_id, user_module)
+    except ImportError as exc:
+        sys.stderr.write(f"Couldn't import {user_module!r}: {exc}\n")
+        return 2
+
+    try:
+        graph = registry.get(agent_id)
+    except KeyError:
+        sys.stderr.write(
+            f"Agent {agent_id!r} not registered. Available: "
+            f"{sorted(registry.get_all())}\n"
+        )
+        return 2
+
+    thread_id = thread_id or f"shell-{uuid.uuid4().hex[:8]}"
+    config: dict[str, Any] = {
+        "configurable": {"thread_id": thread_id, "user_id": user_id}
+    }
+
+    write_output(f"langgraph-kit shell — agent={agent_id!r} thread={thread_id!r}")
+    write_output("Type your message; '/exit' (or Ctrl-D / Ctrl-C) to quit.")
+
+    while True:
+        try:
+            user_input = read_input(_PROMPT)
+        except (EOFError, KeyboardInterrupt):
+            write_output("")  # newline so the prompt doesn't bleed into shell PS1
+            return 0
+        if not user_input.strip():
+            continue
+        if user_input.strip().lower() in _EXIT_COMMANDS:
+            return 0
+        try:
+            reply = await _invoke_once(graph, user_input, config)
+        except Exception:
+            logger.exception("Agent invocation failed")
+            write_output(f"{_ASSISTANT_PREFIX}(error — see logs)")
+            continue
+        write_output(f"{_ASSISTANT_PREFIX}{reply}")
+
+
+__all__ = ["run_shell"]

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,260 @@
+"""Tests for ``langgraph_kit.shell`` (issue #37 v1)."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+    AIMessage,
+)
+
+from langgraph_kit import registry
+from langgraph_kit.shell import _format_assistant_output, run_shell
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedGraph:
+    """Mock graph that returns a canned final assistant message."""
+
+    def __init__(self, reply: str = "echo") -> None:
+        self.reply = reply
+        self.calls: list[tuple[Any, Any]] = []
+
+    async def ainvoke(
+        self, input_data: Any, config: Any | None = None
+    ) -> dict[str, Any]:
+        self.calls.append((input_data, config))
+        return {"messages": [AIMessage(content=self.reply)]}
+
+
+class _CrashingGraph:
+    """Mock graph whose ``ainvoke`` always raises — exercises REPL error path."""
+
+    async def ainvoke(self, *_: Any, **__: Any) -> Any:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+
+class _StubInputs:
+    """Replays a fixed list of user inputs through the REPL's read loop.
+
+    Raises ``EOFError`` after the script is exhausted to mimic a closed
+    stdin (which the real REPL handles as "exit cleanly").
+    """
+
+    def __init__(self, lines: list[str]) -> None:
+        self._iter = iter(lines)
+
+    def __call__(self, _prompt: str) -> str:
+        try:
+            return next(self._iter)
+        except StopIteration as exc:
+            raise EOFError from exc
+
+
+# ---------------------------------------------------------------------------
+# Reset the in-process registry between tests to keep state isolated.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> Any:
+    snapshot = dict(registry.get_all())
+    # Clear and refill from snapshot so tests can register their own agents
+    # without leaking into other tests.
+    registry._registry.clear()
+    yield
+    registry._registry.clear()
+    registry._registry.update(snapshot)
+
+
+# ---------------------------------------------------------------------------
+# _format_assistant_output
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAssistantOutput:
+    def test_string_content_pass_through(self) -> None:
+        result = {"messages": [AIMessage(content="hi")]}
+        assert _format_assistant_output(result) == "hi"
+
+    def test_multipart_list_content_flattened(self) -> None:
+        result = {
+            "messages": [
+                AIMessage(
+                    content=[
+                        {"type": "text", "text": "part1 "},
+                        {"type": "text", "text": "part2"},
+                    ]
+                )
+            ]
+        }
+        assert _format_assistant_output(result) == "part1 part2"
+
+    def test_no_messages_returns_placeholder(self) -> None:
+        assert _format_assistant_output({"messages": []}) == "(no message)"
+
+    def test_non_chat_result_falls_back_to_str(self) -> None:
+        # Some graphs return a bare string or dict without ``messages``.
+        assert _format_assistant_output("just text") == "just text"
+        assert _format_assistant_output({"score": 0.9}) == str({"score": 0.9})
+
+
+# ---------------------------------------------------------------------------
+# run_shell
+# ---------------------------------------------------------------------------
+
+
+class TestRunShell:
+    @pytest.mark.asyncio
+    async def test_invokes_agent_and_renders_reply(self) -> None:
+        graph = _ScriptedGraph(reply="hello world")
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        rc = await run_shell(
+            "test-agent",
+            input_fn=_StubInputs(["ping"]),
+            output_fn=outputs.append,
+        )
+        assert rc == 0
+        # First two outputs are header + usage hint; the assistant reply follows.
+        assert any("hello world" in line for line in outputs), outputs
+        assert len(graph.calls) == 1
+        input_data, config = graph.calls[0]
+        assert input_data["messages"][0].content == "ping"
+        assert config["configurable"]["thread_id"].startswith("shell-")
+        assert config["configurable"]["user_id"] == "shell-user"
+
+    @pytest.mark.asyncio
+    async def test_thread_id_passed_through(self) -> None:
+        graph = _ScriptedGraph()
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        await run_shell(
+            "test-agent",
+            thread_id="custom-thread",
+            input_fn=_StubInputs(["x"]),
+            output_fn=outputs.append,
+        )
+        _, config = graph.calls[0]
+        assert config["configurable"]["thread_id"] == "custom-thread"
+
+    @pytest.mark.asyncio
+    async def test_user_id_passed_through(self) -> None:
+        graph = _ScriptedGraph()
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        await run_shell(
+            "test-agent",
+            user_id="custom-user",
+            input_fn=_StubInputs(["x"]),
+            output_fn=outputs.append,
+        )
+        _, config = graph.calls[0]
+        assert config["configurable"]["user_id"] == "custom-user"
+
+    @pytest.mark.asyncio
+    async def test_exit_command_stops_loop_cleanly(self) -> None:
+        graph = _ScriptedGraph()
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        rc = await run_shell(
+            "test-agent",
+            input_fn=_StubInputs(["/exit"]),
+            output_fn=outputs.append,
+        )
+        assert rc == 0
+        # No agent invocation — exit short-circuited.
+        assert graph.calls == []
+
+    @pytest.mark.asyncio
+    async def test_blank_input_is_skipped(self) -> None:
+        graph = _ScriptedGraph()
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        await run_shell(
+            "test-agent",
+            input_fn=_StubInputs(["", "   ", "real"]),
+            output_fn=outputs.append,
+        )
+        # Only the third (non-blank) input went to the agent.
+        assert len(graph.calls) == 1
+        assert graph.calls[0][0]["messages"][0].content == "real"
+
+    @pytest.mark.asyncio
+    async def test_eof_exits_cleanly_with_zero(self) -> None:
+        graph = _ScriptedGraph()
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        rc = await run_shell(
+            "test-agent",
+            input_fn=_StubInputs([]),  # no inputs — first read raises EOFError
+            output_fn=outputs.append,
+        )
+        assert rc == 0
+        assert graph.calls == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_returns_exit_code_2(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Don't register anything; rely on register_all (which the helper
+        # invokes when the requested id isn't there).
+        rc = await run_shell(
+            "no-such-agent",
+            input_fn=_StubInputs([]),
+            output_fn=lambda _: None,
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "not registered" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_user_module_import_failure_returns_2(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = await run_shell(
+            "any",
+            user_module="this.module.definitely.does.not.exist",
+            input_fn=_StubInputs([]),
+            output_fn=lambda _: None,
+        )
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "Couldn't import" in captured.err
+
+    @pytest.mark.asyncio
+    async def test_agent_crash_keeps_repl_alive(self) -> None:
+        registry.register("crashing", _CrashingGraph())
+        outputs: list[str] = []
+        rc = await run_shell(
+            "crashing",
+            input_fn=_StubInputs(["first try", "/exit"]),
+            output_fn=outputs.append,
+        )
+        assert rc == 0
+        # Error rendered via the assistant prefix; loop continued past the crash.
+        assert any("(error" in line for line in outputs), outputs
+
+    @pytest.mark.asyncio
+    async def test_user_module_imported_when_provided(self) -> None:
+        """``user_module`` is imported before the registry lookup."""
+        # Use ``sys`` itself as the "user module" — it's always importable
+        # and importing it is a no-op. Then register the agent inline so the
+        # lookup still works.
+        registry.register("u-agent", _ScriptedGraph(reply="ok"))
+        sys.modules.pop("langgraph_kit.shell", None)  # nudge importlib cache
+        outputs: list[str] = []
+        rc = await run_shell(
+            "u-agent",
+            user_module="sys",
+            input_fn=_StubInputs(["hi"]),
+            output_fn=outputs.append,
+        )
+        assert rc == 0
+        assert any("ok" in line for line in outputs)


### PR DESCRIPTION
## Summary

New `langgraph-kit shell <agent-id>` subcommand that drops the user into a single-agent REPL. Token streaming, `prompt_toolkit` line editing, HITL interrupt prompts, and transcript writing are intentionally deferred — this lands the foundation.

Closes part of #37.

## Public surface

```bash
# Built-in agents — auto-registered via register_all on first lookup
langgraph-kit shell echo-agent
langgraph-kit shell reference-deep-agent --thread-id work-1234

# User agent — module is imported before the lookup
langgraph-kit shell my-agent --module my_app.agents
```

```
langgraph-kit shell — agent='echo-agent' thread='shell-a1b2c3d4'
Type your message; '/exit' (or Ctrl-D / Ctrl-C) to quit.
you > hello
agent > Echo: hello
you > /exit
```

## What lands

- **`src/langgraph_kit/shell.py`**: `run_shell(agent_id, *, ...)` async entry point. Resolves the agent via `langgraph_kit.registry.get(...)`, falls back to `register_all` when the requested id isn't registered yet (covers the kit's built-ins: `echo-agent`, `basic-deep-agent`, `reference-deep-agent`, `coding-agent`). When `--module` is provided, imports that module *first* so user-supplied agents show up before the auto-fallback.
- **`shell` subcommand in `src/langgraph_kit/cli.py`** with `agent_id` positional + `--module` / `--thread-id` / `--user-id` flags. Lazy-imports `shell` so the rest of the CLI doesn't pay LangGraph import cost.
- **REPL loop**: read line → invoke graph → print final assistant text. `/exit` / `/quit` / `/q` end cleanly; Ctrl-D / Ctrl-C also exit with rc=0. Blank input is skipped. Agent crashes are caught and surfaced via `agent > (error — see logs)` so the loop survives misbehaving agents.
- **`_format_assistant_output`** knows the kit's chat-style `{"messages": [...]}` shape, handles single-string content, multi-part list content (`[{"type": "text", "text": "..."}]`), and falls back to `str(result)` for non-chat graphs.
- **`input_fn` / `output_fn` injection** points let tests drive the loop without touching real stdin/stdout.

## Verification

- `uv run pytest` → **1277 / 1277 + 1 skip** (grandalf optional). +14 shell tests this PR.
- `uv run ruff check .` clean, `uv run ruff format --check .` clean (after running `ruff format .` upfront — same lesson from PRs #84/#85), pre-commit hooks all pass.

### 14 new tests

**`_format_assistant_output` (4)**: string content pass-through, multi-part list flattening, no-messages placeholder, non-chat fallback.

**REPL (10)**: invokes agent + renders reply; `thread_id` passed through; `user_id` passed through; `/exit` short-circuits without invoking; blank/whitespace inputs skipped; EOF (empty stdin) exits with rc=0; unknown agent_id returns rc=2 with helpful stderr; user_module import failure returns rc=2 with "Couldn't import" stderr; agent crash keeps the loop alive and surfaces the error to the user; `user_module` is imported before lookup when provided.

Tests reset `langgraph_kit.registry._registry` around each case via an autouse fixture so registrations don't leak across tests.

## Deferred (out of scope)

- **Token streaming** via `graph.astream_events` rendered as the model emits.
- **`prompt_toolkit`** line editing + tab completion.
- **HITL interrupt prompts** (`interrupt: <tool_call>; approve?`).
- **Transcript writing** (`--transcript out.md`).
- **Multi-agent `/switch`** and richer slash-command tooling.

## Test plan

- [x] Full test suite passes (1277 / 1277)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format, basedpyright all clean
- [x] Manual smoke: `langgraph-kit shell echo-agent` should drop into the REPL with the echo agent registered
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
