### PR TITLE
feat(reference): populate default deferred-tool catalog (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: default deferred-tool catalog.**
+  `build_reference_deep_agent` now populates the
+  `DeferredToolRegistry` with three side-effect-free demo tools
+  (`web_fetch_demo`, `code_indexer_demo`, `db_query_demo`), so the
+  `tool_search` / `call_deferred_tool` discovery loop is exercised by
+  default — closing the showcase gap where the reference always
+  tripped the "empty deferred → strip the search tools" branch and
+  the `deferred_tools` prompt condition never fired. Two new kwargs
+  let callers compose: `enable_default_deferred_tools` (default
+  `True`) opts out, and `extra_deferred_tools` is a configurator
+  callback run after the default so caller-registered ids override
+  the demos. Closes
+  [#99](https://github.com/allada-homelab/langgraph-kit/issues/99).
+
 - **Reference deep agent: default `TurnTelemetryStopHook`.**
   `build_reference_deep_agent` now wires a non-blocking
   `TurnTelemetryStopHook` against `StopHooksMiddleware` so the

--- a/src/langgraph_kit/graphs/_reference_deferred_tools.py
+++ b/src/langgraph_kit/graphs/_reference_deferred_tools.py
@@ -1,0 +1,112 @@
+"""Demo deferred tools wired into the reference deep agent.
+
+These are intentionally side-effect-free stubs whose only purpose is to
+exercise the ``tool_search`` + ``call_deferred_tool`` discovery loop in
+the reference build. Real integrations (HTTP fetch, code indexing, SQL)
+belong in their own modules — clone the registration helper below and
+swap the stubs out.
+
+The trio (``web_fetch_demo``, ``code_indexer_demo``, ``db_query_demo``)
+covers three discovery shapes deliberately:
+
+- a tool with a URL-like argument (web fetch) — search by ``"web"`` /
+  ``"http"``
+- a tool with a query argument over a "large" catalog (code indexer) —
+  search by ``"code"`` / ``"index"``
+- a tool with a single structured-string argument (db query) — search
+  by ``"sql"`` / ``"database"``
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
+from langgraph_kit.core.tools.deferred import DeferredToolRegistry
+
+
+async def _web_fetch_demo(url: str) -> str:
+    """Stub: pretend to fetch a URL."""
+    return f"[demo] would fetch: {url}"
+
+
+async def _code_indexer_demo(query: str, *, limit: int = 5) -> str:
+    """Stub: pretend to search a large code index."""
+    return f"[demo] would search code index for: {query!r} (limit={limit})"
+
+
+async def _db_query_demo(sql: str) -> str:
+    """Stub: pretend to run a read-only SQL query."""
+    return f"[demo] would run SQL: {sql}"
+
+
+def _build_demo_capabilities() -> list[ToolCapability]:
+    """Return the three demo capabilities with stable ids and tags.
+
+    Kept tag-rich so :meth:`DeferredToolRegistry.search` returns sensible
+    matches across the typical query shapes a user would attempt
+    (``"web"``, ``"http"``, ``"code"``, ``"sql"``, ``"database"``).
+    """
+    return [
+        ToolCapability(
+            id="ref_web_fetch_demo",
+            name="web_fetch_demo",
+            description=(
+                "Demo deferred tool — fetches the contents of a URL over HTTP. "
+                "Returns a stub string; replace with a real HTTP fetcher in "
+                "your build."
+            ),
+            fn=_web_fetch_demo,
+            tags=["web", "http", "fetch", "network"],
+            risk=ToolRisk.READ_ONLY,
+        ),
+        ToolCapability(
+            id="ref_code_indexer_demo",
+            name="code_indexer_demo",
+            description=(
+                "Demo deferred tool — searches a large code index by keyword "
+                "and returns matching snippets. Returns a stub string; "
+                "replace with a real indexer in your build."
+            ),
+            fn=_code_indexer_demo,
+            tags=["code", "index", "search", "grep"],
+            risk=ToolRisk.READ_ONLY,
+        ),
+        ToolCapability(
+            id="ref_db_query_demo",
+            name="db_query_demo",
+            description=(
+                "Demo deferred tool — runs a read-only SQL query against a "
+                "database. Returns a stub string; replace with a real DB "
+                "connector in your build."
+            ),
+            fn=_db_query_demo,
+            tags=["sql", "database", "query", "data"],
+            risk=ToolRisk.READ_ONLY,
+        ),
+    ]
+
+
+def register_reference_deferred_tools(deferred: DeferredToolRegistry) -> None:
+    """Populate the deferred catalog with the reference demo tools."""
+    deferred.register_many(_build_demo_capabilities())
+
+
+def make_reference_deferred_configurator(
+    extra: Any | None = None,
+) -> Any:
+    """Build a ``configure_deferred_tools=`` callback for the reference build.
+
+    The callback registers the default demo tools first, then runs the
+    optional ``extra`` callback. Because :class:`DeferredToolRegistry` is
+    keyed by capability id, anything ``extra`` registers under one of
+    the demo ids will override the demo — keeping the documented
+    "caller wins on collisions" precedence.
+    """
+
+    def _configure(deferred: DeferredToolRegistry) -> None:
+        register_reference_deferred_tools(deferred)
+        if extra is not None:
+            extra(deferred)
+
+    return _configure

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -19,6 +19,9 @@ from langgraph_kit.core.prompt_assembly.sections import (
 )
 from langgraph_kit.core.resilience.stop_hooks import TurnTelemetryStopHook
 from langgraph_kit.graphs._builder import DEFAULT_RECURSION_LIMIT, build_deep_agent
+from langgraph_kit.graphs._reference_deferred_tools import (
+    make_reference_deferred_configurator,
+)
 
 # ---------------------------------------------------------------------------
 # Prompt sections — stable core + volatile context
@@ -117,6 +120,8 @@ def build_reference_deep_agent(
     recursion_limit: int = DEFAULT_RECURSION_LIMIT,
     enable_default_stop_hooks: bool = True,
     extra_stop_hooks: list[Any] | None = None,
+    enable_default_deferred_tools: bool = True,
+    extra_deferred_tools: Any | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -139,12 +144,37 @@ def build_reference_deep_agent(
     Each entry should expose an awaitable ``on_turn_complete(state)``;
     set ``blocking=True`` on a hook to make its exceptions fail the turn
     rather than be logged and swallowed.
+
+    ``enable_default_deferred_tools`` (default ``True``) populates the
+    :class:`~langgraph_kit.core.tools.deferred.DeferredToolRegistry` with
+    a small set of demo tools so the ``tool_search`` /
+    ``call_deferred_tool`` discovery loop is exercised by default —
+    closing the showcase gap where the reference always tripped the
+    "empty deferred → strip the search tools" branch in the builder.
+    Set to ``False`` to leave the catalog empty.
+
+    ``extra_deferred_tools`` is a callback
+    ``(DeferredToolRegistry) -> None`` that runs *after* the default
+    registration. Because the registry is keyed by capability id, a
+    callback registering under a default id (e.g. ``"ref_web_fetch_demo"``)
+    overrides the demo — keeping the "caller wins on collisions"
+    precedence the rest of the builder follows.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
         stop_hooks.append(TurnTelemetryStopHook())
     if extra_stop_hooks:
         stop_hooks.extend(extra_stop_hooks)
+
+    if enable_default_deferred_tools:
+        configure_deferred_tools = make_reference_deferred_configurator(
+            extra=extra_deferred_tools
+        )
+    elif extra_deferred_tools is not None:
+        configure_deferred_tools = extra_deferred_tools
+    else:
+        configure_deferred_tools = None
+
     return build_deep_agent(
         agent_name="reference-deep-agent",
         core_sections=_CORE_SECTIONS,
@@ -155,4 +185,5 @@ def build_reference_deep_agent(
         plugins=plugins,
         recursion_limit=recursion_limit,
         stop_hooks=stop_hooks or None,
+        configure_deferred_tools=configure_deferred_tools,
     )

--- a/tests/e2e/test_deferred_tools_e2e.py
+++ b/tests/e2e/test_deferred_tools_e2e.py
@@ -134,7 +134,7 @@ async def test_empty_deferred_registry_does_not_push_llm_toward_tool_search(
     e2e_store: Any,
     patched_build_llm: Any,
 ) -> None:
-    """Default build with an empty DeferredToolRegistry must NOT tell the LLM to tool_search.
+    """An empty DeferredToolRegistry must NOT tell the LLM to tool_search.
 
     The regression: prompt said "don't assume unavailable — search first"
     while the registry was empty. Fix: ``build_deep_agent`` now auto-gates
@@ -146,12 +146,17 @@ async def test_empty_deferred_registry_does_not_push_llm_toward_tool_search(
     during that invocation via a capturing scripted model. Stronger
     than inspecting compose-time output because it proves the prompt
     survives all middleware transformations on the way to the model.
+
+    Note: the reference build now ships with a default deferred catalog
+    (the ``ref_*_demo`` tools), so we explicitly disable it here to
+    recreate the empty-registry condition this test pins.
     """
     capturing = capturing_scripted_llm([answer("hi there")])
     with patched_build_llm(capturing):
         graph, _ = build_reference_deep_agent(
             checkpointer=checkpointer,
             store=e2e_store,
+            enable_default_deferred_tools=False,
         )
 
     await graph.ainvoke(

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -856,6 +856,8 @@ def _build_reference_with_capture(
     *,
     enable_default_stop_hooks: bool | None = None,
     extra_stop_hooks: list[Any] | None = None,
+    enable_default_deferred_tools: bool | None = None,
+    extra_deferred_tools: Any | None = None,
 ) -> MagicMock:
     """Helper: build the reference graph under mocked deepagents+llm.
 
@@ -868,6 +870,10 @@ def _build_reference_with_capture(
         kwargs["enable_default_stop_hooks"] = enable_default_stop_hooks
     if extra_stop_hooks is not None:
         kwargs["extra_stop_hooks"] = extra_stop_hooks
+    if enable_default_deferred_tools is not None:
+        kwargs["enable_default_deferred_tools"] = enable_default_deferred_tools
+    if extra_deferred_tools is not None:
+        kwargs["extra_deferred_tools"] = extra_deferred_tools
     with (
         patch.dict(sys.modules, module_patches),
         patch(
@@ -939,3 +945,102 @@ def test_reference_extra_only_when_default_disabled(mock_store: Any) -> None:
     stop_mw = next(m for m in middleware if isinstance(m, StopHooksMiddleware))
     hooks = stop_mw._hooks
     assert hooks == [extra]
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: deferred-tool wiring
+# ---------------------------------------------------------------------------
+# The reference build must populate the DeferredToolRegistry by default
+# so the tool_search / call_deferred_tool discovery loop is exercised.
+# With the registry empty the builder strips both tools from the active
+# surface and the deferred_tools prompt section is gated off — the
+# showcase disappears entirely. These tests pin the wiring.
+
+
+def test_reference_default_deferred_tools_are_populated(mock_store: Any) -> None:
+    """Default build registers demo tools; tool_search + call_deferred_tool reach the LLM."""
+    create = _build_reference_with_capture(mock_store)
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "tool_search" in tool_names
+    assert "call_deferred_tool" in tool_names
+    assert (
+        "use the tool_search tool to discover"
+        in create.call_args.kwargs["system_prompt"]
+    )
+
+
+def test_reference_default_deferred_tools_can_be_disabled(mock_store: Any) -> None:
+    """``enable_default_deferred_tools=False`` opts out — back to empty registry semantics."""
+    create = _build_reference_with_capture(
+        mock_store, enable_default_deferred_tools=False
+    )
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "tool_search" not in tool_names
+    assert "call_deferred_tool" not in tool_names
+
+
+def test_reference_extra_deferred_tools_runs_after_default(mock_store: Any) -> None:
+    """``extra_deferred_tools=`` runs after the default registration so caller IDs win."""
+    from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
+
+    captured: dict[str, Any] = {}
+
+    async def _custom_tool() -> str:
+        return "custom"
+
+    def _extra(deferred: Any) -> None:
+        captured["pre_extra_ids"] = sorted(c.id for c in deferred.list_all())
+        deferred.register(
+            ToolCapability(
+                id="ref_web_fetch_demo",
+                name="caller_override",
+                description="caller override",
+                fn=_custom_tool,
+                risk=ToolRisk.READ_ONLY,
+            )
+        )
+
+    _build_reference_with_capture(mock_store, extra_deferred_tools=_extra)
+
+    assert "ref_web_fetch_demo" in captured["pre_extra_ids"]
+    assert "ref_code_indexer_demo" in captured["pre_extra_ids"]
+    assert "ref_db_query_demo" in captured["pre_extra_ids"]
+
+
+def test_reference_extra_deferred_tools_alone_when_default_disabled(
+    mock_store: Any,
+) -> None:
+    """With default disabled, ``extra_deferred_tools=`` is the sole configurator."""
+    from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
+
+    captured: dict[str, Any] = {}
+
+    async def _solo() -> str:
+        return ""
+
+    def _extra(deferred: Any) -> None:
+        captured["pre_extra_ids"] = sorted(c.id for c in deferred.list_all())
+        deferred.register(
+            ToolCapability(
+                id="solo_tool",
+                name="solo_tool",
+                description="x",
+                fn=_solo,
+                risk=ToolRisk.READ_ONLY,
+            )
+        )
+
+    create = _build_reference_with_capture(
+        mock_store,
+        enable_default_deferred_tools=False,
+        extra_deferred_tools=_extra,
+    )
+
+    assert captured["pre_extra_ids"] == []
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "tool_search" in tool_names


### PR DESCRIPTION
## Summary

- Reference deep agent now populates `DeferredToolRegistry` by default with three side-effect-free demo capabilities (`web_fetch_demo`, `code_indexer_demo`, `db_query_demo`), so the `tool_search` / `call_deferred_tool` discovery flow is exercised in the showcase build instead of being silently stripped.
- Two new kwargs on `build_reference_deep_agent`: `enable_default_deferred_tools` (default `True`) opts out, and `extra_deferred_tools` is a configurator callback run after the default so caller-registered ids override the demo tools.
- Existing e2e test pinning the auto-gating behavior on an empty registry now disables the default explicitly to recreate the empty-registry condition.

## Test plan

- [x] `uv run pytest` (1404 passed, 1 skipped)
- [x] `uv run basedpyright` on touched files (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 4 wire-up tests covering default-on, opt-out, extras-after-default, extras-only-with-default-disabled. The unit assertions pin both the bound-tool surface (`tool_search` / `call_deferred_tool` present) and the prompt-condition activation (`deferred_tools_awareness` text present).

Fixes #99