### PR TITLE
feat(prompts): curated prompt_templates library + diff_section helper (#43 v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Curated prompt-template library (`langgraph_kit.prompt_templates`).**
+  Nine shipped, versioned `PromptSection` instances covering the
+  common prompt families: `core_identity`, `operate_carefully`,
+  `be_concise`, `completion_signal`, `memory_awareness` (conditional
+  on `"memory"`), `tool_use_discipline` (conditional on `"tools"`),
+  `error_handling`, plus a paired `output_format_natural` /
+  `output_format_structured` sharing the `"output_format"` id with
+  distinct versions (composes with #18's per-id versioning so a
+  single registry can swap formats via `set_current`). New
+  `diff_section(custom, baseline) -> str` helper renders unified
+  diffs of any customization vs the shipped baseline — useful as a
+  startup-log entry for deploys that customize prompts. Sections
+  are importable today; auto-registration on `SectionRegistry()`
+  and `AgentConfig.prompt_overrides` lifecycle integration are
+  intentionally deferred to follow-ups so this PR doesn't change
+  graph-build semantics for existing callers. Closes part of
+  [#43](https://github.com/allada-homelab/langgraph-kit/issues/43).
+
 - **Public testing utilities (`langgraph_kit.testing`).** New module
   promotes the kit's internal `MockStore` test fixture to a stable
   public `FakeStore` (Fake = behaves like the real thing; Mock = can

--- a/src/langgraph_kit/prompt_templates/__init__.py
+++ b/src/langgraph_kit/prompt_templates/__init__.py
@@ -1,0 +1,86 @@
+"""Curated, reusable :class:`PromptSection` library for langgraph-kit consumers.
+
+Each shipped section is a versioned, frozen ``PromptSection`` with a
+clear id and stability label — drop them into a
+:class:`SectionRegistry` to get a sensible baseline prompt without
+hand-rolling the same boilerplate per agent.
+
+Usage::
+
+    from langgraph_kit.core.prompt_assembly.sections import SectionRegistry
+    from langgraph_kit.prompt_templates import (
+        core_identity,
+        operate_carefully,
+        be_concise,
+    )
+
+    registry = SectionRegistry()
+    registry.register_many([core_identity, operate_carefully, be_concise])
+
+To customize a shipped section without forking the kit:
+
+    from langgraph_kit.prompt_templates import core_identity
+    custom = core_identity.model_copy(update={
+        "content": "You are an internal-tools agent for ...",
+        "version": "custom-1",
+    })
+    registry.register(custom)  # replaces by id
+
+Override-by-id replaces the entire section. Per the original issue
+spec, partial-merge overrides (changing only ``content`` while
+keeping the kit's ``priority``/``stability``) aren't supported — use
+``model_copy`` to derive your own and replace whole.
+
+Use :func:`diff_section` to introspect what your override actually
+changed vs the shipped baseline; useful as a startup-log entry on
+deploys that customize prompts so the actual prompt in use is
+visible without reading source.
+
+Scope (issue #43 v1):
+
+- Eight shipped sections covering the common prompt families
+  (identity, operating discipline, conciseness, memory awareness,
+  tool guidance, error handling, output format, completion
+  signaling). Each has ``version="1"``.
+- ``diff_section`` helper for visualizing customizations.
+- Sections are *importable*. Auto-registration on a fresh
+  ``SectionRegistry`` and ``AgentConfig.prompt_overrides`` lifecycle
+  integration are intentionally deferred to follow-ups so this PR
+  doesn't change graph-build semantics for existing callers.
+- Existing scattered prompts (``BASIC_SYSTEM_PROMPT``,
+  ``_EXTRACTION_PROMPT`` etc.) are left in place; consumers who
+  want the library can adopt it incrementally. Migration of those
+  is its own follow-up.
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.prompt_templates.core import (
+    be_concise,
+    completion_signal,
+    core_identity,
+    operate_carefully,
+)
+from langgraph_kit.prompt_templates.diff import diff_section
+from langgraph_kit.prompt_templates.memory import (
+    memory_awareness,
+)
+from langgraph_kit.prompt_templates.safety import (
+    error_handling,
+    output_format_natural,
+    output_format_structured,
+)
+from langgraph_kit.prompt_templates.tools import tool_use_discipline
+
+__all__ = [
+    "be_concise",
+    "completion_signal",
+    "core_identity",
+    "diff_section",
+    "error_handling",
+    "memory_awareness",
+    "operate_carefully",
+    "output_format_natural",
+    "output_format_structured",
+    "tool_use_discipline",
+]

--- a/src/langgraph_kit/prompt_templates/core.py
+++ b/src/langgraph_kit/prompt_templates/core.py
@@ -1,0 +1,100 @@
+"""Core identity + operating-discipline sections.
+
+Captures the "be a careful, concise assistant" framing that almost
+every agent built on the kit ends up writing in its system prompt.
+Pulled from the same content as
+``langgraph_kit.graphs._basic_prompt.BASIC_SYSTEM_PROMPT`` but split
+into discrete sections so callers can compose subsets — an
+internal-tools agent might want :data:`operate_carefully` and
+:data:`be_concise` without :data:`core_identity`'s "AI assistant"
+framing, for example.
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionStability,
+)
+
+core_identity = PromptSection(
+    id="core_identity",
+    version="1",
+    content="You are a helpful AI assistant.",
+    stability=SectionStability.STABLE,
+    priority=100,
+)
+"""Establishes the agent as an AI assistant.
+
+Highest-priority STABLE section so it lands at the top of the
+composed prompt. Replace via ``model_copy(update={"content": ...})``
+when you want a domain-specific persona ("You are a payments-ops
+specialist…") instead of the generic framing.
+"""
+
+
+operate_carefully = PromptSection(
+    id="operate_carefully",
+    version="1",
+    content=(
+        "Operate carefully and deliberately. When tools are available, "
+        "use them only when they materially advance the task. Prefer "
+        "the most direct approach."
+    ),
+    stability=SectionStability.STABLE,
+    priority=90,
+)
+"""Operating-discipline guidance.
+
+Discourages tool spam and over-engineered approaches. Pairs well
+with :data:`core_identity` and :data:`be_concise` for a baseline
+"thoughtful agent" prompt.
+"""
+
+
+be_concise = PromptSection(
+    id="be_concise",
+    version="1",
+    content=(
+        "Be concise. State results and decisions directly. If you "
+        "cannot answer or complete something, say so explicitly "
+        "rather than guessing."
+    ),
+    stability=SectionStability.STABLE,
+    priority=80,
+)
+"""Pushes terse, honest responses.
+
+The "say so explicitly rather than guessing" clause is load-bearing
+— without it, instruction-following models tend to invent answers
+when they don't know something.
+"""
+
+
+completion_signal = PromptSection(
+    id="completion_signal",
+    version="1",
+    content=(
+        "When the task is complete, end your response with a clear "
+        "signal that the work is done — don't trail off mid-thought. "
+        "If you're blocked or need input, say so explicitly so the "
+        "user knows it's their turn."
+    ),
+    stability=SectionStability.STABLE,
+    priority=60,
+)
+"""Encourages clear turn-handoff signaling.
+
+Helps with multi-turn agents and agents wired into HITL where the
+caller needs to know whether the agent is genuinely done or
+expecting a follow-up. Lower priority than identity/discipline
+because it's a polish on top of those.
+"""
+
+
+__all__ = [
+    "be_concise",
+    "completion_signal",
+    "core_identity",
+    "operate_carefully",
+]

--- a/src/langgraph_kit/prompt_templates/diff.py
+++ b/src/langgraph_kit/prompt_templates/diff.py
@@ -1,0 +1,76 @@
+"""Diff helper for visualizing prompt-section customizations."""
+
+from __future__ import annotations
+
+import difflib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from langgraph_kit.core.prompt_assembly.sections import PromptSection
+
+
+def diff_section(custom: PromptSection, baseline: PromptSection) -> str:
+    """Return a unified diff between *baseline* and *custom* sections.
+
+    Useful as a startup-log entry on deployments that customize the
+    shipped prompt-templates library — the actual prompt in use is
+    visible without grepping source. The diff covers content,
+    version, priority, stability, and condition; ``id`` and
+    ``cache_key`` are intentionally omitted (id is the join key,
+    cache_key is content-derived).
+
+    Empty string when the two sections are identical (down to
+    metadata). The output uses ``difflib.unified_diff`` markers
+    (``---`` / ``+++`` / ``@@``) so terminals that highlight diffs
+    light up automatically.
+
+    Example::
+
+        from langgraph_kit.prompt_templates import core_identity, diff_section
+
+        custom = core_identity.model_copy(update={
+            "content": "You are an internal-tools agent for the X team.",
+            "version": "x-team-1",
+        })
+        print(diff_section(custom, baseline=core_identity))
+    """
+    if (
+        custom.content == baseline.content
+        and custom.version == baseline.version
+        and custom.priority == baseline.priority
+        and custom.stability == baseline.stability
+        and custom.condition == baseline.condition
+    ):
+        return ""
+
+    baseline_lines = _section_lines(baseline)
+    custom_lines = _section_lines(custom)
+    diff = difflib.unified_diff(
+        baseline_lines,
+        custom_lines,
+        fromfile=f"shipped:{baseline.id}@{baseline.version}",
+        tofile=f"custom:{custom.id}@{custom.version}",
+        lineterm="",
+    )
+    return "\n".join(diff)
+
+
+def _section_lines(section: PromptSection) -> list[str]:
+    """Render a section as a stable, line-oriented form for diffing.
+
+    Metadata first, then a blank line, then the content split on
+    newlines. ``difflib.unified_diff`` works on iterables of lines;
+    keeping the metadata block at the top means version / priority
+    bumps land on contiguous lines (easy to read in a diff view).
+    """
+    return [
+        f"# version: {section.version}",
+        f"# priority: {section.priority}",
+        f"# stability: {section.stability.value}",
+        f"# condition: {section.condition or '<none>'}",
+        "",
+        *section.content.splitlines(),
+    ]
+
+
+__all__ = ["diff_section"]

--- a/src/langgraph_kit/prompt_templates/memory.py
+++ b/src/langgraph_kit/prompt_templates/memory.py
@@ -1,0 +1,47 @@
+"""Memory-awareness sections.
+
+Tells the model that persistent memory exists and frames how to
+think about it. The actual memory-extraction prompt
+(``langgraph_kit.core.memory.extraction._EXTRACTION_PROMPT``) lives
+elsewhere because it's a complete middleware prompt with its own
+input/output contract; this section is the chat-side awareness that
+"by the way, you have memory tools."
+
+Conditional on ``"memory"`` so it only fires when the agent is built
+with memory enabled.
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionStability,
+)
+
+memory_awareness = PromptSection(
+    id="memory_awareness",
+    version="1",
+    content=(
+        "You have access to persistent memory tools. Use them to:\n"
+        "- Save durable facts that will matter in future conversations\n"
+        "- Remember user preferences, project constraints, and "
+        "external references\n"
+        "- DO NOT save: code patterns visible in the repo, file "
+        "layouts, git history, temporary task state\n"
+        "- Prefer updating an existing memory over creating a duplicate"
+    ),
+    stability=SectionStability.CONDITIONAL,
+    condition="memory",
+    priority=80,
+)
+"""Surfaces the memory tool surface to the model.
+
+Mirrors ``langgraph_kit.graphs.reference_deep_agent._CORE_SECTIONS``'s
+``memory_instructions`` section but standalone — usable from any agent
+build that wires the memory subsystem in. The "DO NOT save" line is
+load-bearing: without it, small models fill memory with code-snippet
+noise that crowds out genuinely durable facts.
+"""
+
+
+__all__ = ["memory_awareness"]

--- a/src/langgraph_kit/prompt_templates/safety.py
+++ b/src/langgraph_kit/prompt_templates/safety.py
@@ -1,0 +1,82 @@
+"""Error-handling and output-format sections."""
+
+from __future__ import annotations
+
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionStability,
+)
+
+error_handling = PromptSection(
+    id="error_handling",
+    version="1",
+    content=(
+        "When something goes wrong:\n"
+        "- Read the full error message before deciding what to do\n"
+        "- Don't keep retrying the same approach if it's already failed twice\n"
+        "- If you're stuck, surface what you tried and what blocked you "
+        "rather than silently producing a degraded answer"
+    ),
+    stability=SectionStability.STABLE,
+    priority=70,
+)
+"""Error-handling discipline.
+
+Counters two common LLM failure modes: skimming errors (so the model
+misses the part that says "you must include field X") and infinite
+retry loops on the same approach. The "surface what blocked you"
+clause is critical for HITL flows where a human is waiting to help.
+"""
+
+
+output_format_natural = PromptSection(
+    id="output_format",
+    version="1-natural",
+    content=(
+        "Reply in plain natural language. No markdown headers unless "
+        "the user's question genuinely benefits from structure. No "
+        'preamble like "Sure!" or "Here\'s the answer:" — just '
+        "the answer."
+    ),
+    stability=SectionStability.STABLE,
+    priority=50,
+)
+"""Plain natural-language output formatting.
+
+Pairs with chat-style consumers where markdown structure is noise.
+Note the ``id="output_format"`` is shared with
+:data:`output_format_structured` — they're meant to be mutually
+exclusive (callers register one or the other), not both. The
+``version`` field disambiguates which variant landed in a given
+:class:`SectionRegistry`.
+"""
+
+
+output_format_structured = PromptSection(
+    id="output_format",
+    version="1-structured",
+    content=(
+        "Use markdown structure when it helps the user scan the "
+        "response: section headers for distinct topics, bullet "
+        "lists for enumerations, code fences for code or shell "
+        "commands. Don't add structure for the sake of it — a "
+        "single-paragraph answer is a single paragraph."
+    ),
+    stability=SectionStability.STABLE,
+    priority=50,
+)
+"""Markdown-structured output formatting.
+
+Mirror of :data:`output_format_natural` for callers whose UI renders
+markdown well (a docs viewer, a developer console, etc.). Same id,
+different version — :class:`SectionRegistry`'s versioning support
+(issue #18) lets a single registry hold both and switch via
+``set_current``.
+"""
+
+
+__all__ = [
+    "error_handling",
+    "output_format_natural",
+    "output_format_structured",
+]

--- a/src/langgraph_kit/prompt_templates/tools.py
+++ b/src/langgraph_kit/prompt_templates/tools.py
@@ -1,0 +1,35 @@
+"""Tool-use guidance sections."""
+
+from __future__ import annotations
+
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionStability,
+)
+
+tool_use_discipline = PromptSection(
+    id="tool_use_discipline",
+    version="1",
+    content=(
+        "When you have multiple tool calls to make and they're "
+        "independent of each other, batch them in parallel rather "
+        "than serializing — saves wall time and is the user's "
+        "common expectation. If a tool call fails, read the error "
+        "and fix the cause; don't retry blindly more than once."
+    ),
+    stability=SectionStability.CONDITIONAL,
+    condition="tools",
+    priority=85,
+)
+"""Tool-use discipline: parallelize independent calls, don't retry blindly.
+
+Conditional on ``"tools"`` because non-tool agents shouldn't see
+this. The "fix the cause; don't retry blindly" framing addresses
+the most expensive tool-loop failure mode (model retries the same
+call expecting different output). Pairs with the kit's
+``ToolErrorMiddleware``, which surfaces the actual error text the
+model needs to act on.
+"""
+
+
+__all__ = ["tool_use_discipline"]

--- a/tests/test_prompt_templates.py
+++ b/tests/test_prompt_templates.py
@@ -1,0 +1,223 @@
+"""Tests for the public ``langgraph_kit.prompt_templates`` library (issue #43 v1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionRegistry,
+    SectionStability,
+)
+from langgraph_kit.prompt_templates import (
+    be_concise,
+    completion_signal,
+    core_identity,
+    diff_section,
+    error_handling,
+    memory_awareness,
+    operate_carefully,
+    output_format_natural,
+    output_format_structured,
+    tool_use_discipline,
+)
+
+ALL_SHIPPED = [
+    core_identity,
+    operate_carefully,
+    be_concise,
+    completion_signal,
+    memory_awareness,
+    tool_use_discipline,
+    error_handling,
+    output_format_natural,
+    output_format_structured,
+]
+
+
+# ---------------------------------------------------------------------------
+# Library-shape invariants
+# ---------------------------------------------------------------------------
+
+
+class TestLibraryShape:
+    def test_all_shipped_sections_are_promptsection_instances(self) -> None:
+        for section in ALL_SHIPPED:
+            assert isinstance(section, PromptSection), section
+
+    def test_every_shipped_section_has_non_empty_content(self) -> None:
+        for section in ALL_SHIPPED:
+            assert section.content.strip(), f"empty content: {section.id}"
+
+    def test_every_shipped_section_has_a_version(self) -> None:
+        for section in ALL_SHIPPED:
+            assert section.version, f"missing version: {section.id}"
+
+    def test_section_ids_unique_within_a_version(self) -> None:
+        """``output_format_natural`` and ``output_format_structured`` share an id but differ in version."""
+        seen: set[tuple[str, str]] = set()
+        for section in ALL_SHIPPED:
+            key = (section.id, section.version)
+            assert key not in seen, f"duplicate (id, version): {key}"
+            seen.add(key)
+
+    def test_at_least_eight_shipped_sections(self) -> None:
+        """Issue #43 acceptance criterion: 8+ sections shipped."""
+        assert len(ALL_SHIPPED) >= 8, len(ALL_SHIPPED)
+
+    def test_conditional_sections_declare_their_condition(self) -> None:
+        for section in ALL_SHIPPED:
+            if section.stability == SectionStability.CONDITIONAL:
+                assert section.condition, (
+                    f"CONDITIONAL section {section.id} missing condition"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    def test_register_many_with_full_library(self) -> None:
+        """All shipped sections register cleanly into a fresh SectionRegistry."""
+        registry = SectionRegistry()
+        # Skip the duplicate-id pair to avoid auto-promotion confusion.
+        registry.register_many(
+            [s for s in ALL_SHIPPED if s.id != "output_format"]
+            + [output_format_natural]  # explicitly pick one variant
+        )
+        # Spot-check: the registry sees every id we put in.
+        for section in ALL_SHIPPED:
+            if section.id == "output_format":
+                continue
+            assert registry.get(section.id) is not None, section.id
+
+    def test_get_active_returns_unconditional_sections(self) -> None:
+        """Without conditions set, only STABLE+VOLATILE sections appear."""
+        registry = SectionRegistry()
+        registry.register(core_identity)
+        registry.register(memory_awareness)  # CONDITIONAL on "memory"
+        active = registry.get_active(conditions=set())
+        ids = [s.id for s in active]
+        assert "core_identity" in ids
+        assert "memory_awareness" not in ids
+
+    def test_get_active_with_memory_condition_includes_memory_awareness(self) -> None:
+        registry = SectionRegistry()
+        registry.register(core_identity)
+        registry.register(memory_awareness)
+        active = registry.get_active(conditions={"memory"})
+        ids = [s.id for s in active]
+        assert "memory_awareness" in ids
+
+    def test_overriding_a_shipped_section_replaces_it(self) -> None:
+        """Per the docstring contract: register-by-id overrides whole-section."""
+        registry = SectionRegistry()
+        registry.register(core_identity)
+        custom = core_identity.model_copy(
+            update={"content": "Domain-specific identity here."}
+        )
+        registry.register(custom)
+        result = registry.get("core_identity")
+        assert result is not None
+        assert result.content == "Domain-specific identity here."
+
+
+# ---------------------------------------------------------------------------
+# Versioning interplay (issue #18)
+# ---------------------------------------------------------------------------
+
+
+class TestVersioningInterplay:
+    def test_output_format_pair_can_coexist_in_one_registry(self) -> None:
+        """Same id, different versions — exactly what #18's per-id versioning enables."""
+        registry = SectionRegistry()
+        registry.register(output_format_natural, set_current=False)
+        registry.register(output_format_structured)  # current
+        assert sorted(registry.list_versions("output_format")) == sorted(
+            ["1-natural", "1-structured"]
+        )
+        assert registry.current_version("output_format") == "1-structured"
+        # Switch via #18's set_current API.
+        registry.set_current("output_format", "1-natural")
+        active = registry.get("output_format")
+        assert active is not None
+        assert "natural language" in active.content
+
+
+# ---------------------------------------------------------------------------
+# diff_section helper
+# ---------------------------------------------------------------------------
+
+
+class TestDiffSection:
+    def test_identical_sections_diff_to_empty_string(self) -> None:
+        assert diff_section(core_identity, core_identity) == ""
+
+    def test_content_change_appears_in_diff(self) -> None:
+        custom = core_identity.model_copy(update={"content": "Custom identity here."})
+        diff = diff_section(custom, core_identity)
+        assert "shipped:core_identity@1" in diff
+        assert "Custom identity here." in diff
+        assert diff.startswith("---")  # unified diff header
+
+    def test_version_change_appears_in_diff(self) -> None:
+        custom = core_identity.model_copy(update={"version": "custom-1"})
+        diff = diff_section(custom, core_identity)
+        assert "version: custom-1" in diff
+        assert "version: 1" in diff
+
+    def test_priority_change_appears_in_diff(self) -> None:
+        custom = core_identity.model_copy(update={"priority": 999})
+        diff = diff_section(custom, core_identity)
+        assert "priority: 999" in diff
+
+    def test_condition_change_appears_in_diff(self) -> None:
+        custom = core_identity.model_copy(update={"condition": "premium-tier"})
+        diff = diff_section(custom, core_identity)
+        assert "condition: premium-tier" in diff
+
+    def test_stability_change_appears_in_diff(self) -> None:
+        custom = core_identity.model_copy(
+            update={"stability": SectionStability.VOLATILE}
+        )
+        diff = diff_section(custom, core_identity)
+        # Diff shows the actual enum value text.
+        assert "stability: volatile" in diff
+
+    def test_diff_uses_unified_format_markers(self) -> None:
+        """Confirms the diff is parseable by terminal diff highlighters."""
+        custom = core_identity.model_copy(update={"content": "x"})
+        diff = diff_section(custom, core_identity)
+        assert any(line.startswith("@@") for line in diff.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# Public-API surface check
+# ---------------------------------------------------------------------------
+
+
+class TestPublicApi:
+    def test_all_promised_names_importable(self) -> None:
+        from langgraph_kit import prompt_templates
+
+        for name in prompt_templates.__all__:
+            assert hasattr(prompt_templates, name), name
+
+    def test_diff_section_round_trip_no_change(self) -> None:
+        """``diff_section(s, s)`` short-circuits without invoking difflib."""
+        # Just confirms the equality fast-path produces the empty-string contract.
+        for section in ALL_SHIPPED:
+            assert diff_section(section, section) == ""
+
+
+# ---------------------------------------------------------------------------
+# pytest fixture for verifying section content stability
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def shipped_library() -> list[PromptSection]:
+    """Convenience fixture for downstream test suites that want to scan the library."""
+    return ALL_SHIPPED


### PR DESCRIPTION
## Summary

New `langgraph_kit.prompt_templates` package shipping 9 reusable `PromptSection` instances plus a `diff_section` helper for visualizing customizations. Integration with `AgentConfig.prompt_overrides` and auto-registration on `SectionRegistry()` are intentionally deferred to follow-ups so this PR doesn't change graph-build semantics for existing callers.

Closes part of #43.

## Public surface

```python
from langgraph_kit.core.prompt_assembly.sections import SectionRegistry
from langgraph_kit.prompt_templates import (
    core_identity, operate_carefully, be_concise,
    memory_awareness, tool_use_discipline,
    error_handling, output_format_natural,
    diff_section,
)

registry = SectionRegistry()
registry.register_many([
    core_identity, operate_carefully, be_concise,
    memory_awareness, tool_use_discipline, error_handling,
    output_format_natural,
])

# Customize a shipped section:
custom = core_identity.model_copy(update={
    "content": "You are an internal-tools agent for the X team.",
    "version": "x-team-1",
})
registry.register(custom)

# See what changed at startup:
print(diff_section(custom, baseline=core_identity))
# --- shipped:core_identity@1
# +++ custom:core_identity@x-team-1
# @@ -1,5 +1,5 @@
# -# version: 1
# +# version: x-team-1
#  ...
# -You are a helpful AI assistant.
# +You are an internal-tools agent for the X team.
```

## What lands

- **`core.py`** (4 sections): `core_identity`, `operate_carefully`, `be_concise`, `completion_signal` — the "be a careful, concise assistant" baseline split into discrete sections so callers can compose subsets.
- **`memory.py`** (1 section): `memory_awareness` — CONDITIONAL on `"memory"`; mirrors the kit's reference deep-agent `memory_instructions` section but standalone.
- **`tools.py`** (1 section): `tool_use_discipline` — CONDITIONAL on `"tools"`; encourages parallel batching and discourages blind retries.
- **`safety.py`** (3 sections): `error_handling` plus paired `output_format_natural` / `output_format_structured` sharing the `"output_format"` id with distinct versions.
- **`diff.py`**: `diff_section(custom, baseline)` renders a unified diff over content + version + priority + stability + condition. Returns `""` when sections match.

Each shipped section is frozen (Pydantic), versioned, priority-ranked, and has a docstring explaining its scope. **9 total** — meets the issue's "8+" acceptance criterion.

## Versioning interplay (issue #18)

The `output_format_natural` / `output_format_structured` pair demonstrates the kit's #18 per-id versioning: same id, different `version` field, both can coexist in one `SectionRegistry` and switch via `set_current`. Test covers this round-trip.

## Customization contract

Override is whole-section: `custom = shipped.model_copy(update={...})` then `registry.register(custom)` replaces by id (registry semantics unchanged from before this PR). Partial-merge overrides aren't supported; documented in the package docstring.

## Verification

- `uv run pytest` → **1348 / 1348 + 1 skip** (grandalf optional). +20 new tests.
- `uv run ruff check .` clean, `uv run ruff format --check .` clean, `uv run basedpyright` 0 errors on the new package.

### 20 new tests across 5 classes

- **Library shape (6)**: every shipped section is a `PromptSection`, has non-empty content, has a version, ids unique within (id, version) pairs, at least 8 sections, CONDITIONAL sections declare their condition.
- **Registry integration (4)**: `register_many` round-trip, `get_active` filters by condition (`memory_awareness` only fires with `conditions={"memory"}`), `get_active` with memory condition surfaces it, override-by-id replaces whole section.
- **Versioning interplay (1)**: `output_format_natural` / `output_format_structured` coexist in one registry; `set_current` switches the active variant.
- **`diff_section` (7)**: identical sections diff to empty, content / version / priority / condition / stability changes appear in the diff, output uses unified-diff markers (parseable by terminal diff highlighters).
- **Public API surface (2)**: every name in `__all__` resolves; `diff_section(s, s)` short-circuits to empty string.

## Deferred (out of scope)

- **`AgentConfig.prompt_overrides`** dict + lifecycle integration through `SectionRegistry`. Wider change touching the config and graph-build paths; needs its own design + caller migration story.
- **Auto-registration** of the shipped library on a fresh `SectionRegistry` instance. Action-at-a-distance — opt-in imports keep the surface predictable for now.
- **Migrating the kit's existing scattered prompts** (`BASIC_SYSTEM_PROMPT`, `_EXTRACTION_PROMPT`, `_CORE_SECTIONS`, etc.) to reference the library. Each migration is its own small refactor; consumers can adopt the library incrementally.
- **Per-language prompts** (i18n). Document English-only.

## Test plan

- [x] Full test suite passes (1348 / 1348)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format, basedpyright all clean
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)