### PR TITLE
feat(cli): openapi subcommand to dump FastAPI router spec (#39 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **`langgraph-kit openapi` subcommand.** Mounts the agent router on
+  a temporary FastAPI app and dumps `app.openapi()` as JSON, either
+  to stdout or to `--output spec.json`. `--indent 0` emits compact
+  JSON for machine consumers. The `get_current_user` dependency is
+  stubbed during introspection so the command works without auth
+  config — only the route shape and request/response schemas
+  matter for the spec. Foundation for issue #40 (typed SDK
+  generation via `openapi-python-client`). Closes part of
+  [#39](https://github.com/allada-homelab/langgraph-kit/issues/39).
+
 - **Interactive REPL (`langgraph-kit shell`).** New
   `langgraph_kit.shell.run_shell` entry point and CLI subcommand
   drop you into a single-agent REPL. Loads the requested

--- a/src/langgraph_kit/cli.py
+++ b/src/langgraph_kit/cli.py
@@ -272,6 +272,70 @@ def _cmd_examples_list() -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# openapi — dump the FastAPI router's spec
+# ---------------------------------------------------------------------------
+
+
+def _cmd_openapi(output: Path | None = None, indent: int = 2) -> int:
+    """Mount the agent router on a temporary FastAPI app and dump its spec.
+
+    The spec describes the request/response schemas (``InvokeRequest``,
+    ``InvokeResponse``, ``QueueMessageRequest`` etc.) plus all routes
+    declared by ``create_agent_router`` — exactly what
+    ``app.openapi()`` would surface at runtime, just emitted to a file
+    so it can be fed into ``openapi-python-client`` /
+    ``openapi-generator-cli`` without spinning up a server. This is the
+    foundation #40 (typed SDK) consumes.
+
+    The ``get_current_user`` dependency is stubbed with a permissive
+    callable that returns a dict — the spec doesn't need real auth, it
+    only needs enough type information for FastAPI to introspect the
+    routes. ``indent=0`` emits compact JSON for machine consumers.
+    """
+    import json
+    from typing import Annotated
+
+    try:
+        from fastapi import Depends, FastAPI
+    except ImportError:
+        sys.stderr.write(
+            "openapi requires fastapi. Install via "
+            "``pip install langgraph-kit[fastapi]``.\n"
+        )
+        return 2
+
+    from langgraph_kit.contrib.fastapi import create_agent_router
+
+    def _stub_user() -> dict[str, str]:
+        return {"id": "openapi-introspection", "email": "openapi@example.invalid"}
+
+    current_user_dep = Annotated[dict[str, str], Depends(_stub_user)]
+
+    app = FastAPI(
+        title="langgraph-kit",
+        description=(
+            "Agent runtime endpoints. Generated via "
+            "``python -m langgraph_kit.cli openapi``."
+        ),
+    )
+    app.include_router(create_agent_router(get_current_user=current_user_dep))
+    spec = app.openapi()
+
+    text = (
+        json.dumps(spec, indent=indent if indent > 0 else None)
+        if indent > 0
+        else json.dumps(spec, separators=(",", ":"))
+    )
+
+    if output is not None:
+        output.write_text(text + "\n", encoding="utf-8")
+        _out(f"Wrote OpenAPI spec to {output}")
+    else:
+        _out(text)
+    return 0
+
+
 def _cmd_examples_run(name: str, *, real_llm: bool = False) -> int:
     examples_dir = _examples_dir()
     if examples_dir is None:
@@ -322,6 +386,23 @@ def main() -> None:
 
     # list command
     sub.add_parser("list", help="List available agent templates")
+
+    # openapi command — dump the OpenAPI spec for the FastAPI router.
+    openapi_parser = sub.add_parser(
+        "openapi", help="Dump the FastAPI agent router's OpenAPI spec"
+    )
+    openapi_parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Write the spec to this file instead of stdout.",
+    )
+    openapi_parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indent level (default 2; pass 0 for compact).",
+    )
 
     # shell command — interactive REPL for a registered agent.
     shell_parser = sub.add_parser(
@@ -389,6 +470,8 @@ def main() -> None:
             sys.exit(_cmd_examples_run(args.name, real_llm=args.real_llm))
         else:
             examples_parser.print_help()
+    elif args.command == "openapi":
+        sys.exit(_cmd_openapi(output=args.output, indent=args.indent))
     elif args.command == "shell":
         # Lazy import — keeps ``langgraph-kit new`` / ``list`` etc.
         # cheap when the user isn't using the REPL.

--- a/tests/test_cli_openapi.py
+++ b/tests/test_cli_openapi.py
@@ -1,0 +1,77 @@
+"""Tests for the ``langgraph-kit openapi`` subcommand (issue #39 v1)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from langgraph_kit.cli import _cmd_openapi
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+class TestOpenapiCommand:
+    def test_stdout_emits_valid_openapi_3x_document(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = _cmd_openapi()
+        assert rc == 0
+        out = capsys.readouterr().out
+        spec = json.loads(out)
+        assert spec["openapi"].startswith("3."), spec.get("openapi")
+        assert spec["info"]["title"] == "langgraph-kit"
+        # Paths exist and at least one agent route is present.
+        assert "paths" in spec
+        assert any("agents" in path for path in spec["paths"]), (
+            f"no /agents path in {sorted(spec['paths'])}"
+        )
+
+    def test_output_writes_file_when_path_given(self, tmp_path: Path) -> None:
+        out_file = tmp_path / "spec.json"
+        rc = _cmd_openapi(output=out_file)
+        assert rc == 0
+        assert out_file.exists()
+        spec = json.loads(out_file.read_text())
+        assert "paths" in spec
+        # File ends with a newline (POSIX-friendly).
+        assert out_file.read_text().endswith("\n")
+
+    def test_indent_zero_emits_compact_json(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = _cmd_openapi(indent=0)
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Compact JSON has no inline whitespace after separators.
+        assert ": " not in out  # default ``json.dumps`` uses ", " and ": "
+        # Still parseable.
+        json.loads(out)
+
+    def test_indent_default_is_human_friendly(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = _cmd_openapi(indent=2)
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Indented output puts opening brace on its own line and uses 2-space indent.
+        assert out.startswith("{\n")
+        assert "  " in out
+
+    def test_components_schemas_include_kit_request_response_models(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The kit's Pydantic request/response models should appear in components.
+
+        Concrete check: ``InvokeRequest`` and ``InvokeResponse`` are referenced
+        by routes the agent router exposes, so FastAPI must include them in
+        ``components.schemas``. Confirms the spec is rich enough to drive
+        ``openapi-python-client`` (issue #40).
+        """
+        _cmd_openapi()
+        spec = json.loads(capsys.readouterr().out)
+        schemas = spec.get("components", {}).get("schemas", {})
+        assert "InvokeRequest" in schemas, sorted(schemas)
+        assert "InvokeResponse" in schemas, sorted(schemas)


### PR DESCRIPTION
## Summary

New `langgraph-kit openapi` subcommand. Tiny, focused — mounts the agent router on a temporary FastAPI app, calls `app.openapi()`, emits JSON. Foundation for issue #40 (typed SDK generation via `openapi-python-client`).

Closes part of #39.

## Public surface

```bash
langgraph-kit openapi                                    # JSON to stdout (indent=2)
langgraph-kit openapi --output spec.json                 # write to file
langgraph-kit openapi --output spec.json --indent 0      # compact JSON for tools
```

## What lands

- `openapi` subcommand in `src/langgraph_kit/cli.py` with `--output PATH` and `--indent N` flags.
- `_cmd_openapi` helper:
  - **Lazy-imports FastAPI**; surfaces a clear "install `langgraph-kit[fastapi]`" error when missing.
  - **Stubs the `get_current_user` dependency** with a permissive callable returning a dict — introspection doesn't need real auth, just enough type info for FastAPI to walk the routes.
  - `--indent 0` emits compact JSON (`json.dumps(spec, separators=(",", ":"))`); `--indent 2` (default) is human-friendly.
  - File output appends a trailing newline (POSIX convention) and prints a confirmation message; stdout output is the JSON only.

## Verification

- `uv run pytest` → **1282 / 1282 + 1 skip** (grandalf optional). +5 openapi tests this PR.
- `uv run ruff check .` clean (after moving annotation-only test imports into `TYPE_CHECKING`), `uv run ruff format --check .` clean.

### 5 new tests

- Stdout emits a valid OpenAPI 3.x document with at least one `/agents` path.
- `--output PATH` writes the spec to a file (with trailing newline).
- `--indent 0` emits compact JSON (no inline whitespace); output still parses.
- `--indent 2` (default) emits indented JSON with the opening brace on its own line.
- `components.schemas` includes `InvokeRequest` and `InvokeResponse` — concrete check that the spec is rich enough to drive `openapi-python-client` generation (#40 dependency).

## Deferred (out of scope)

- Generated-client recipe doc page (separate docs PR).
- Per-endpoint request/response model audit (route docstrings could be richer; not blocking spec generation today).
- SSE event-shape documentation in the spec (OpenAPI doesn't model `text/event-stream` elegantly; recipe doc covers it when it lands).

## Test plan

- [x] Full test suite passes (1282 / 1282)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format clean
- [x] Manual smoke: `uv run langgraph-kit openapi | head` returns a valid OpenAPI 3.x doc
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)