### PR TITLE
feat(testing): public langgraph_kit.testing module with FakeStore (#42 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Public testing utilities (`langgraph_kit.testing`).** New module
+  promotes the kit's internal `MockStore` test fixture to a stable
+  public `FakeStore` (Fake = behaves like the real thing; Mock = can
+  be inspected — we want behavior). `FakeStore` is a process-local
+  `BaseStore` substitute implementing the kit's read+write surface
+  (`aput` / `aget` / `asearch` / `adelete` / `alist_namespaces`);
+  `FakeItem` is the matching wrapper shape. `assert_namespace_contains`
+  and `assert_namespace_empty` are async assertion helpers that wrap
+  Store reads with clear `AssertionError` messages — good for
+  "did the thing-under-test write what I expected to this Store
+  namespace?" tests. `tests/conftest.py` re-exports the legacy
+  `MockStore` / `MockItem` names so the existing test corpus keeps
+  working without a sweeping rename. `FakeCheckpointer`, scripted-LLM
+  builders, and a pytest entry-point plugin are intentionally
+  deferred to follow-ups. Closes part of
+  [#42](https://github.com/allada-homelab/langgraph-kit/issues/42).
+
 - **Config validation (`validate_config` + `langgraph-kit
   validate-config`).** New `langgraph_kit._config.validate_config(cfg)
   returns a frozen `ValidationReport(errors, warnings, is_ok)` without

--- a/src/langgraph_kit/testing/__init__.py
+++ b/src/langgraph_kit/testing/__init__.py
@@ -1,0 +1,46 @@
+"""Public testing utilities for langgraph-kit consumers.
+
+Promotes the kit's internal pytest fixtures to a stable public API so
+downstream tests don't have to copy-paste them. The names exported
+here are treated as the kit's strictest API: changes go through the
+deprecation cycle one major version ahead of code-path APIs.
+
+Currently exposes:
+
+- :class:`FakeStore` — in-memory ``BaseStore`` shim with the full
+  protocol (``aput`` / ``aget`` / ``asearch`` / ``adelete`` /
+  ``alist_namespaces``). Use whenever a test needs to call into
+  Store-backed kit code without spinning up SQLite or Postgres.
+- :class:`FakeItem` — the ``aget`` / ``asearch`` return-shape
+  (``key`` / ``value`` / ``namespace``).
+- :func:`assert_namespace_contains` — assertion helper for "did the
+  thing-under-test write what I expected to this Store namespace?"
+- :func:`assert_namespace_empty` — assertion helper for the
+  no-side-effect side of the same coin.
+
+Deferred to follow-ups (each its own small PR):
+
+- ``FakeCheckpointer`` (thin wrapper over ``InMemorySaver`` with
+  ``dump_state`` and ``assert_thread_has_messages`` affordances).
+- ``scripted_llm`` / ``tool_call_turn`` / ``answer`` — the
+  ``RecordedChatModel`` script builders currently in
+  ``tests/e2e/conftest.py``.
+- Pytest ``entry_points.pytest11`` plugin so fixtures auto-register
+  on ``pytest`` invocation; today callers do
+  ``from langgraph_kit.testing import FakeStore`` explicitly.
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.testing.assertions import (
+    assert_namespace_contains,
+    assert_namespace_empty,
+)
+from langgraph_kit.testing.fakes import FakeItem, FakeStore
+
+__all__ = [
+    "FakeItem",
+    "FakeStore",
+    "assert_namespace_contains",
+    "assert_namespace_empty",
+]

--- a/src/langgraph_kit/testing/assertions.py
+++ b/src/langgraph_kit/testing/assertions.py
@@ -1,0 +1,118 @@
+"""Pytest-friendly assertions for kit-based tests.
+
+Each helper is a thin wrapper over a Store-protocol read + a clear
+``AssertionError`` on mismatch. The kit's tests use these directly;
+downstream consumers can import them via :mod:`langgraph_kit.testing`.
+
+Two assertion shapes for now:
+
+- :func:`assert_namespace_contains` — at least one item in
+  *namespace* matches a value-predicate.
+- :func:`assert_namespace_empty` — *namespace* is empty (or doesn't
+  exist).
+
+Both work against any object that exposes the kit's read-side Store
+protocol (``aget`` / ``asearch``), so they cover the real
+``InMemoryStore`` / ``AsyncPostgresStore`` and :class:`FakeStore`
+without branching on type. Memory- / queue- / inbox-specific
+assertions are deferred — they can layer on these primitives.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+async def assert_namespace_contains(
+    store: Any,
+    namespace: tuple[str, ...],
+    *,
+    where: Any = None,
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Assert at least one item in *namespace* matches *where*.
+
+    Returns the matching item's ``value`` dict (handy for chained
+    assertions: "yes the memory was saved AND its content is X").
+
+    Parameters
+    ----------
+    store:
+        Any object with an ``asearch(namespace, limit=...)`` method —
+        the kit's real Store backends and :class:`FakeStore` both work.
+    namespace:
+        Store namespace tuple (e.g. ``("workspace", "board-1")``).
+    where:
+        Optional predicate. ``None`` (default) matches "any item
+        present"; a callable receives the item's ``value`` dict and
+        should return truthy on match. Use for stronger assertions
+        like ``where=lambda v: v["title"] == "preferences"``.
+    description:
+        Optional human-readable description for the assertion error
+        message (e.g. ``"the user's preferences memory"``). Falls
+        back to a generic message if omitted.
+
+    Raises
+    ------
+    AssertionError
+        If the namespace is empty or no item satisfies *where*.
+    """
+    items = await store.asearch(namespace, limit=10_000)
+    if not items:
+        msg = description or f"namespace {namespace!r}"
+        raise AssertionError(
+            f"Expected at least one item in {msg}, but the namespace is empty"
+        )
+    if where is None:
+        return _value(items[0])
+    for item in items:
+        value = _value(item)
+        if where(value):
+            return value
+    msg = description or f"namespace {namespace!r}"
+    raise AssertionError(
+        f"No item in {msg} satisfies the predicate. "
+        f"Found {len(items)} item(s); first value: {_value(items[0])!r}"
+    )
+
+
+async def assert_namespace_empty(
+    store: Any,
+    namespace: tuple[str, ...],
+    *,
+    description: str | None = None,
+) -> None:
+    """Assert *namespace* is empty (no items, or doesn't exist).
+
+    Useful for "the test path should NOT have written anything to
+    this namespace" — common after testing error paths or
+    permission-checked writes.
+
+    Raises
+    ------
+    AssertionError
+        If any item exists in the namespace.
+    """
+    items = await store.asearch(namespace, limit=1)
+    if items:
+        msg = description or f"namespace {namespace!r}"
+        raise AssertionError(
+            f"Expected {msg} to be empty, but it contains "
+            f"{len(items)}+ item(s); first key: {items[0].key!r}"
+        )
+
+
+def _value(item: Any) -> dict[str, Any]:
+    """Pull the value dict off an item, falling back to ``item`` itself.
+
+    The real Store and :class:`FakeStore` both return wrapper objects
+    with a ``.value`` attribute. Some tests pass raw dicts directly;
+    fall through so callers don't need to wrap them.
+    """
+    return item.value if hasattr(item, "value") else item
+
+
+__all__ = [
+    "assert_namespace_contains",
+    "assert_namespace_empty",
+]

--- a/src/langgraph_kit/testing/fakes.py
+++ b/src/langgraph_kit/testing/fakes.py
@@ -1,0 +1,131 @@
+"""In-memory fakes for kit-internal protocols.
+
+A "fake" (vs a "mock") behaves like the real thing — it just lives in
+process memory instead of hitting a real database. Tests that drive
+kit code through fakes are exercising the same code paths as
+production; only the persistence layer is swapped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FakeItem:
+    """Shape returned by :py:meth:`FakeStore.aget` and
+    :py:meth:`FakeStore.asearch`.
+
+    Mirrors LangGraph's ``Item`` (``key`` / ``value`` / ``namespace``)
+    so kit code that consumes the real Store works against this fake
+    unchanged. Construct directly when a test wants to inject a
+    pre-baked item (e.g. seed memory state without running the kit's
+    write path).
+    """
+
+    def __init__(
+        self,
+        key: str,
+        value: dict[str, Any],
+        namespace: tuple[str, ...],
+    ) -> None:
+        super().__init__()
+        self.key = key
+        self.value = value
+        self.namespace = namespace
+
+    def __repr__(self) -> str:
+        return (
+            f"FakeItem(key={self.key!r}, "
+            f"namespace={self.namespace!r}, "
+            f"value_keys={sorted(self.value.keys())!r})"
+        )
+
+
+class FakeStore:
+    """Process-local ``BaseStore`` substitute for kit tests.
+
+    Implements the subset of LangGraph's Store protocol that the kit
+    actually calls: ``aput``, ``aget``, ``asearch``, ``adelete``,
+    ``alist_namespaces``. Every kit module that takes a ``store``
+    parameter accepts this in place of an ``InMemoryStore`` /
+    ``AsyncPostgresStore`` — same shape, no I/O.
+
+    Use cases:
+
+    - Unit tests for memory / queue / inbox / workspace primitives
+      that are Store-backed.
+    - Integration tests that compose multiple Store-using subsystems
+      without paying SQLite startup cost.
+    - Test fixtures that need to assert on what was written
+      (the ``_data`` attribute is intentionally accessible).
+
+    Construct directly: ``store = FakeStore()``. Or use the
+    matching ``mock_store`` pytest fixture in
+    ``tests/conftest.py`` for backwards compatibility with the kit's
+    pre-extraction tests.
+
+    Not a substitute for the real Store:
+
+    - No persistence across process restarts.
+    - No vector-similarity search (``asearch`` returns insertion
+      order; LangChain's real backends rank by query similarity
+      when an embedding fn is configured).
+    - No transaction semantics.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # ``_data[namespace][key] -> value``. Public-ish for tests
+        # that want to inspect raw state; renames here are a
+        # breaking change.
+        self._data: dict[tuple[str, ...], dict[str, dict[str, Any]]] = {}
+
+    async def aput(
+        self,
+        namespace: tuple[str, ...],
+        key: str,
+        value: dict[str, Any],
+    ) -> None:
+        """Store *value* under (*namespace*, *key*). Upsert semantics."""
+        if namespace not in self._data:
+            self._data[namespace] = {}
+        self._data[namespace][key] = value
+
+    async def aget(self, namespace: tuple[str, ...], key: str) -> FakeItem | None:
+        """Return the item at (*namespace*, *key*), or ``None`` if missing."""
+        val = self._data.get(namespace, {}).get(key)
+        if val is None:
+            return None
+        return FakeItem(key=key, value=val, namespace=namespace)
+
+    async def asearch(
+        self,
+        namespace: tuple[str, ...],
+        query: str | None = None,  # noqa: ARG002 - protocol parity
+        limit: int = 10,
+    ) -> list[FakeItem]:
+        """Return up to *limit* items in *namespace* (insertion order).
+
+        ``query`` is accepted for protocol parity but ignored — the
+        real ``asearch`` ranks by embedding similarity to *query*; the
+        fake just returns insertion order. Tests that depend on
+        similarity ranking should use a real Store + embedding fn.
+        """
+        return [
+            FakeItem(key=k, value=v, namespace=namespace)
+            for k, v in list(self._data.get(namespace, {}).items())[:limit]
+        ]
+
+    async def adelete(self, namespace: tuple[str, ...], key: str) -> None:
+        """Drop the item at (*namespace*, *key*). No-op if missing."""
+        if namespace in self._data:
+            self._data[namespace].pop(key, None)
+
+    async def alist_namespaces(self, prefix: tuple[str, ...]) -> list[tuple[str, ...]]:
+        """Return every non-empty namespace that starts with *prefix*."""
+        return [
+            ns for ns in self._data if ns[: len(prefix)] == prefix and self._data[ns]
+        ]
+
+
+__all__ = ["FakeItem", "FakeStore"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,61 +1,20 @@
-"""Conftest for agent tests — shared fixtures, no database required."""
+"""Conftest for agent tests — shared fixtures, no database required.
+
+Issue #42 promoted ``MockStore`` / ``MockItem`` to a public
+``langgraph_kit.testing`` module as ``FakeStore`` / ``FakeItem``.
+This conftest re-exports the legacy names so the (large) existing
+test corpus keeps working without a sweeping rename. New tests
+should import from ``langgraph_kit.testing`` directly.
+"""
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
+from langgraph_kit.testing import FakeItem as MockItem
+from langgraph_kit.testing import FakeStore as MockStore
 
-class MockItem:
-    """Mimics a LangGraph Store Item."""
-
-    def __init__(
-        self, key: str, value: dict[str, Any], namespace: tuple[str, ...]
-    ) -> None:
-        self.key = key
-        self.value = value
-        self.namespace = namespace
-
-
-class MockStore:
-    """In-memory mock of LangGraph BaseStore for testing."""
-
-    def __init__(self) -> None:
-        self._data: dict[tuple[str, ...], dict[str, dict[str, Any]]] = {}
-
-    async def aput(
-        self, namespace: tuple[str, ...], key: str, value: dict[str, Any]
-    ) -> None:
-        if namespace not in self._data:
-            self._data[namespace] = {}
-        self._data[namespace][key] = value
-
-    async def aget(self, namespace: tuple[str, ...], key: str) -> MockItem | None:
-        val = self._data.get(namespace, {}).get(key)
-        if val is None:
-            return None
-        return MockItem(key=key, value=val, namespace=namespace)
-
-    async def asearch(
-        self,
-        namespace: tuple[str, ...],
-        query: str | None = None,
-        limit: int = 10,
-    ) -> list[MockItem]:
-        return [
-            MockItem(key=k, value=v, namespace=namespace)
-            for k, v in list(self._data.get(namespace, {}).items())[:limit]
-        ]
-
-    async def adelete(self, namespace: tuple[str, ...], key: str) -> None:
-        if namespace in self._data:
-            self._data[namespace].pop(key, None)
-
-    async def alist_namespaces(self, prefix: tuple[str, ...]) -> list[tuple[str, ...]]:
-        return [
-            ns for ns in self._data if ns[: len(prefix)] == prefix and self._data[ns]
-        ]
+__all__ = ["MockItem", "MockStore"]
 
 
 @pytest.fixture

--- a/tests/test_testing_module.py
+++ b/tests/test_testing_module.py
@@ -1,0 +1,225 @@
+"""Tests for the public ``langgraph_kit.testing`` module (issue #42 v1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from langgraph_kit.testing import (
+    FakeItem,
+    FakeStore,
+    assert_namespace_contains,
+    assert_namespace_empty,
+)
+
+# ---------------------------------------------------------------------------
+# Public-API surface check
+# ---------------------------------------------------------------------------
+
+
+class TestPublicApiSurface:
+    def test_exports_are_importable(self) -> None:
+        """Smoke check: every name promoted to the public API resolves."""
+        from langgraph_kit import testing
+
+        for name in (
+            "FakeItem",
+            "FakeStore",
+            "assert_namespace_contains",
+            "assert_namespace_empty",
+        ):
+            assert hasattr(testing, name), f"missing public export: {name}"
+
+    def test_all_matches_actual_exports(self) -> None:
+        """``__all__`` should describe what the module actually exposes."""
+        from langgraph_kit import testing
+
+        for name in testing.__all__:
+            assert hasattr(testing, name), f"__all__ promises {name!r} but it's missing"
+
+
+# ---------------------------------------------------------------------------
+# FakeStore — protocol parity with the real Store
+# ---------------------------------------------------------------------------
+
+
+class TestFakeStore:
+    @pytest.mark.asyncio
+    async def test_aput_then_aget_round_trip(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k", {"x": 1})
+        item = await store.aget(("ns",), "k")
+        assert item is not None
+        assert isinstance(item, FakeItem)
+        assert item.key == "k"
+        assert item.value == {"x": 1}
+        assert item.namespace == ("ns",)
+
+    @pytest.mark.asyncio
+    async def test_aget_missing_returns_none(self) -> None:
+        store = FakeStore()
+        assert await store.aget(("ns",), "missing") is None
+
+    @pytest.mark.asyncio
+    async def test_asearch_returns_insertion_order(self) -> None:
+        """The fake doesn't rank by similarity — insertion order only."""
+        store = FakeStore()
+        for i in range(3):
+            await store.aput(("ns",), f"k{i}", {"i": i})
+        items = await store.asearch(("ns",))
+        assert [item.value["i"] for item in items] == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_asearch_respects_limit(self) -> None:
+        store = FakeStore()
+        for i in range(5):
+            await store.aput(("ns",), f"k{i}", {"i": i})
+        items = await store.asearch(("ns",), limit=2)
+        assert len(items) == 2
+
+    @pytest.mark.asyncio
+    async def test_adelete_removes_item(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k", {"x": 1})
+        await store.adelete(("ns",), "k")
+        assert await store.aget(("ns",), "k") is None
+
+    @pytest.mark.asyncio
+    async def test_adelete_missing_is_noop(self) -> None:
+        store = FakeStore()
+        await store.adelete(("ns",), "no-such-key")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_alist_namespaces_returns_matching_prefixes(self) -> None:
+        store = FakeStore()
+        await store.aput(("workspace", "a"), "doc", {"x": 1})
+        await store.aput(("workspace", "b"), "doc", {"x": 2})
+        await store.aput(("inbox", "a"), "msg", {"text": "hi"})
+        ws_namespaces = await store.alist_namespaces(("workspace",))
+        assert sorted(ws_namespaces) == [("workspace", "a"), ("workspace", "b")]
+        # Other prefix doesn't leak.
+        inbox_namespaces = await store.alist_namespaces(("inbox",))
+        assert inbox_namespaces == [("inbox", "a")]
+
+    @pytest.mark.asyncio
+    async def test_alist_namespaces_skips_empty_namespaces(self) -> None:
+        """A namespace whose only item was deleted shouldn't appear."""
+        store = FakeStore()
+        await store.aput(("workspace", "x"), "doc", {})
+        await store.adelete(("workspace", "x"), "doc")
+        # Empty namespace remains in ``_data`` as an empty dict; alist
+        # should still skip it because nothing's stored there now.
+        result = await store.alist_namespaces(("workspace",))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# FakeItem
+# ---------------------------------------------------------------------------
+
+
+class TestFakeItem:
+    def test_construct_directly(self) -> None:
+        """Tests can mint pre-baked items without running the kit's write path."""
+        item = FakeItem(key="k", value={"x": 1}, namespace=("ns",))
+        assert item.key == "k"
+        assert item.value == {"x": 1}
+        assert item.namespace == ("ns",)
+
+    def test_repr_includes_value_keys_only(self) -> None:
+        """Repr summarizes value keys (don't dump full payload into logs)."""
+        item = FakeItem(
+            key="k", value={"secret": "super-private", "id": 1}, namespace=("ns",)
+        )
+        rep = repr(item)
+        assert "key='k'" in rep
+        assert "namespace=('ns',)" in rep
+        # Value keys are listed; values are NOT.
+        assert "'id'" in rep
+        assert "'secret'" in rep
+        assert "super-private" not in rep
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+
+
+class TestAssertNamespaceContains:
+    @pytest.mark.asyncio
+    async def test_returns_value_dict_on_match(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k", {"title": "preferences"})
+        value = await assert_namespace_contains(store, ("ns",))
+        assert value == {"title": "preferences"}
+
+    @pytest.mark.asyncio
+    async def test_with_predicate_finds_matching_item(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k1", {"title": "color", "value": "blue"})
+        await store.aput(("ns",), "k2", {"title": "size", "value": "L"})
+        match = await assert_namespace_contains(
+            store, ("ns",), where=lambda v: v["title"] == "size"
+        )
+        assert match["value"] == "L"
+
+    @pytest.mark.asyncio
+    async def test_empty_namespace_raises(self) -> None:
+        store = FakeStore()
+        with pytest.raises(AssertionError, match="empty"):
+            await assert_namespace_contains(store, ("ns",))
+
+    @pytest.mark.asyncio
+    async def test_no_predicate_match_raises(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k", {"title": "color"})
+        with pytest.raises(AssertionError, match=r"No item.*satisfies"):
+            await assert_namespace_contains(
+                store, ("ns",), where=lambda v: v["title"] == "missing"
+            )
+
+    @pytest.mark.asyncio
+    async def test_description_threaded_into_error_message(self) -> None:
+        store = FakeStore()
+        with pytest.raises(AssertionError, match="user's preferences memory"):
+            await assert_namespace_contains(
+                store, ("ns",), description="user's preferences memory"
+            )
+
+
+class TestAssertNamespaceEmpty:
+    @pytest.mark.asyncio
+    async def test_empty_namespace_passes(self) -> None:
+        store = FakeStore()
+        await assert_namespace_empty(store, ("ns",))  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_namespace_with_item_raises(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k", {"x": 1})
+        with pytest.raises(AssertionError, match=r"Expected.*to be empty"):
+            await assert_namespace_empty(store, ("ns",))
+
+    @pytest.mark.asyncio
+    async def test_description_threaded_into_error_message(self) -> None:
+        store = FakeStore()
+        await store.aput(("ns",), "k", {"x": 1})
+        with pytest.raises(AssertionError, match="audit log"):
+            await assert_namespace_empty(store, ("ns",), description="audit log")
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat re-exports from tests/conftest.py
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardsCompatReexports:
+    def test_old_mockstore_name_still_works(self) -> None:
+        """Existing tests that import ``MockStore`` from conftest still resolve."""
+        from tests.conftest import MockStore as LegacyMockStore
+
+        assert LegacyMockStore is FakeStore
+
+    def test_old_mockitem_name_still_works(self) -> None:
+        from tests.conftest import MockItem as LegacyMockItem
+
+        assert LegacyMockItem is FakeItem


### PR DESCRIPTION
## Summary

Promotes the kit's internal `MockStore` test fixture to a stable public `langgraph_kit.testing` module so downstream test code can `from langgraph_kit.testing import FakeStore` instead of copy-pasting it from the kit's own conftest. Renamed along the way: `MockStore` → `FakeStore` (Fake = behaves like the real thing; Mock = can be inspected — we want behavior).

Closes part of #42.

## Public surface

```python
from langgraph_kit.testing import (
    FakeItem, FakeStore,
    assert_namespace_contains, assert_namespace_empty,
)

store = FakeStore()
await store.aput(("workspace", "demo"), "doc", {"todo": ["x"]})

# Single-call assertion that's nicer than rolling your own:
value = await assert_namespace_contains(
    store, ("workspace", "demo"),
    where=lambda v: "todo" in v,
    description="the task board for demo workspace",
)
assert value["todo"] == ["x"]

# And the negative side:
await assert_namespace_empty(
    store, ("audit",),
    description="audit log (should not have written on the error path)",
)
```

## What lands

- **`FakeStore`** (`src/langgraph_kit/testing/fakes.py`) — process-local `BaseStore` substitute. Same protocol as `InMemoryStore` / `AsyncPostgresStore`: `aput` / `aget` / `asearch` / `adelete` / `alist_namespaces`. No I/O, no embedding-ranked search, no transactions — explicit about what it doesn't do in the docstring.
- **`FakeItem`** — the wrapper shape `aget`/`asearch` return (`key`/`value`/`namespace`); construct directly to seed pre-baked items.
- **`assert_namespace_contains`** — returns the matching value dict for chained assertions; raises on empty namespace or no predicate match. Threads `description` into the error so failures say "user's preferences memory" instead of "namespace ('ns',)".
- **`assert_namespace_empty`** — raises if anything's there.
- **`tests/conftest.py`** re-exports `MockStore` / `MockItem` as aliases for `FakeStore` / `FakeItem` so the kit's existing 1300+ tests keep working without a sweeping rename. New tests should import from `langgraph_kit.testing` directly.

## Verification

- `uv run pytest` → **1328 / 1328 + 1 skip** (grandalf optional). +22 new tests for the public module.
- `uv run ruff check .` clean, `uv run ruff format --check .` clean. Existing tests still pass against the re-exported `MockStore` alias — non-breaking promotion.

## 22 new tests

- **Public API surface (2)**: every exported name resolves; `__all__` matches actual exports.
- **`FakeStore` (8)**: aput/aget round-trip, missing aget returns None, asearch returns insertion order (NOT similarity), asearch limit respected, adelete removes, adelete missing is no-op, alist_namespaces filters by prefix, alist_namespaces skips empty namespaces.
- **`FakeItem` (2)**: direct construction, repr summarizes value keys without leaking values (so secrets-as-test-fixtures don't end up in CI logs).
- **`assert_namespace_contains` (5)**: returns value dict, predicate finds matching item, empty namespace raises, no predicate match raises, description threaded into error.
- **`assert_namespace_empty` (3)**: empty passes, non-empty raises, description threaded into error.
- **Backwards-compat (2)**: `tests.conftest.MockStore` is `langgraph_kit.testing.FakeStore`; ditto MockItem/FakeItem.

## Deferred (out of scope)

- **`FakeCheckpointer`** (thin wrapper over `InMemorySaver` with `dump_state` and `assert_thread_has_messages` affordances).
- **`scripted_llm`** / `tool_call_turn` / `answer` — the `RecordedChatModel` script builders currently in `tests/e2e/conftest.py`. Promote when the e2e fixtures stop evolving.
- **Pytest `entry_points.pytest11`** plugin so fixtures auto-register on `pytest` invocation.
- **Memory- / queue- / inbox-specific assertions** (e.g. `assert_memory_saved`). The two namespace-level helpers shipped here are the primitive everything else builds on.

## Test plan

- [x] Full test suite passes (1328 / 1328) — non-breaking promotion of `MockStore` confirmed
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format clean
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)