### PR TITLE
feat(contrib): cron-style scheduled triggers via apscheduler (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Cron-style scheduled triggers
+  (`langgraph_kit.contrib.schedule`).** New optional dependency
+  `langgraph-kit[schedule]` (apscheduler). `ScheduledSpec(id,
+  agent_id, cron, payload_template)` defines one cron-fired
+  invocation; `ScheduledRegistry` collects them; cron expressions
+  are validated at registration time so typos fail at deploy
+  instead of at first fire. `ScheduledTriggerRunner(registry,
+  graph_resolver=...)` is an async context manager that drives
+  apscheduler's `AsyncIOScheduler`; `fire_now(spec_id)` triggers
+  out of band for tests and manual ops. **UTC-only** by design —
+  local-time cron is a footgun across multi-region deployments.
+  Multi-worker advisory-lock coordination is intentionally
+  deferred (depends on the wider Postgres-coordination work in
+  #27); run one scheduler per deployment for now. Closes
+  [#81](https://github.com/allada-homelab/langgraph-kit/issues/81).
+
 - **`ReplayRunner.step()` — async-iterator replay variant.** New
   `step(*, start_at=0, stop_at=None, overrides=None)` async
   generator yields one `TurnResult(turn_index, user_input,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,9 @@ mcp = ["langchain-mcp-adapters>=0.2.2"]
 mcp-server = ["mcp>=1.27"]
 fastapi = ["fastapi>=0.136"]
 agui = ["ag-ui-protocol>=0.1.18"]
+schedule = ["apscheduler>=3.11"]
 all = [
-    "langgraph-kit[postgres,openai,anthropic,google,deepagents,langfuse,mcp,mcp-server,fastapi,agui]",
+    "langgraph-kit[postgres,openai,anthropic,google,deepagents,langfuse,mcp,mcp-server,fastapi,agui,schedule]",
 ]
 
 [build-system]

--- a/src/langgraph_kit/contrib/schedule.py
+++ b/src/langgraph_kit/contrib/schedule.py
@@ -1,0 +1,294 @@
+"""Cron-style scheduled triggers for agent invocation.
+
+A scheduled spec ties a cron expression to an agent and a payload
+template that renders into the user message the agent sees on each
+fire. Built on apscheduler's ``AsyncIOScheduler`` so it integrates
+cleanly with the FastAPI lifespan / any asyncio app.
+
+Usage::
+
+    from langgraph_kit.contrib.schedule import (
+        ScheduledRegistry, ScheduledSpec, ScheduledTriggerRunner,
+    )
+
+    registry = ScheduledRegistry()
+    registry.register(ScheduledSpec(
+        id="weekly-summary",
+        agent_id="reports-agent",
+        cron="0 9 * * MON",  # UTC — see below
+        payload_template="Generate this week's summary report.",
+    ))
+
+    async with ScheduledTriggerRunner(registry, graph_resolver=...) as runner:
+        await runner.start()
+        # ... lifespan continues; runner.stop() called on __aexit__
+
+The runner exposes ``fire_now(spec_id)`` for testing and manual
+invocation; production fires happen via the apscheduler loop.
+
+## Scope (issue #81 v1)
+
+- One scheduled-trigger surface backed by ``apscheduler``.
+- Cron expressions validated at registration (apscheduler raises
+  ``ValueError`` on bad syntax).
+- **UTC-only.** Local-time cron is a footgun across deployments —
+  ``"0 9 * * MON"`` always means 09:00 UTC, never local time.
+- ``graph_resolver`` callable matches the webhook-router signature
+  (``(agent_id) -> compiled graph``) so callers can share one
+  resolver across multiple trigger surfaces.
+
+## Deferred
+
+- Multi-worker advisory lock. Issue spec calls for Postgres
+  ``pg_try_advisory_lock`` to prevent duplicate fires when N
+  workers run the same scheduler. That depends on the wider
+  Postgres-coordination work in #27. Until then, run one scheduler
+  per deployment (or cope with at-most-N duplicate fires).
+- FastAPI lifespan integration as a one-call helper. Today the
+  caller wires ``ScheduledTriggerRunner`` into their lifespan
+  manually — small enough that a helper is premature.
+- Persistence of fire history / next-run timestamps to the Store.
+  Useful for ops dashboards; defer until someone asks.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
+
+logger = logging.getLogger(__name__)
+
+
+class ScheduledSpec(BaseModel):
+    """Configuration for one cron-fired agent invocation.
+
+    Frozen because the registry uses ``id`` as a stable key — a spec
+    that mutates after it's registered would silently re-target
+    the schedule with no audit trail.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    """Stable identifier; used as the apscheduler job id and the
+    key in :class:`ScheduledRegistry`."""
+
+    agent_id: str
+    """Which registered agent the schedule fires against. Resolved
+    via the ``graph_resolver`` callable passed to
+    :class:`ScheduledTriggerRunner`."""
+
+    cron: str
+    """Five-field cron expression (``minute hour day month
+    day-of-week``). Validated at registration via apscheduler's
+    parser — bad syntax raises ``ValueError`` immediately rather
+    than at first fire.
+
+    UTC-only by design — see module docstring. The ``timezone``
+    field on the underlying ``CronTrigger`` is hardcoded to
+    ``"UTC"`` because every other choice is a footgun across
+    multi-region deployments.
+    """
+
+    payload_template: str = ""
+    """Plain string handed to the agent as the user message at fire
+    time. ``str.format``-style templating against the spec's
+    ``payload_data`` would let callers parameterize fires at
+    registration time but adds complexity — for v1 the template is
+    a literal string. Use Python f-strings at registration for any
+    parameterization you need."""
+
+    payload_data: dict[str, Any] = Field(default_factory=dict)
+    """Free-form metadata stored on the spec; surfaced to caller
+    code via :py:meth:`ScheduledRegistry.get` (e.g. for logging the
+    fire context). The agent itself only sees ``payload_template``
+    as the user message."""
+
+
+class ScheduledRegistry:
+    """In-process registry of :class:`ScheduledSpec` instances.
+
+    Persistence is intentionally out of scope for v1 — initialize
+    at app startup with whatever specs you care about.
+    Re-registering an existing id replaces it; the runner picks up
+    the new schedule on its next ``start()``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._specs: dict[str, ScheduledSpec] = {}
+
+    def register(self, spec: ScheduledSpec) -> None:
+        """Register *spec*. Validates the cron expression up front.
+
+        Raises ``ValueError`` (from apscheduler) if the cron string
+        is malformed — catches typos at deploy time instead of at
+        first fire.
+        """
+        # Validate by attempting to construct the apscheduler
+        # CronTrigger; we discard the result and let the runner
+        # build its own at start time.
+        from apscheduler.triggers.cron import (
+            CronTrigger,
+        )
+
+        CronTrigger.from_crontab(spec.cron, timezone="UTC")
+        self._specs[spec.id] = spec
+
+    def get(self, spec_id: str) -> ScheduledSpec | None:
+        return self._specs.get(spec_id)
+
+    def remove(self, spec_id: str) -> None:
+        self._specs.pop(spec_id, None)
+
+    def list_ids(self) -> list[str]:
+        return list(self._specs.keys())
+
+    def all_specs(self) -> list[ScheduledSpec]:
+        """All registered specs in insertion order. Used by the runner."""
+        return list(self._specs.values())
+
+
+class ScheduledTriggerRunner:
+    """apscheduler lifecycle wrapper for a :class:`ScheduledRegistry`.
+
+    Built as an async context manager so the FastAPI lifespan
+    pattern is the natural shape::
+
+        async with ScheduledTriggerRunner(registry, graph_resolver=...) as runner:
+            await runner.start()
+            yield  # FastAPI lifespan continues
+            # __aexit__ stops the scheduler cleanly
+
+    For tests: ``fire_now(spec_id)`` triggers the agent invocation
+    out of band so coverage doesn't depend on real wall-clock
+    advancement.
+    """
+
+    def __init__(
+        self,
+        registry: ScheduledRegistry,
+        *,
+        graph_resolver: Callable[[str], Any],
+    ) -> None:
+        super().__init__()
+        # graph_resolver mirrors the webhook router's signature:
+        # ``(agent_id) -> compiled graph``. Anything that quacks
+        # like a LangGraph compiled graph works (real graph in
+        # production, mock in tests).
+        self._registry = registry
+        self._graph_resolver = graph_resolver
+        self._scheduler: Any = None
+
+    async def __aenter__(self) -> ScheduledTriggerRunner:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.stop()
+
+    async def start(self) -> None:
+        """Build the scheduler, register every spec's job, start the loop.
+
+        Idempotent — calling ``start()`` twice is a no-op on the
+        second call (apscheduler raises if you try to start a
+        running scheduler, so we guard).
+        """
+        if self._scheduler is not None and self._scheduler.running:
+            return
+        from apscheduler.schedulers.asyncio import (
+            AsyncIOScheduler,
+        )
+        from apscheduler.triggers.cron import (
+            CronTrigger,
+        )
+
+        scheduler = AsyncIOScheduler(timezone="UTC")
+        for spec in self._registry.all_specs():
+            scheduler.add_job(
+                self._fire,
+                trigger=CronTrigger.from_crontab(spec.cron, timezone="UTC"),
+                id=spec.id,
+                args=[spec.id],
+                replace_existing=True,
+                misfire_grace_time=60,
+            )
+        scheduler.start()
+        self._scheduler = scheduler
+        logger.info(
+            "ScheduledTriggerRunner started with %d job(s)",
+            len(self._registry.all_specs()),
+        )
+
+    async def stop(self) -> None:
+        """Stop the scheduler. Idempotent."""
+        if self._scheduler is None:
+            return
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+        self._scheduler = None
+
+    async def fire_now(self, spec_id: str) -> str:
+        """Fire *spec_id* immediately, bypassing the cron schedule.
+
+        Returns the thread id of the resulting agent run. Useful for
+        tests (no wall-clock dependency) and manual ops invocations.
+        Raises ``KeyError`` if *spec_id* isn't registered.
+        """
+        spec = self._registry.get(spec_id)
+        if spec is None:
+            msg = f"Unknown scheduled spec id: {spec_id!r}"
+            raise KeyError(msg)
+        return await self._fire(spec_id)
+
+    async def _fire(self, spec_id: str) -> str:
+        """Internal fire path used by both apscheduler and ``fire_now``."""
+        from langchain_core.messages import (
+            HumanMessage,
+        )
+
+        spec = self._registry.get(spec_id)
+        if spec is None:
+            # Spec was removed between schedule registration and
+            # this fire — surface as a warning rather than blowing
+            # up the scheduler thread.
+            logger.warning(
+                "ScheduledTrigger %s fired but spec is no longer registered",
+                spec_id,
+            )
+            return ""
+
+        graph = self._graph_resolver(spec.agent_id)
+        thread_id = f"scheduled-{spec.id}-{uuid.uuid4().hex[:12]}"
+        config = {"configurable": {"thread_id": thread_id}}
+        await graph.ainvoke(
+            {"messages": [HumanMessage(content=spec.payload_template)]},
+            config=config,
+        )
+        logger.info(
+            "ScheduledTrigger fired",
+            extra={
+                "spec_id": spec.id,
+                "agent_id": spec.agent_id,
+                "thread_id": thread_id,
+            },
+        )
+        return thread_id
+
+
+__all__ = [
+    "ScheduledRegistry",
+    "ScheduledSpec",
+    "ScheduledTriggerRunner",
+]

--- a/tests/test_contrib_schedule.py
+++ b/tests/test_contrib_schedule.py
@@ -1,0 +1,212 @@
+"""Tests for ``langgraph_kit.contrib.schedule`` (issue #81)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph_kit.contrib.schedule import (
+    ScheduledRegistry,
+    ScheduledSpec,
+    ScheduledTriggerRunner,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraph:
+    """Records each ``ainvoke`` call so tests can assert on what was sent."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+
+    async def ainvoke(
+        self, input_data: dict[str, Any], config: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        self.calls.append((input_data, config))
+        return {"messages": []}
+
+
+# ---------------------------------------------------------------------------
+# ScheduledSpec
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledSpec:
+    def test_default_payload_is_empty(self) -> None:
+        spec = ScheduledSpec(id="weekly", agent_id="agent", cron="0 9 * * MON")
+        assert spec.payload_template == ""
+        assert spec.payload_data == {}
+
+    def test_spec_is_frozen(self) -> None:
+        spec = ScheduledSpec(id="weekly", agent_id="agent", cron="0 9 * * MON")
+        with pytest.raises(Exception):  # noqa: B017,PT011
+            spec.cron = "* * * * *"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ScheduledRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledRegistry:
+    def test_register_and_get_round_trip(self) -> None:
+        registry = ScheduledRegistry()
+        spec = ScheduledSpec(id="weekly", agent_id="agent", cron="0 9 * * MON")
+        registry.register(spec)
+        assert registry.get("weekly") is spec
+
+    def test_get_unknown_id_returns_none(self) -> None:
+        assert ScheduledRegistry().get("missing") is None
+
+    def test_register_replaces_existing_id(self) -> None:
+        registry = ScheduledRegistry()
+        registry.register(ScheduledSpec(id="x", agent_id="a", cron="0 9 * * *"))
+        registry.register(ScheduledSpec(id="x", agent_id="a", cron="0 10 * * *"))
+        spec = registry.get("x")
+        assert spec is not None
+        assert spec.cron == "0 10 * * *"
+
+    def test_remove_drops_spec(self) -> None:
+        registry = ScheduledRegistry()
+        registry.register(ScheduledSpec(id="x", agent_id="a", cron="0 9 * * *"))
+        registry.remove("x")
+        assert registry.get("x") is None
+
+    def test_list_ids_and_all_specs_match(self) -> None:
+        registry = ScheduledRegistry()
+        registry.register(ScheduledSpec(id="a", agent_id="x", cron="0 * * * *"))
+        registry.register(ScheduledSpec(id="b", agent_id="x", cron="*/5 * * * *"))
+        assert sorted(registry.list_ids()) == ["a", "b"]
+        assert {s.id for s in registry.all_specs()} == {"a", "b"}
+
+    def test_invalid_cron_raises_at_registration(self) -> None:
+        """Catches typos at deploy time, not at first fire."""
+        registry = ScheduledRegistry()
+        with pytest.raises(ValueError, match=r"Wrong number of fields|Invalid"):
+            registry.register(ScheduledSpec(id="bad", agent_id="a", cron="not a cron"))
+
+
+# ---------------------------------------------------------------------------
+# ScheduledTriggerRunner
+# ---------------------------------------------------------------------------
+
+
+class TestScheduledTriggerRunner:
+    @pytest.mark.asyncio
+    async def test_fire_now_invokes_agent_with_payload(self) -> None:
+        spec = ScheduledSpec(
+            id="weekly",
+            agent_id="reports",
+            cron="0 9 * * MON",
+            payload_template="Generate this week's summary report.",
+        )
+        registry = ScheduledRegistry()
+        registry.register(spec)
+        graph = _FakeGraph()
+
+        async with ScheduledTriggerRunner(
+            registry, graph_resolver=lambda _: graph
+        ) as runner:
+            thread_id = await runner.fire_now("weekly")
+
+        assert thread_id.startswith("scheduled-weekly-")
+        assert len(graph.calls) == 1
+        input_data, config = graph.calls[0]
+        msg = input_data["messages"][0]
+        assert msg.content == "Generate this week's summary report."
+        assert config is not None
+        assert config["configurable"]["thread_id"] == thread_id
+
+    @pytest.mark.asyncio
+    async def test_fire_now_unknown_spec_raises_keyerror(self) -> None:
+        registry = ScheduledRegistry()
+        async with ScheduledTriggerRunner(
+            registry, graph_resolver=lambda _: _FakeGraph()
+        ) as runner:
+            with pytest.raises(KeyError, match="Unknown scheduled spec"):
+                await runner.fire_now("missing")
+
+    @pytest.mark.asyncio
+    async def test_start_stop_lifecycle(self) -> None:
+        """Idempotent ``start()`` + ``stop()`` matches the lifespan pattern."""
+        spec = ScheduledSpec(id="job", agent_id="agent", cron="* * * * *")
+        registry = ScheduledRegistry()
+        registry.register(spec)
+
+        runner = ScheduledTriggerRunner(registry, graph_resolver=lambda _: _FakeGraph())
+        await runner.start()
+        # Second start is a no-op (idempotent).
+        await runner.start()
+        await runner.stop()
+        # Stop is also idempotent.
+        await runner.stop()
+
+    @pytest.mark.asyncio
+    async def test_two_fires_get_distinct_thread_ids(self) -> None:
+        spec = ScheduledSpec(id="job", agent_id="agent", cron="* * * * *")
+        registry = ScheduledRegistry()
+        registry.register(spec)
+        graph = _FakeGraph()
+
+        async with ScheduledTriggerRunner(
+            registry, graph_resolver=lambda _: graph
+        ) as runner:
+            t1 = await runner.fire_now("job")
+            t2 = await runner.fire_now("job")
+
+        assert t1 != t2
+        assert len(graph.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_aenter_aexit_propagates_stop(self) -> None:
+        """Context manager exit calls stop() even when no exception was raised."""
+        registry = ScheduledRegistry()
+        registry.register(ScheduledSpec(id="job", agent_id="a", cron="* * * * *"))
+        runner = ScheduledTriggerRunner(registry, graph_resolver=lambda _: _FakeGraph())
+        async with runner:
+            await runner.start()
+            assert runner._scheduler is not None
+            assert runner._scheduler.running
+        # After exit, scheduler is stopped + cleared.
+        assert runner._scheduler is None
+
+    @pytest.mark.asyncio
+    async def test_fire_with_unregistered_spec_logs_and_returns_empty(self) -> None:
+        """Race: spec removed after the scheduler queued it. Don't crash."""
+        spec = ScheduledSpec(id="job", agent_id="agent", cron="* * * * *")
+        registry = ScheduledRegistry()
+        registry.register(spec)
+
+        async with ScheduledTriggerRunner(
+            registry, graph_resolver=lambda _: _FakeGraph()
+        ) as runner:
+            # Simulate the race by calling the internal _fire after removal.
+            registry.remove("job")
+            result = await runner._fire("job")
+            assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_graph_resolver_receives_agent_id(self) -> None:
+        """Resolver is called with spec.agent_id (not spec.id)."""
+        seen: list[str] = []
+
+        def resolver(agent_id: str) -> _FakeGraph:
+            seen.append(agent_id)
+            return _FakeGraph()
+
+        registry = ScheduledRegistry()
+        registry.register(
+            ScheduledSpec(
+                id="schedule-x",
+                agent_id="agent-y",
+                cron="* * * * *",
+            )
+        )
+        async with ScheduledTriggerRunner(registry, graph_resolver=resolver) as runner:
+            await runner.fire_now("schedule-x")
+
+        assert seen == ["agent-y"]

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -952,6 +964,7 @@ agui = [
 ]
 all = [
     { name = "ag-ui-protocol" },
+    { name = "apscheduler" },
     { name = "deepagents" },
     { name = "fastapi" },
     { name = "langchain-anthropic" },
@@ -989,6 +1002,9 @@ openai = [
 postgres = [
     { name = "langgraph-checkpoint-postgres" },
 ]
+schedule = [
+    { name = "apscheduler" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1024,6 +1040,8 @@ type = [
 requires-dist = [
     { name = "ag-ui-protocol", marker = "extra == 'agui'", specifier = ">=0.1.18" },
     { name = "ag-ui-protocol", marker = "extra == 'all'", specifier = ">=0.1.18" },
+    { name = "apscheduler", marker = "extra == 'all'", specifier = ">=3.11" },
+    { name = "apscheduler", marker = "extra == 'schedule'", specifier = ">=3.11" },
     { name = "deepagents", marker = "extra == 'all'", specifier = ">=0.5.3" },
     { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.5.3" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.136" },
@@ -1047,7 +1065,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp-server'", specifier = ">=1.27" },
     { name = "pydantic", specifier = ">=2.13" },
 ]
-provides-extras = ["agui", "all", "anthropic", "deepagents", "fastapi", "google", "langfuse", "mcp", "mcp-server", "openai", "postgres"]
+provides-extras = ["agui", "all", "anthropic", "deepagents", "fastapi", "google", "langfuse", "mcp", "mcp-server", "openai", "postgres", "schedule"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2368,6 +2386,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Cron-fired agent invocations through a focused `langgraph_kit.contrib.schedule` module. New optional dependency `langgraph-kit[schedule]` (apscheduler). Multi-worker advisory-lock coordination from the original issue plan is intentionally deferred to follow up after #27 lands the wider Postgres-coordination work; run one scheduler per deployment until then.

Closes #81.

## Public surface

```python
from langgraph_kit.contrib.schedule import (
    ScheduledRegistry, ScheduledSpec, ScheduledTriggerRunner,
)

registry = ScheduledRegistry()
registry.register(ScheduledSpec(
    id="weekly-summary",
    agent_id="reports-agent",
    cron="0 9 * * MON",  # 09:00 UTC every Monday
    payload_template="Generate this week's summary report.",
))

# In your FastAPI lifespan or any asyncio app:
async with ScheduledTriggerRunner(registry, graph_resolver=my_graph_lookup) as runner:
    await runner.start()
    yield  # lifespan continues; runner.stop() called on __aexit__

# For tests / manual ops:
thread_id = await runner.fire_now("weekly-summary")
```

## What lands

- **New optional dep** `langgraph-kit[schedule]` (apscheduler ≥ 3.11). Added to the `all` extra.
- **`ScheduledSpec`** (frozen Pydantic): id, agent_id, cron string, payload_template, optional payload_data metadata.
- **`ScheduledRegistry`**: register/get/remove/list_ids/all_specs. `register` validates the cron expression via apscheduler's parser, so typos raise at deploy time instead of at first fire.
- **`ScheduledTriggerRunner`**: async context manager that wraps `apscheduler.AsyncIOScheduler`, registers each spec's job at `start()`, shuts the scheduler down on `__aexit__`. `fire_now(spec_id)` triggers out of band for tests and manual ops invocations.
- **UTC-only.** `CronTrigger.from_crontab(..., timezone="UTC")` hardcoded. Local-time cron is a footgun across multi-region deployments — documented in the module + spec docstrings.
- **`graph_resolver`** callable matches the webhook router's signature `(agent_id) -> compiled graph`, so callers can share one resolver across multiple trigger surfaces.

## Verification

- `uv run pytest` → **1371 / 1371 + 1 skip** (grandalf optional). +15 schedule tests this PR.
- `uv run ruff check .` clean, `uv run ruff format --check .` clean, `uv run basedpyright` 0 errors on the new module.

### 15 new tests across 3 classes

- **`ScheduledSpec` (2)**: default payload empty; spec is frozen.
- **`ScheduledRegistry` (6)**: register/get round-trip, get unknown returns None, register replaces same id, remove drops spec, list_ids/all_specs match, invalid cron raises `ValueError` at registration with helpful message.
- **`ScheduledTriggerRunner` (7)**: `fire_now` invokes agent with payload, `fire_now` unknown spec raises `KeyError`, idempotent start/stop, two consecutive fires get distinct thread ids, context-manager exit calls stop, race condition (spec removed after queueing) logs and returns empty rather than crashing, `graph_resolver` receives `spec.agent_id` (not `spec.id`).

## Deferred (out of scope)

- **Multi-worker advisory-lock** coordination via Postgres `pg_try_advisory_lock`. Depends on the wider Postgres-coordination work in #27. Until then, run one scheduler per deployment.
- **FastAPI lifespan helper** that wires `ScheduledTriggerRunner` automatically. Today the caller wires it manually inside their `create_app_lifespan` — small enough that a helper is premature.
- **Persistence of fire history** / next-run timestamps to the Store (ops dashboards). Defer until someone asks.

## Test plan

- [x] Full test suite passes (1371 / 1371)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Lint, format, basedpyright all clean
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)