### PR TITLE
feat(prompt-assembly): SystemContextProvider as default in reference (#101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: default `SystemContextProvider`.**
+  `build_reference_deep_agent` now registers a `SystemContextProvider`
+  on the prompt composer, mirroring how `coding_agent` ships
+  `GitContextProvider` — closing the gap where the only in-tree
+  exemplar of `extra_providers=` was domain-specific. The provider
+  injects current UTC datetime (ISO 8601), `platform.system()`,
+  `os.name`, and the kit version under a `# System Context` heading.
+  Output is deterministic given a fixed `clock=` for testability. Two
+  new kwargs: `enable_default_extra_providers` (default `True`) opts
+  out, and `extra_providers` is appended after the default. Closes
+  [#101](https://github.com/allada-homelab/langgraph-kit/issues/101).
+
 - **Reference deep agent: default custom tool via
   `configure_tools=`.** `build_reference_deep_agent` now registers a
   read-only `current_environment` tool through the `configure_tools=`

--- a/src/langgraph_kit/core/prompt_assembly/system_context.py
+++ b/src/langgraph_kit/core/prompt_assembly/system_context.py
@@ -1,0 +1,55 @@
+"""System-environment context provider for the reference deep agent.
+
+Mirrors :class:`GitContextProvider`'s shape but targets the no-domain
+case: a minimal exemplar of the ``extra_providers=`` extension point so
+new domain agents have an in-tree pattern that doesn't assume git.
+
+Output is deterministic given a fixed clock (callers can inject
+``clock=`` for tests). Calling ``provide`` twice with the same clock
+returns the same string, so prompt-cache reuse is preserved when the
+provider is invoked multiple times within a single turn.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+
+class SystemContextProvider:
+    """Injects basic system / runtime info into the prompt.
+
+    Provides: current UTC datetime (ISO 8601), `platform.system()`,
+    `os.name`, and the kit version. Output is rendered under a
+    ``# System Context`` heading.
+
+    ``clock`` accepts a no-arg callable returning a ``datetime``;
+    defaults to ``datetime.now(UTC)``. Replace it in tests to make the
+    output deterministic.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        super().__init__()
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    async def provide(self, context: dict[str, Any]) -> str:  # noqa: ARG002
+        try:
+            from langgraph_kit import __version__ as kit_version
+        except ImportError:
+            kit_version = "unknown"
+
+        now = self._clock().isoformat(timespec="seconds")
+        return (
+            "# System Context\n"
+            f"- Current time (UTC): {now}\n"
+            f"- Platform: {platform.system()}\n"
+            f"- OS name: {os.name}\n"
+            f"- Kit version: {kit_version}"
+        )

--- a/src/langgraph_kit/core/prompt_assembly/system_context.py
+++ b/src/langgraph_kit/core/prompt_assembly/system_context.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 
 import os
 import platform
-from collections.abc import Callable
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class SystemContextProvider:

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -17,6 +17,7 @@ from langgraph_kit.core.prompt_assembly.sections import (
     PromptSection,
     SectionStability,
 )
+from langgraph_kit.core.prompt_assembly.system_context import SystemContextProvider
 from langgraph_kit.core.resilience.stop_hooks import TurnTelemetryStopHook
 from langgraph_kit.graphs._builder import DEFAULT_RECURSION_LIMIT, build_deep_agent
 from langgraph_kit.graphs._reference_custom_tools import (
@@ -127,6 +128,8 @@ def build_reference_deep_agent(
     extra_deferred_tools: Any | None = None,
     enable_default_custom_tools: bool = True,
     extra_configure_tools: Any | None = None,
+    enable_default_extra_providers: bool = True,
+    extra_providers: list[Any] | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -176,6 +179,18 @@ def build_reference_deep_agent(
     ``(ToolRegistry) -> None`` that runs *after* the default tool
     registration so caller registrations under matching ids override
     the defaults — same upsert-by-id precedence as plugin tools.
+
+    ``enable_default_extra_providers`` (default ``True``) registers a
+    :class:`~langgraph_kit.core.prompt_assembly.system_context.SystemContextProvider`
+    on the prompt composer, mirroring how ``coding_agent`` ships
+    ``GitContextProvider``. The provider injects current UTC datetime,
+    platform name, OS name, and the kit version under a
+    ``# System Context`` heading.
+
+    ``extra_providers`` is appended after the default so callers can
+    stack additional :class:`~langgraph_kit.core.prompt_assembly.context_providers.ContextProvider`
+    instances. Each provider's ``async provide(context)`` is invoked
+    by :class:`PromptComposer` when a full prompt is composed.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
@@ -199,6 +214,12 @@ def build_reference_deep_agent(
     else:
         configure_tools = None
 
+    providers: list[Any] = []
+    if enable_default_extra_providers:
+        providers.append(SystemContextProvider())
+    if extra_providers:
+        providers.extend(extra_providers)
+
     return build_deep_agent(
         agent_name="reference-deep-agent",
         core_sections=_CORE_SECTIONS,
@@ -211,4 +232,5 @@ def build_reference_deep_agent(
         stop_hooks=stop_hooks or None,
         configure_tools=configure_tools,
         configure_deferred_tools=configure_deferred_tools,
+        extra_providers=providers or None,
     )

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -860,6 +860,8 @@ def _build_reference_with_capture(
     extra_deferred_tools: Any | None = None,
     enable_default_custom_tools: bool | None = None,
     extra_configure_tools: Any | None = None,
+    enable_default_extra_providers: bool | None = None,
+    extra_providers: list[Any] | None = None,
 ) -> MagicMock:
     """Helper: build the reference graph under mocked deepagents+llm.
 
@@ -880,6 +882,10 @@ def _build_reference_with_capture(
         kwargs["enable_default_custom_tools"] = enable_default_custom_tools
     if extra_configure_tools is not None:
         kwargs["extra_configure_tools"] = extra_configure_tools
+    if enable_default_extra_providers is not None:
+        kwargs["enable_default_extra_providers"] = enable_default_extra_providers
+    if extra_providers is not None:
+        kwargs["extra_providers"] = extra_providers
     with (
         patch.dict(sys.modules, module_patches),
         patch(
@@ -1148,3 +1154,97 @@ def test_reference_extra_configure_tools_alone_when_default_disabled(
     tool_names = {getattr(fn, "__name__", getattr(fn, "name", None)) for fn in tools}
     assert "solo_tool" in tool_names
     assert "current_environment" not in tool_names
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: extra_providers wiring
+# ---------------------------------------------------------------------------
+# The reference must showcase the extra_providers= extension point so
+# new domain agents have an exemplar that doesn't assume git (the only
+# in-tree provider before this was GitContextProvider on coding_agent).
+
+
+def _captured_providers(mock_store: Any, **kwargs: Any) -> list[Any]:
+    """Build the reference with PromptComposer patched to capture provider list."""
+    captured: dict[str, list[Any]] = {}
+
+    from langgraph_kit.core.prompt_assembly.composer import PromptComposer as _Real
+
+    class _SpyComposer(_Real):
+        def __init__(self, sections: Any, providers: list[Any]) -> None:
+            captured["providers"] = providers
+            super().__init__(sections, providers)
+
+    module_patches, _, _ = _mock_deepagents_env()
+    full_kwargs: dict[str, Any] = {"checkpointer": MagicMock(), "store": mock_store}
+    full_kwargs.update(kwargs)
+
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+        patch("langgraph_kit.graphs._builder.PromptComposer", _SpyComposer),
+    ):
+        build_reference_deep_agent(**full_kwargs)
+
+    return captured["providers"]
+
+
+def test_reference_default_system_context_provider_is_wired(mock_store: Any) -> None:
+    """Default build registers a SystemContextProvider on the prompt composer."""
+    from langgraph_kit.core.prompt_assembly.system_context import SystemContextProvider
+
+    providers = _captured_providers(mock_store)
+    assert any(isinstance(p, SystemContextProvider) for p in providers), (
+        f"SystemContextProvider must be wired by default; got {providers!r}"
+    )
+
+
+def test_reference_default_system_context_provider_can_be_disabled(
+    mock_store: Any,
+) -> None:
+    """``enable_default_extra_providers=False`` removes the SystemContextProvider."""
+    from langgraph_kit.core.prompt_assembly.system_context import SystemContextProvider
+
+    providers = _captured_providers(mock_store, enable_default_extra_providers=False)
+    assert not any(isinstance(p, SystemContextProvider) for p in providers)
+
+
+def test_reference_extra_providers_appended_after_default(mock_store: Any) -> None:
+    """Caller-supplied ``extra_providers=`` are appended after the default."""
+    from langgraph_kit.core.prompt_assembly.system_context import SystemContextProvider
+
+    class _Marker:
+        async def provide(self, context: dict[str, Any]) -> str:
+            return "marker"
+
+    extra = _Marker()
+    providers = _captured_providers(mock_store, extra_providers=[extra])
+
+    # Default present, caller's provider appended after the kit's three +
+    # the SystemContextProvider default.
+    assert any(isinstance(p, SystemContextProvider) for p in providers)
+    assert providers[-1] is extra
+
+
+def test_reference_extra_providers_alone_when_default_disabled(
+    mock_store: Any,
+) -> None:
+    """With default disabled, only kit defaults + caller's providers appear."""
+    from langgraph_kit.core.prompt_assembly.system_context import SystemContextProvider
+
+    class _Marker:
+        async def provide(self, context: dict[str, Any]) -> str:
+            return "marker"
+
+    extra = _Marker()
+    providers = _captured_providers(
+        mock_store,
+        enable_default_extra_providers=False,
+        extra_providers=[extra],
+    )
+
+    assert not any(isinstance(p, SystemContextProvider) for p in providers)
+    assert providers[-1] is extra

--- a/tests/test_system_context_provider.py
+++ b/tests/test_system_context_provider.py
@@ -1,0 +1,47 @@
+"""Unit tests for ``SystemContextProvider``."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from langgraph_kit.core.prompt_assembly.system_context import SystemContextProvider
+
+
+@pytest.mark.asyncio
+async def test_provide_includes_expected_fields() -> None:
+    """Output contains datetime, platform, OS name, and a kit version line."""
+    out = await SystemContextProvider().provide({})
+
+    assert out.startswith("# System Context")
+    assert "Current time (UTC):" in out
+    assert "Platform:" in out
+    assert "OS name:" in out
+    assert "Kit version:" in out
+
+
+@pytest.mark.asyncio
+async def test_provide_is_deterministic_with_fixed_clock() -> None:
+    """Two calls with a frozen clock return identical output.
+
+    The agent prompt is composed multiple times within a turn (e.g.
+    coordinator re-render, sub-worker pass). If the system context
+    drifts between those passes, prompt-cache reuse breaks. Pinning a
+    clock here guards that contract.
+    """
+    fixed = datetime(2026, 4, 26, 12, 0, 0, tzinfo=UTC)
+    provider = SystemContextProvider(clock=lambda: fixed)
+
+    first = await provider.provide({})
+    second = await provider.provide({})
+
+    assert first == second
+    assert "2026-04-26T12:00:00+00:00" in first
+
+
+@pytest.mark.asyncio
+async def test_provide_advances_with_real_clock() -> None:
+    """Default clock returns *now*; output is non-empty."""
+    out = await SystemContextProvider().provide({})
+    assert "Current time (UTC):" in out


### PR DESCRIPTION
## Summary

- New `SystemContextProvider` (in `core/prompt_assembly/system_context.py`) injects current UTC datetime, platform, OS name, and kit version under a `# System Context` heading.
- Wired as a default `extra_provider` in `build_reference_deep_agent`, mirroring the coding agent's `GitContextProvider` so the `extra_providers=` extension point now has an in-tree exemplar that isn't domain-specific.
- Provider takes an injectable `clock=` for deterministic output in tests.
- Two new kwargs: `enable_default_extra_providers` (opt-out) and `extra_providers` (appended after the default).

## Test plan

- [x] `uv run pytest` (1415 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: `tests/test_system_context_provider.py` (3 cases — fields present, deterministic with frozen clock, real clock works) + 4 reference-wiring tests (default-on, opt-out, extras-appended, extras-only-with-default-disabled). Wiring tests use a `PromptComposer` spy to capture the provider list passed by the builder.

Fixes #101