### PR TITLE
feat(reference): showcase configure_tools= with current_environment demo (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: default custom tool via
+  `configure_tools=`.** `build_reference_deep_agent` now registers a
+  read-only `current_environment` tool through the `configure_tools=`
+  extension callback so the path has an in-tree exemplar that isn't
+  domain-specific (the existing example was the coding agent's
+  worktree tools). The tool reports Python version, OS, kit version,
+  and whether the working directory is a git repo. Two new kwargs:
+  `enable_default_custom_tools` (default `True`) opts out, and
+  `extra_configure_tools` is a callback `(ToolRegistry) -> None` that
+  runs after the default so caller-registered ids override the demo.
+  Closes [#100](https://github.com/allada-homelab/langgraph-kit/issues/100).
+
 - **Reference deep agent: default deferred-tool catalog.**
   `build_reference_deep_agent` now populates the
   `DeferredToolRegistry` with three side-effect-free demo tools

--- a/src/langgraph_kit/graphs/_reference_custom_tools.py
+++ b/src/langgraph_kit/graphs/_reference_custom_tools.py
@@ -1,0 +1,81 @@
+"""Demo custom tool wired into the reference deep agent.
+
+This module exists to give cloners of ``reference_deep_agent`` an
+in-tree, minimal exemplar of the ``configure_tools=`` extension point.
+``coding_agent`` ships a production-shaped example (worktree tools);
+this is the no-domain version: a single read-only tool that reports
+basic process metadata.
+
+The tool is intentionally narrow — clone the registration helper and
+swap the body when adding your own.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+from typing import Any
+
+from langgraph_kit.core.graph_builder.tools import register_tool
+from langgraph_kit.core.tools.capability import ToolRisk
+from langgraph_kit.core.tools.registry import ToolRegistry
+
+
+async def current_environment() -> str:
+    """Report basic info about the agent's runtime: Python version,
+    OS, kit version, and whether the working directory is a git repo.
+
+    Use this when the user asks about the agent's environment, or when
+    you need to surface kit / Python version info for diagnostics.
+    Returns a plain-text summary; do not parse the structure
+    programmatically.
+    """
+    try:
+        from langgraph_kit import __version__ as kit_version
+    except ImportError:
+        kit_version = "unknown"
+
+    git_present = (Path.cwd() / ".git").exists()
+    return (
+        f"python={platform.python_version()} "
+        f"system={platform.system()} "
+        f"kit={kit_version} "
+        f"git_repo={git_present}"
+    )
+
+
+def register_reference_custom_tools(registry: ToolRegistry) -> None:
+    """Register the demo ``current_environment`` tool on ``registry``."""
+    register_tool(
+        registry,
+        current_environment,
+        id_prefix="reference",
+        name="current_environment",
+        tags=["reference", "environment", "diagnostics"],
+        risk=ToolRisk.READ_ONLY,
+        prompt_guidance=(
+            "Use current_environment to report the agent's Python "
+            "version, OS, kit version, and whether the working "
+            "directory is a git repo. Read-only and side-effect-free."
+        ),
+    )
+
+
+def make_reference_configure_tools(
+    extra: Any | None = None,
+) -> Any:
+    """Build a ``configure_tools=`` callback for the reference build.
+
+    The callback registers the default demo tool first, then runs the
+    optional ``extra`` callback. ``ToolRegistry.register`` is an upsert
+    on capability id, so anything ``extra`` registers under the demo's
+    id (``"reference_current_environment"``) overrides the demo —
+    matching the documented "caller wins on collisions" precedence.
+    """
+
+    def _configure(registry: ToolRegistry) -> None:
+        register_reference_custom_tools(registry)
+        if extra is not None:
+            extra(registry)
+
+    return _configure

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -19,6 +19,9 @@ from langgraph_kit.core.prompt_assembly.sections import (
 )
 from langgraph_kit.core.resilience.stop_hooks import TurnTelemetryStopHook
 from langgraph_kit.graphs._builder import DEFAULT_RECURSION_LIMIT, build_deep_agent
+from langgraph_kit.graphs._reference_custom_tools import (
+    make_reference_configure_tools,
+)
 from langgraph_kit.graphs._reference_deferred_tools import (
     make_reference_deferred_configurator,
 )
@@ -122,6 +125,8 @@ def build_reference_deep_agent(
     extra_stop_hooks: list[Any] | None = None,
     enable_default_deferred_tools: bool = True,
     extra_deferred_tools: Any | None = None,
+    enable_default_custom_tools: bool = True,
+    extra_configure_tools: Any | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -159,6 +164,18 @@ def build_reference_deep_agent(
     callback registering under a default id (e.g. ``"ref_web_fetch_demo"``)
     overrides the demo — keeping the "caller wins on collisions"
     precedence the rest of the builder follows.
+
+    ``enable_default_custom_tools`` (default ``True``) registers a
+    minimal ``current_environment`` tool via the ``configure_tools=``
+    extension point. The tool is read-only and side-effect-free; its
+    purpose is to demonstrate how domain agents can layer custom tools
+    onto the reference build (see ``coding_agent`` for a
+    production-shaped example with worktree tools).
+
+    ``extra_configure_tools`` is a callback
+    ``(ToolRegistry) -> None`` that runs *after* the default tool
+    registration so caller registrations under matching ids override
+    the defaults — same upsert-by-id precedence as plugin tools.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
@@ -175,6 +192,13 @@ def build_reference_deep_agent(
     else:
         configure_deferred_tools = None
 
+    if enable_default_custom_tools:
+        configure_tools = make_reference_configure_tools(extra=extra_configure_tools)
+    elif extra_configure_tools is not None:
+        configure_tools = extra_configure_tools
+    else:
+        configure_tools = None
+
     return build_deep_agent(
         agent_name="reference-deep-agent",
         core_sections=_CORE_SECTIONS,
@@ -185,5 +209,6 @@ def build_reference_deep_agent(
         plugins=plugins,
         recursion_limit=recursion_limit,
         stop_hooks=stop_hooks or None,
+        configure_tools=configure_tools,
         configure_deferred_tools=configure_deferred_tools,
     )

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -858,6 +858,8 @@ def _build_reference_with_capture(
     extra_stop_hooks: list[Any] | None = None,
     enable_default_deferred_tools: bool | None = None,
     extra_deferred_tools: Any | None = None,
+    enable_default_custom_tools: bool | None = None,
+    extra_configure_tools: Any | None = None,
 ) -> MagicMock:
     """Helper: build the reference graph under mocked deepagents+llm.
 
@@ -874,6 +876,10 @@ def _build_reference_with_capture(
         kwargs["enable_default_deferred_tools"] = enable_default_deferred_tools
     if extra_deferred_tools is not None:
         kwargs["extra_deferred_tools"] = extra_deferred_tools
+    if enable_default_custom_tools is not None:
+        kwargs["enable_default_custom_tools"] = enable_default_custom_tools
+    if extra_configure_tools is not None:
+        kwargs["extra_configure_tools"] = extra_configure_tools
     with (
         patch.dict(sys.modules, module_patches),
         patch(
@@ -1044,3 +1050,101 @@ def test_reference_extra_deferred_tools_alone_when_default_disabled(
     tools = create.call_args.kwargs["tools"]
     tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
     assert "tool_search" in tool_names
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: configure_tools= wiring
+# ---------------------------------------------------------------------------
+# The reference must showcase the configure_tools= extension point so
+# new domain agents have an in-tree pattern other than the
+# coding-specific worktree tools. The default registers a single
+# read-only ``current_environment`` tool.
+
+
+def test_reference_default_custom_tool_is_registered(mock_store: Any) -> None:
+    """Default build registers ``current_environment`` on the active tool surface."""
+    create = _build_reference_with_capture(mock_store)
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "current_environment" in tool_names
+
+
+def test_reference_default_custom_tool_can_be_disabled(mock_store: Any) -> None:
+    """``enable_default_custom_tools=False`` strips the demo tool from the surface."""
+    create = _build_reference_with_capture(
+        mock_store, enable_default_custom_tools=False
+    )
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "current_environment" not in tool_names
+
+
+def test_reference_extra_configure_tools_runs_after_default(mock_store: Any) -> None:
+    """``extra_configure_tools=`` runs after the default — caller can inspect/override."""
+    captured: dict[str, Any] = {}
+
+    async def custom_caller_tool() -> str:
+        return "custom"
+
+    def _extra(registry: Any) -> None:
+        captured["pre_extra_caps"] = sorted(c.id for c in registry.list_all())
+        # Register a brand-new caller-only tool to confirm the callback ran.
+        from langgraph_kit.core.graph_builder.tools import register_tool
+        from langgraph_kit.core.tools.capability import ToolRisk
+
+        register_tool(
+            registry,
+            custom_caller_tool,
+            id_prefix="caller",
+            tags=["caller"],
+            risk=ToolRisk.READ_ONLY,
+        )
+
+    create = _build_reference_with_capture(mock_store, extra_configure_tools=_extra)
+
+    # Default ran before extra: the demo tool is present in the registry
+    # snapshot taken inside the callback.
+    assert "reference_current_environment" in captured["pre_extra_caps"]
+
+    # And the caller's tool reaches the bound surface.
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "custom_caller_tool" in tool_names
+
+
+def test_reference_extra_configure_tools_alone_when_default_disabled(
+    mock_store: Any,
+) -> None:
+    """With default disabled, ``extra_configure_tools=`` is the sole tool callback."""
+    captured: dict[str, Any] = {}
+
+    async def solo_tool() -> str:
+        return ""
+
+    def _extra(registry: Any) -> None:
+        captured["pre_extra_caps"] = sorted(c.id for c in registry.list_all())
+        from langgraph_kit.core.graph_builder.tools import register_tool
+        from langgraph_kit.core.tools.capability import ToolRisk
+
+        register_tool(
+            registry,
+            solo_tool,
+            id_prefix="solo",
+            tags=["solo"],
+            risk=ToolRisk.READ_ONLY,
+        )
+
+    create = _build_reference_with_capture(
+        mock_store,
+        enable_default_custom_tools=False,
+        extra_configure_tools=_extra,
+    )
+
+    # Default did NOT run — the demo tool isn't in the snapshot.
+    assert "reference_current_environment" not in captured["pre_extra_caps"]
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
+    assert "solo_tool" in tool_names
+    assert "current_environment" not in tool_names


### PR DESCRIPTION
## Summary

- New read-only `current_environment` demo tool wired into `build_reference_deep_agent` via `configure_tools=`, giving cloners an in-tree exemplar that isn't domain-specific (the previous one was the coding agent's worktree tools).
- Tool reports Python version, OS, kit version, and whether `cwd/.git` exists. Tagged `["reference", "environment", "diagnostics"]`, risk `READ_ONLY`.
- New kwargs: `enable_default_custom_tools` (default `True`) and `extra_configure_tools` for caller composition.

## Test plan

- [x] `uv run pytest` (1408 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 4 wire-up tests (default-on, opt-out, extras-after-default with the default capability snapshot, extras-only-with-default-disabled).

Fixes #100