### PR TITLE
feat(config): validate_config + langgraph-kit validate-config CLI (#41 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Config validation (`validate_config` + `langgraph-kit
+  validate-config`).** New `langgraph_kit._config.validate_config(cfg)
+  returns a frozen `ValidationReport(errors, warnings, is_ok)` without
+  raising; the CLI subcommand prints both lists and exits 1 on errors,
+  0 on warnings-only, 0 on clean. Catches: bad / empty `database_url`
+  scheme (sqlite, postgresql, postgresql+psycopg only), empty
+  `llm_model`, negative `token_budget_per_thread` /
+  `shutdown_timeout_seconds`, unknown `prompt_injection_mode` /
+  `output_safety_mode` (typos that silently fall through to defaults
+  today), Langfuse public/secret key mismatch (warn — tracing
+  silently disables), `langfuse_tracing_enabled=True` without
+  complete credentials (error), invalid `mcp_servers` JSON. Pure
+  function — no I/O. Lifespan integration and Pydantic migration of
+  `AgentConfig` are intentionally deferred to follow-ups; this lands
+  the validator + CLI surface so callers can run pre-flight checks
+  today. Closes part of
+  [#41](https://github.com/allada-homelab/langgraph-kit/issues/41).
+
 - **`langgraph-kit openapi` subcommand.** Mounts the agent router on
   a temporary FastAPI app and dumps `app.openapi()` as JSON, either
   to stdout or to `--output spec.json`. `--indent 0` emits compact

--- a/src/langgraph_kit/_config.py
+++ b/src/langgraph_kit/_config.py
@@ -192,3 +192,154 @@ def _coerce(field: dataclasses.Field[Any], value: Any) -> Any:
     if field.type == "str" and not isinstance(value, str):
         return str(value)
     return value
+
+
+# ---------------------------------------------------------------------------
+# Configuration validation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Result of running :func:`validate_config` against an :class:`AgentConfig`.
+
+    Two-tier surface: ``errors`` would prevent the kit from running
+    correctly (bad URL scheme, negative budget); ``warnings`` are
+    suspicious but not fatal (Langfuse public key set without secret,
+    embedding-fn unset when memory is heavily used).
+
+    Frozen so callers can hand the report around without worrying
+    about downstream mutation. Helpers like :py:meth:`is_ok` keep the
+    common "did anything fail?" check terse.
+    """
+
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def is_ok(self) -> bool:
+        """``True`` iff no errors. Warnings don't fail this gate."""
+        return not self.errors
+
+
+_VALID_DB_SCHEMES = ("sqlite://", "postgresql://", "postgresql+psycopg://")
+"""URL schemes ``create_persistence`` recognizes. SQLite for dev,
+Postgres (with the optional psycopg driver suffix) for production.
+Unknown schemes silently fall through to "checkpointer + store can't
+be built" failures deep in the stack — better to catch up front."""
+
+
+_VALID_PROMPT_INJECTION_MODES = ("off", "warn")
+"""Modes accepted by :pyattr:`AgentConfig.prompt_injection_mode`.
+
+The ``"quarantine"`` mode is reserved for a follow-up PR; if a caller
+sets it today the scanner falls back to ``"warn"`` semantics. Validate
+against the actual accepted set so typos are caught."""
+
+
+_VALID_OUTPUT_SAFETY_MODES = ("off", "warn", "redact")
+"""Modes accepted by :pyattr:`AgentConfig.output_safety_mode`."""
+
+
+def validate_config(cfg: AgentConfig) -> ValidationReport:
+    """Surface configuration mistakes without raising.
+
+    Returns a :class:`ValidationReport` with separate ``errors`` and
+    ``warnings`` tuples. Caller decides what to do — the kit's CLI
+    ``validate-config`` subcommand prints both and exits non-zero on
+    errors; production callers can wire this into their startup path
+    for fail-loud-and-early behavior.
+
+    Pure function — no I/O, no side effects. A separate
+    ``--check-connections`` pass that actually opens the database is
+    deferred to a follow-up; it would change this contract.
+
+    Checks performed:
+
+    1. ``database_url`` uses a recognized scheme.
+    2. ``llm_model`` is non-empty (every code path needs one).
+    3. ``token_budget_per_thread`` is non-negative.
+    4. ``shutdown_timeout_seconds`` is non-negative.
+    5. ``prompt_injection_mode`` is one of :data:`_VALID_PROMPT_INJECTION_MODES`.
+    6. ``output_safety_mode`` is one of :data:`_VALID_OUTPUT_SAFETY_MODES`.
+    7. Langfuse keys appear in matching pairs; loud warning when only
+       one half is set (the kit silently disables tracing in that
+       case, which is a reliable source of confusion).
+    8. ``langfuse_tracing_enabled=True`` requires both keys; warns
+       when tracing is on but credentials are incomplete.
+    9. ``mcp_servers`` parses as JSON when non-empty.
+    """
+    import json  # local import — keeps validation cheap when not invoked
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # 1. database_url scheme
+    if not cfg.database_url:
+        errors.append("database_url is empty; set a sqlite:// or postgresql:// URL")
+    elif not cfg.database_url.startswith(_VALID_DB_SCHEMES):
+        errors.append(
+            f"database_url uses an unsupported scheme: {cfg.database_url!r} "
+            f"(expected one of {_VALID_DB_SCHEMES})"
+        )
+
+    # 2. llm_model
+    if not cfg.llm_model:
+        errors.append("llm_model is empty; the kit requires a default model")
+
+    # 3-4. Numeric bounds
+    if cfg.token_budget_per_thread < 0:
+        errors.append(
+            f"token_budget_per_thread must be >= 0 (0 = unlimited); "
+            f"got {cfg.token_budget_per_thread}"
+        )
+    if cfg.shutdown_timeout_seconds < 0:
+        errors.append(
+            f"shutdown_timeout_seconds must be >= 0 "
+            f"(0 = cancel immediately); got {cfg.shutdown_timeout_seconds}"
+        )
+
+    # 5-6. Mode strings
+    if cfg.prompt_injection_mode not in _VALID_PROMPT_INJECTION_MODES:
+        errors.append(
+            f"prompt_injection_mode={cfg.prompt_injection_mode!r} "
+            f"is not one of {_VALID_PROMPT_INJECTION_MODES}"
+        )
+    if cfg.output_safety_mode not in _VALID_OUTPUT_SAFETY_MODES:
+        errors.append(
+            f"output_safety_mode={cfg.output_safety_mode!r} "
+            f"is not one of {_VALID_OUTPUT_SAFETY_MODES}"
+        )
+
+    # 7. Langfuse pair consistency
+    has_public = bool(cfg.langfuse_public_key)
+    has_secret = bool(cfg.langfuse_secret_key)
+    if has_public and not has_secret:
+        warnings.append(
+            "langfuse_public_key is set but langfuse_secret_key is empty; "
+            "Langfuse tracing will be disabled at runtime"
+        )
+    elif has_secret and not has_public:
+        warnings.append(
+            "langfuse_secret_key is set but langfuse_public_key is empty; "
+            "Langfuse tracing will be disabled at runtime"
+        )
+
+    # 8. Tracing-enabled guard
+    if cfg.langfuse_tracing_enabled:
+        if not has_public or not has_secret:
+            errors.append(
+                "langfuse_tracing_enabled=True requires both "
+                "langfuse_public_key and langfuse_secret_key"
+            )
+        if not cfg.langfuse_host:
+            errors.append("langfuse_tracing_enabled=True requires a langfuse_host URL")
+
+    # 9. mcp_servers JSON
+    if cfg.mcp_servers:
+        try:
+            json.loads(cfg.mcp_servers)
+        except ValueError as exc:
+            errors.append(f"mcp_servers is not valid JSON: {exc}")
+
+    return ValidationReport(errors=tuple(errors), warnings=tuple(warnings))

--- a/src/langgraph_kit/cli.py
+++ b/src/langgraph_kit/cli.py
@@ -273,6 +273,41 @@ def _cmd_examples_list() -> int:
 
 
 # ---------------------------------------------------------------------------
+# validate-config — surface AgentConfig issues without raising
+# ---------------------------------------------------------------------------
+
+
+def _cmd_validate_config() -> int:
+    """Print the active config's validation report; exit non-zero on errors.
+
+    Reads the live config via :func:`get_config` so this checks
+    whatever ``configure(...)`` was last called with — typically the
+    config the running app would use. Pure check (no DB connection,
+    no LLM call); a future ``--check-connections`` flag can layer on
+    network probes.
+
+    Exit codes:
+
+    * ``0`` — clean, or warnings only.
+    * ``1`` — at least one error; deployment should not proceed.
+    """
+    from langgraph_kit._config import get_config, validate_config
+
+    report = validate_config(get_config())
+    for warning in report.warnings:
+        sys.stderr.write(f"WARN: {warning}\n")
+    for error in report.errors:
+        sys.stderr.write(f"FAIL: {error}\n")
+    if report.errors:
+        return 1
+    if report.warnings:
+        sys.stderr.write(f"Config valid with {len(report.warnings)} warning(s).\n")
+    else:
+        _out("Config is valid.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # openapi — dump the FastAPI router's spec
 # ---------------------------------------------------------------------------
 
@@ -387,6 +422,12 @@ def main() -> None:
     # list command
     sub.add_parser("list", help="List available agent templates")
 
+    # validate-config command — surface AgentConfig issues without raising.
+    sub.add_parser(
+        "validate-config",
+        help="Check the active AgentConfig for errors and warnings",
+    )
+
     # openapi command — dump the OpenAPI spec for the FastAPI router.
     openapi_parser = sub.add_parser(
         "openapi", help="Dump the FastAPI agent router's OpenAPI spec"
@@ -470,6 +511,8 @@ def main() -> None:
             sys.exit(_cmd_examples_run(args.name, real_llm=args.real_llm))
         else:
             examples_parser.print_help()
+    elif args.command == "validate-config":
+        sys.exit(_cmd_validate_config())
     elif args.command == "openapi":
         sys.exit(_cmd_openapi(output=args.output, indent=args.indent))
     elif args.command == "shell":

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,216 @@
+"""Tests for ``langgraph_kit._config.validate_config`` (issue #41 v1)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langgraph_kit._config import (
+    AgentConfig,
+    ValidationReport,
+    validate_config,
+)
+from langgraph_kit.cli import _cmd_validate_config
+
+if TYPE_CHECKING:
+    import pytest
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigHappy:
+    def test_default_config_passes(self) -> None:
+        """The bare ``AgentConfig()`` should validate clean — defaults are sane."""
+        report = validate_config(AgentConfig())
+        assert report.errors == ()
+        assert report.warnings == ()
+        assert report.is_ok is True
+
+    def test_postgres_url_accepted(self) -> None:
+        cfg = AgentConfig(database_url="postgresql://user:pw@localhost/db")
+        assert validate_config(cfg).errors == ()
+
+    def test_postgres_psycopg_driver_accepted(self) -> None:
+        """The ``+psycopg`` SQLAlchemy driver suffix is the kit's preferred shape."""
+        cfg = AgentConfig(database_url="postgresql+psycopg://user:pw@localhost/db")
+        assert validate_config(cfg).errors == ()
+
+
+# ---------------------------------------------------------------------------
+# Field-level errors
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigErrors:
+    def test_unknown_db_scheme_is_error(self) -> None:
+        cfg = AgentConfig(database_url="mysql://localhost/db")
+        report = validate_config(cfg)
+        assert any("database_url" in e and "scheme" in e for e in report.errors), report
+
+    def test_empty_db_url_is_error(self) -> None:
+        cfg = AgentConfig(database_url="")
+        report = validate_config(cfg)
+        assert any("database_url is empty" in e for e in report.errors), report
+
+    def test_empty_llm_model_is_error(self) -> None:
+        cfg = AgentConfig(llm_model="")
+        report = validate_config(cfg)
+        assert any("llm_model is empty" in e for e in report.errors), report
+
+    def test_negative_token_budget_is_error(self) -> None:
+        cfg = AgentConfig(token_budget_per_thread=-1)
+        report = validate_config(cfg)
+        assert any("token_budget_per_thread" in e for e in report.errors), report
+
+    def test_negative_shutdown_timeout_is_error(self) -> None:
+        cfg = AgentConfig(shutdown_timeout_seconds=-0.5)
+        report = validate_config(cfg)
+        assert any("shutdown_timeout_seconds" in e for e in report.errors), report
+
+    def test_invalid_prompt_injection_mode_is_error(self) -> None:
+        cfg = AgentConfig(prompt_injection_mode="quarantine")
+        report = validate_config(cfg)
+        assert any("prompt_injection_mode" in e for e in report.errors), report
+
+    def test_invalid_output_safety_mode_is_error(self) -> None:
+        cfg = AgentConfig(output_safety_mode="strip")
+        report = validate_config(cfg)
+        assert any("output_safety_mode" in e for e in report.errors), report
+
+    def test_invalid_mcp_servers_json_is_error(self) -> None:
+        cfg = AgentConfig(mcp_servers="not json")
+        report = validate_config(cfg)
+        assert any("mcp_servers" in e and "JSON" in e for e in report.errors), report
+
+    def test_valid_mcp_servers_json_no_error(self) -> None:
+        cfg = AgentConfig(mcp_servers='{"servers": []}')
+        assert validate_config(cfg).errors == ()
+
+
+# ---------------------------------------------------------------------------
+# Cross-field warnings
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigWarnings:
+    def test_langfuse_public_only_warns(self) -> None:
+        cfg = AgentConfig(langfuse_public_key="pk_x")
+        report = validate_config(cfg)
+        assert report.errors == ()
+        assert any(
+            "langfuse_public_key" in w and "secret_key" in w for w in report.warnings
+        ), report
+
+    def test_langfuse_secret_only_warns(self) -> None:
+        cfg = AgentConfig(langfuse_secret_key="sk_x")
+        report = validate_config(cfg)
+        assert report.errors == ()
+        assert any(
+            "langfuse_secret_key" in w and "public_key" in w for w in report.warnings
+        ), report
+
+    def test_langfuse_complete_pair_no_warning(self) -> None:
+        cfg = AgentConfig(
+            langfuse_public_key="pk_x",
+            langfuse_secret_key="sk_x",
+            langfuse_host="https://cloud.langfuse.com",
+        )
+        report = validate_config(cfg)
+        assert report.errors == ()
+        # Public/secret pair complete; no Langfuse-related warnings.
+        assert not any("langfuse" in w.lower() for w in report.warnings), report
+
+
+# ---------------------------------------------------------------------------
+# Cross-field tracing-enabled guard
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigTracingEnabled:
+    def test_tracing_enabled_without_keys_is_error(self) -> None:
+        cfg = AgentConfig(langfuse_tracing_enabled=True)
+        report = validate_config(cfg)
+        assert any(
+            "tracing_enabled" in e and "secret_key" in e for e in report.errors
+        ), report
+
+    def test_tracing_enabled_without_host_is_error(self) -> None:
+        cfg = AgentConfig(
+            langfuse_tracing_enabled=True,
+            langfuse_public_key="pk",
+            langfuse_secret_key="sk",
+        )
+        report = validate_config(cfg)
+        assert any(
+            "tracing_enabled" in e and "langfuse_host" in e for e in report.errors
+        ), report
+
+    def test_tracing_enabled_with_full_config_clean(self) -> None:
+        cfg = AgentConfig(
+            langfuse_tracing_enabled=True,
+            langfuse_public_key="pk",
+            langfuse_secret_key="sk",
+            langfuse_host="https://cloud.langfuse.com",
+        )
+        assert validate_config(cfg).errors == ()
+
+
+# ---------------------------------------------------------------------------
+# ValidationReport semantics
+# ---------------------------------------------------------------------------
+
+
+class TestValidationReport:
+    def test_is_ok_true_when_no_errors_even_with_warnings(self) -> None:
+        rep = ValidationReport(warnings=("just a warning",))
+        assert rep.is_ok is True
+
+    def test_is_ok_false_when_errors_present(self) -> None:
+        rep = ValidationReport(errors=("nope",))
+        assert rep.is_ok is False
+
+    def test_is_ok_true_for_empty_report(self) -> None:
+        assert ValidationReport().is_ok is True
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConfigCommand:
+    def test_returns_zero_on_clean_config(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from langgraph_kit._config import configure
+
+        configure(AgentConfig())  # default config — clean
+        rc = _cmd_validate_config()
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "Config is valid" in captured.out
+
+    def test_returns_one_on_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from langgraph_kit._config import configure
+
+        configure(AgentConfig(database_url="mysql://nope/db"))
+        rc = _cmd_validate_config()
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "FAIL" in captured.err
+        assert "database_url" in captured.err
+
+    def test_returns_zero_on_warnings_only(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from langgraph_kit._config import configure
+
+        configure(AgentConfig(langfuse_public_key="pk_x"))
+        rc = _cmd_validate_config()
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "WARN" in captured.err
+        # Warnings-only path notes the count instead of "Config is valid".
+        assert "warning" in captured.err.lower()


### PR DESCRIPTION
## Summary

New `validate_config(cfg) -> ValidationReport` plus a `langgraph-kit validate-config` subcommand that surfaces configuration mistakes before the kit runs into them as opaque runtime errors. Pydantic migration of `AgentConfig` and lifespan integration are intentionally deferred to follow-ups.

Closes part of #41.

## Public surface

```python
from langgraph_kit._config import AgentConfig, validate_config

cfg = AgentConfig(database_url="mysql://nope", langfuse_public_key="pk")
report = validate_config(cfg)
report.errors    # ('database_url uses an unsupported scheme: ...',)
report.warnings  # ('langfuse_public_key is set but langfuse_secret_key is empty; ...',)
report.is_ok     # False
```

```bash
$ langgraph-kit validate-config
Config is valid.

$ langgraph-kit validate-config        # with bad config
WARN: langfuse_public_key is set but langfuse_secret_key is empty; ...
FAIL: database_url uses an unsupported scheme: 'mysql://nope' ...
$ echo $?
1
```

## Checks (9)

| # | Check | Severity |
| --- | --- | --- |
| 1 | `database_url` scheme (sqlite, postgresql, postgresql+psycopg) | error |
| 2 | `llm_model` non-empty | error |
| 3 | `token_budget_per_thread >= 0` | error |
| 4 | `shutdown_timeout_seconds >= 0` | error |
| 5 | `prompt_injection_mode in {off, warn}` | error (catches typos that silently fall through to defaults today) |
| 6 | `output_safety_mode in {off, warn, redact}` | error |
| 7 | Langfuse public/secret pair consistency | warning (tracing silently disables in mismatch) |
| 8 | `langfuse_tracing_enabled=True` requires both keys + host | error |
| 9 | `mcp_servers` parses as JSON when non-empty | error |

## Verification

- `uv run pytest` → **1306 / 1306 + 1 skip** (grandalf optional). +24 validation tests.
- `uv run ruff check .` clean, `uv run ruff format --check .` clean.

## 24 new tests

- **Happy path (3)**: default config passes, postgres URL accepted, postgres+psycopg driver suffix accepted.
- **Field-level errors (9)**: unknown DB scheme, empty DB URL, empty `llm_model`, negative `token_budget_per_thread`, negative `shutdown_timeout_seconds`, invalid `prompt_injection_mode`, invalid `output_safety_mode`, invalid `mcp_servers` JSON, valid JSON sanity.
- **Cross-field warnings (3)**: langfuse public-only warns, secret-only warns, complete pair clean.
- **Tracing-enabled guard (3)**: tracing_enabled without keys errors, without host errors, full config clean.
- **`ValidationReport` (3)**: `is_ok` true with warnings only, false with errors, true on empty.
- **CLI subcommand (3)**: returns 0 on clean, 1 on errors with `FAIL:` stderr line, 0 on warnings-only with `WARN:` + count summary.

## Deferred (out of scope)

- **`--check-connections` flag** that actually opens the database (slow; needs explicit opt-in).
- **Lifespan integration** (run `validate_config` at FastAPI startup; refuse to start on errors).
- **Migrating `AgentConfig`** from frozen dataclass to Pydantic `BaseModel` for richer field validation. Wide-blast change; the validator function shipped here gives the same coverage without churning every caller.

## Test plan

- [x] Full test suite passes (1306 / 1306)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format clean
- [x] Manual smoke: `uv run langgraph-kit validate-config` with default config returns 0 + "Config is valid."
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)