### PR TITLE
feat(reference): expose output_schema= kwarg (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: opt-in `output_schema=` kwarg.**
+  `build_reference_deep_agent` now accepts an `output_schema:
+  type[BaseModel] | None = None` kwarg and forwards it to
+  `build_deep_agent`, which appends `StructuredOutputMiddleware` to
+  the stack when set. Closes the gap where the structured-output
+  feature shipped without a reference exemplar — callers can now
+  attach a Pydantic schema to the reference build directly. Closes
+  [#102](https://github.com/allada-homelab/langgraph-kit/issues/102).
+
 - **Reference deep agent: default `SystemContextProvider`.**
   `build_reference_deep_agent` now registers a `SystemContextProvider`
   on the prompt composer, mirroring how `coding_agent` ships

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -10,7 +10,10 @@ and tools (see ``coding_agent`` for the canonical extension pattern).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 from langgraph_kit.core.orchestration.workers import GENERAL_WORKERS
 from langgraph_kit.core.prompt_assembly.sections import (
@@ -130,6 +133,7 @@ def build_reference_deep_agent(
     extra_configure_tools: Any | None = None,
     enable_default_extra_providers: bool = True,
     extra_providers: list[Any] | None = None,
+    output_schema: type[BaseModel] | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -191,6 +195,15 @@ def build_reference_deep_agent(
     stack additional :class:`~langgraph_kit.core.prompt_assembly.context_providers.ContextProvider`
     instances. Each provider's ``async provide(context)`` is invoked
     by :class:`PromptComposer` when a full prompt is composed.
+
+    ``output_schema`` accepts a Pydantic ``BaseModel`` subclass. When
+    set, :class:`~langgraph_kit.core.resilience.structured_output.StructuredOutputMiddleware`
+    is appended to the middleware stack and validates the agent's
+    terminal message against the schema (looking for a single
+    ``<output_schema>{...}</output_schema>`` block). On mismatch the
+    middleware injects a retry nudge with the JSON-Schema rendering
+    of the model. ``None`` (default) leaves structured-output
+    validation off.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
@@ -233,4 +246,5 @@ def build_reference_deep_agent(
         configure_tools=configure_tools,
         configure_deferred_tools=configure_deferred_tools,
         extra_providers=providers or None,
+        output_schema=output_schema,
     )

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -1248,3 +1248,60 @@ def test_reference_extra_providers_alone_when_default_disabled(
 
     assert not any(isinstance(p, SystemContextProvider) for p in providers)
     assert providers[-1] is extra
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: output_schema= wiring
+# ---------------------------------------------------------------------------
+# The kwarg flows through to ``build_deep_agent`` which appends
+# StructuredOutputMiddleware when set. These tests pin the wiring so the
+# kwarg can't be silently dropped.
+
+
+def test_reference_output_schema_appends_structured_output_middleware(
+    mock_store: Any,
+) -> None:
+    """``output_schema=Schema`` adds a StructuredOutputMiddleware to the stack."""
+    from pydantic import BaseModel, Field
+
+    from langgraph_kit.core.resilience.structured_output import (
+        StructuredOutputMiddleware,
+    )
+
+    class Answer(BaseModel):
+        summary: str
+        confidence: float = Field(ge=0.0, le=1.0)
+
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_deep_agent(
+            checkpointer=MagicMock(),
+            store=mock_store,
+            output_schema=Answer,
+        )
+
+    middleware = deepagents_mod.create_deep_agent.call_args.kwargs["middleware"]
+    structured = [m for m in middleware if isinstance(m, StructuredOutputMiddleware)]
+    assert structured, (
+        "StructuredOutputMiddleware must be in the stack when output_schema= is set"
+    )
+    assert structured[0]._schema is Answer
+
+
+def test_reference_no_output_schema_omits_structured_output_middleware(
+    mock_store: Any,
+) -> None:
+    """Default build (no schema) leaves StructuredOutputMiddleware out of the stack."""
+    from langgraph_kit.core.resilience.structured_output import (
+        StructuredOutputMiddleware,
+    )
+
+    create = _build_reference_with_capture(mock_store)
+    middleware = create.call_args.kwargs["middleware"]
+    assert not any(isinstance(m, StructuredOutputMiddleware) for m in middleware)


### PR DESCRIPTION
## Summary

- Threads `output_schema: type[BaseModel] | None = None` through `build_reference_deep_agent` to `build_deep_agent`. When set, `StructuredOutputMiddleware` is appended to the reference's stack.
- No behavior change to the middleware itself; this PR is plumbing only so the structured-output feature is callable directly from the reference builder instead of requiring a drop-down to `build_deep_agent`.

## Test plan

- [x] `uv run pytest` (1417 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 2 wire-up tests (middleware appears when schema set, doesn't appear when unset). The middleware's behavior under malformed/valid output is exhaustively covered by the existing `tests/test_structured_output_middleware.py`.

Fixes #102