### PR TITLE
feat(reference): wire default TurnTelemetryStopHook (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: default `TurnTelemetryStopHook`.**
+  `build_reference_deep_agent` now wires a non-blocking
+  `TurnTelemetryStopHook` against `StopHooksMiddleware` so the
+  lifecycle-hook path is exercised by default — closing the
+  docstring/reality mismatch where "stop hooks" was advertised but
+  never populated. The hook emits a single `logger.debug` line per turn
+  with the message count and the tool-call count from the final
+  `AIMessage`. Two new kwargs let callers compose: `enable_default_stop_hooks`
+  (default `True`) opts out, and `extra_stop_hooks` is appended after
+  the default for richer telemetry. Closes
+  [#98](https://github.com/allada-homelab/langgraph-kit/issues/98).
+
 - **Live graph overlay — `node_entered` / `node_exited` SSE
   events.** `stream_agent_events` now emits
   `{"node_entered": {"id", "name"}}` and

--- a/src/langgraph_kit/core/resilience/__init__.py
+++ b/src/langgraph_kit/core/resilience/__init__.py
@@ -8,7 +8,7 @@ from .loop_guard import (
 )
 from .post_run import PostRunBackstopMiddleware
 from .runtime_state import RuntimeStateMiddleware
-from .stop_hooks import StopHooksMiddleware
+from .stop_hooks import StopHooksMiddleware, TurnTelemetryStopHook
 from .structured_output import (
     StructuredOutputMiddleware,
     extract_structured_output,
@@ -27,6 +27,7 @@ __all__ = [
     "StructuredOutputMiddleware",
     "ToolErrorMiddleware",
     "ToolLoopGuardMiddleware",
+    "TurnTelemetryStopHook",
     "extract_structured_output",
     "format_schema_instruction",
     "parse_structured_output",

--- a/src/langgraph_kit/core/resilience/stop_hooks.py
+++ b/src/langgraph_kit/core/resilience/stop_hooks.py
@@ -10,6 +10,7 @@ import logging
 from typing import Any
 
 from langchain.agents.middleware.types import AgentMiddleware as _AgentMiddleware
+from langchain_core.messages import AIMessage
 
 logger = logging.getLogger(__name__)
 
@@ -39,3 +40,37 @@ class StopHooksMiddleware(_AgentMiddleware):  # type: ignore[misc]
                     raise
                 logger.exception("Non-blocking hook failed: %s", hook)
         return None
+
+
+class TurnTelemetryStopHook:
+    """Default stop hook used by the reference deep agent.
+
+    Emits a single ``logger.debug`` line per turn with the message count
+    and the number of tool calls on the final ``AIMessage``. Non-blocking
+    by design — exceptions from this hook are logged and swallowed by
+    :class:`StopHooksMiddleware` rather than failing the turn.
+
+    Suitable as a baseline observability hook; replace or extend via
+    ``extra_stop_hooks=`` on the reference builder for richer telemetry.
+    """
+
+    blocking: bool = False
+
+    async def on_turn_complete(self, state: Any) -> None:
+        messages: list[Any] = []
+        if isinstance(state, dict):
+            raw = state.get("messages")
+            if isinstance(raw, list):
+                messages = raw
+
+        tool_call_count = 0
+        if messages:
+            last = messages[-1]
+            if isinstance(last, AIMessage):
+                tool_call_count = len(last.tool_calls or [])
+
+        logger.debug(
+            "turn_complete messages=%d tool_calls=%d",
+            len(messages),
+            tool_call_count,
+        )

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -17,6 +17,7 @@ from langgraph_kit.core.prompt_assembly.sections import (
     PromptSection,
     SectionStability,
 )
+from langgraph_kit.core.resilience.stop_hooks import TurnTelemetryStopHook
 from langgraph_kit.graphs._builder import DEFAULT_RECURSION_LIMIT, build_deep_agent
 
 # ---------------------------------------------------------------------------
@@ -114,6 +115,8 @@ def build_reference_deep_agent(
     mcp_tools: list[Any] | None = None,
     plugins: Any = None,
     recursion_limit: int = DEFAULT_RECURSION_LIMIT,
+    enable_default_stop_hooks: bool = True,
+    extra_stop_hooks: list[Any] | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -125,7 +128,23 @@ def build_reference_deep_agent(
     ``PluginContribution`` objects whose tools, prompt sections, and
     worker definitions are merged into the build. See
     :func:`langgraph_kit.graphs._builder.build_deep_agent` for details.
+
+    ``enable_default_stop_hooks`` (default ``True``) registers a
+    :class:`~langgraph_kit.core.resilience.stop_hooks.TurnTelemetryStopHook`
+    against :class:`StopHooksMiddleware` so the lifecycle-hook path is
+    exercised by the reference build. Set to ``False`` to opt out.
+
+    ``extra_stop_hooks`` is appended after the default so callers can
+    stack additional hooks alongside (or instead of) the telemetry hook.
+    Each entry should expose an awaitable ``on_turn_complete(state)``;
+    set ``blocking=True`` on a hook to make its exceptions fail the turn
+    rather than be logged and swallowed.
     """
+    stop_hooks: list[Any] = []
+    if enable_default_stop_hooks:
+        stop_hooks.append(TurnTelemetryStopHook())
+    if extra_stop_hooks:
+        stop_hooks.extend(extra_stop_hooks)
     return build_deep_agent(
         agent_name="reference-deep-agent",
         core_sections=_CORE_SECTIONS,
@@ -135,4 +154,5 @@ def build_reference_deep_agent(
         mcp_tools=mcp_tools,
         plugins=plugins,
         recursion_limit=recursion_limit,
+        stop_hooks=stop_hooks or None,
     )

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 
 from langgraph_kit.core.orchestration.workers import GENERAL_WORKERS
 from langgraph_kit.core.resilience.runtime_state import RuntimeStateMiddleware
-from langgraph_kit.core.resilience.stop_hooks import StopHooksMiddleware
+from langgraph_kit.core.resilience.stop_hooks import (
+    StopHooksMiddleware,
+    TurnTelemetryStopHook,
+)
 from langgraph_kit.graphs.reference_deep_agent import build_reference_deep_agent
 
 # ---------------------------------------------------------------------------
@@ -777,3 +782,160 @@ def test_explicit_deferred_tools_condition_with_populated_registry_is_kept(
 
     system_prompt = deepagents_mod.create_deep_agent.call_args.kwargs["system_prompt"]
     assert _DEFERRED_SECTION_MARKER in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# TurnTelemetryStopHook tests
+# ---------------------------------------------------------------------------
+# The hook is the default observability hook wired by
+# ``build_reference_deep_agent``. It must be non-blocking and emit a
+# stable debug log on every turn so the StopHooksMiddleware path is
+# exercised end-to-end without affecting agent behavior.
+
+
+class TestTurnTelemetryStopHook:
+    @pytest.mark.asyncio
+    async def test_logs_message_and_tool_call_count(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Hook emits one debug line with the expected counts."""
+        hook = TurnTelemetryStopHook()
+        state = {
+            "messages": [
+                HumanMessage(content="hi"),
+                AIMessage(
+                    content="working on it",
+                    tool_calls=[
+                        {"name": "search", "args": {}, "id": "tc1"},
+                        {"name": "read", "args": {}, "id": "tc2"},
+                    ],
+                ),
+            ]
+        }
+        with caplog.at_level(
+            logging.DEBUG, logger="langgraph_kit.core.resilience.stop_hooks"
+        ):
+            await hook.on_turn_complete(state)
+
+        records = [r for r in caplog.records if r.name.endswith("stop_hooks")]
+        assert any(
+            "messages=2" in r.getMessage() and "tool_calls=2" in r.getMessage()
+            for r in records
+        ), [r.getMessage() for r in records]
+
+    @pytest.mark.asyncio
+    async def test_zero_tool_calls_when_last_is_human(self) -> None:
+        """A trailing HumanMessage produces tool_calls=0 (no AIMessage)."""
+        hook = TurnTelemetryStopHook()
+        await hook.on_turn_complete(
+            {"messages": [AIMessage(content="ok"), HumanMessage(content="next")]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_messages_key(self) -> None:
+        """Empty / missing state keys must not raise."""
+        hook = TurnTelemetryStopHook()
+        await hook.on_turn_complete({})
+        await hook.on_turn_complete({"messages": []})
+        await hook.on_turn_complete({"messages": "not-a-list"})
+
+    @pytest.mark.asyncio
+    async def test_is_non_blocking(self) -> None:
+        """Hook declares blocking=False so StopHooksMiddleware swallows failures."""
+        hook = TurnTelemetryStopHook()
+        assert hook.blocking is False
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: stop_hooks wiring
+# ---------------------------------------------------------------------------
+
+
+def _build_reference_with_capture(
+    mock_store: Any,
+    *,
+    enable_default_stop_hooks: bool | None = None,
+    extra_stop_hooks: list[Any] | None = None,
+) -> MagicMock:
+    """Helper: build the reference graph under mocked deepagents+llm.
+
+    Returns the mocked ``deepagents.create_deep_agent`` so callers can
+    inspect the kwargs the builder forwarded.
+    """
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    kwargs: dict[str, Any] = {"checkpointer": MagicMock(), "store": mock_store}
+    if enable_default_stop_hooks is not None:
+        kwargs["enable_default_stop_hooks"] = enable_default_stop_hooks
+    if extra_stop_hooks is not None:
+        kwargs["extra_stop_hooks"] = extra_stop_hooks
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_deep_agent(**kwargs)
+    return deepagents_mod.create_deep_agent
+
+
+def test_reference_default_stop_hook_is_wired(mock_store: Any) -> None:
+    """Default build attaches a TurnTelemetryStopHook via StopHooksMiddleware."""
+    create = _build_reference_with_capture(mock_store)
+
+    middleware = create.call_args.kwargs["middleware"]
+    stop_mw = next(m for m in middleware if isinstance(m, StopHooksMiddleware))
+    hooks = stop_mw._hooks
+    assert any(isinstance(h, TurnTelemetryStopHook) for h in hooks), (
+        "TurnTelemetryStopHook must be wired by default; otherwise the "
+        "reference docstring's 'stop hooks' claim is false"
+    )
+
+
+def test_reference_default_stop_hook_can_be_disabled(mock_store: Any) -> None:
+    """``enable_default_stop_hooks=False`` opts out of the telemetry hook."""
+    create = _build_reference_with_capture(mock_store, enable_default_stop_hooks=False)
+
+    middleware = create.call_args.kwargs["middleware"]
+    stop_mw = next(m for m in middleware if isinstance(m, StopHooksMiddleware))
+    assert not any(isinstance(h, TurnTelemetryStopHook) for h in stop_mw._hooks)
+
+
+def test_reference_extra_stop_hooks_appended_after_default(mock_store: Any) -> None:
+    """``extra_stop_hooks=`` runs *after* the default so user hooks observe the same state."""
+
+    class _Marker:
+        blocking = False
+
+        async def on_turn_complete(self, state: Any) -> None:
+            return None
+
+    extra = _Marker()
+    create = _build_reference_with_capture(mock_store, extra_stop_hooks=[extra])
+
+    middleware = create.call_args.kwargs["middleware"]
+    stop_mw = next(m for m in middleware if isinstance(m, StopHooksMiddleware))
+    hooks = stop_mw._hooks
+    # Default hook present, extra appended after it.
+    assert any(isinstance(h, TurnTelemetryStopHook) for h in hooks)
+    assert hooks[-1] is extra
+
+
+def test_reference_extra_only_when_default_disabled(mock_store: Any) -> None:
+    """Disabling the default leaves only the caller-supplied hooks."""
+
+    class _Marker:
+        blocking = False
+
+        async def on_turn_complete(self, state: Any) -> None:
+            return None
+
+    extra = _Marker()
+    create = _build_reference_with_capture(
+        mock_store, enable_default_stop_hooks=False, extra_stop_hooks=[extra]
+    )
+
+    middleware = create.call_args.kwargs["middleware"]
+    stop_mw = next(m for m in middleware if isinstance(m, StopHooksMiddleware))
+    hooks = stop_mw._hooks
+    assert hooks == [extra]


### PR DESCRIPTION
## Summary

- The reference deep agent now wires a default `TurnTelemetryStopHook` against `StopHooksMiddleware`, closing the docstring/reality mismatch where "stop hooks" was advertised but never populated.
- Hook is non-blocking and emits one `logger.debug` line per turn (message count + tool-call count from the final `AIMessage`) — observable by default, side-effect-light.
- Two new kwargs on `build_reference_deep_agent`: `enable_default_stop_hooks` (default `True`) opts out, and `extra_stop_hooks` is appended after the default for richer telemetry stacks.

## Test plan

- [x] `uv run pytest` (1400 passed, 1 skipped)
- [x] `uv run basedpyright` on touched files (0 errors)
- [x] `uv run ruff check src tests` + `uv run ruff format .`
- [x] `uv run pre-commit run --all-files`
- New: `TestTurnTelemetryStopHook` (4 cases) + four wire-up tests covering default-on, opt-out, extras-with-default, extras-only.

Fixes #98