### PR TITLE
feat(reference): coordinator variant of the reference agent (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Coordinator variant of the reference agent.** New
+  `build_reference_coordinator_agent` (and a `coordinator: bool =
+  False` kwarg on `build_reference_deep_agent`) flips the build into
+  `CoordinatorMode`: the active tool surface is narrowed to
+  `ToolRisk.READ_ONLY` capabilities + the `task` delegation tool,
+  and the system prompt picks up the coordinator's role / delegation
+  / synthesis sections. The coordinator build identifies as
+  `reference-coordinator` so logs distinguish the two profiles.
+  Closes [#103](https://github.com/allada-homelab/langgraph-kit/issues/103).
+
 - **Reference deep agent: opt-in `output_schema=` kwarg.**
   `build_reference_deep_agent` now accepts an `output_schema:
   type[BaseModel] | None = None` kwarg and forwards it to

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -134,6 +134,7 @@ def build_reference_deep_agent(
     enable_default_extra_providers: bool = True,
     extra_providers: list[Any] | None = None,
     output_schema: type[BaseModel] | None = None,
+    coordinator: bool = False,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -204,6 +205,14 @@ def build_reference_deep_agent(
     middleware injects a retry nudge with the JSON-Schema rendering
     of the model. ``None`` (default) leaves structured-output
     validation off.
+
+    ``coordinator`` (default ``False``) flips the build into
+    coordinator mode (see :class:`~langgraph_kit.core.coordinator.CoordinatorMode`):
+    the active tool surface is narrowed to ``ToolRisk.READ_ONLY``
+    capabilities + the delegation tools, and coordinator-specific
+    prompt sections are merged. Use the
+    :func:`build_reference_coordinator_agent` convenience wrapper
+    when you want this profile by default.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
@@ -234,7 +243,7 @@ def build_reference_deep_agent(
         providers.extend(extra_providers)
 
     return build_deep_agent(
-        agent_name="reference-deep-agent",
+        agent_name=("reference-coordinator" if coordinator else "reference-deep-agent"),
         core_sections=_CORE_SECTIONS,
         subagents=GENERAL_WORKERS,
         checkpointer=checkpointer,
@@ -247,4 +256,35 @@ def build_reference_deep_agent(
         configure_deferred_tools=configure_deferred_tools,
         extra_providers=providers or None,
         output_schema=output_schema,
+        coordinator=coordinator,
     )
+
+
+def build_reference_coordinator_agent(
+    checkpointer: Any,
+    store: Any,
+    **kwargs: Any,
+) -> Any:
+    """Build the reference deep agent in coordinator mode.
+
+    Thin wrapper over :func:`build_reference_deep_agent` with
+    ``coordinator=True``. Use this when the agent should delegate
+    work via :class:`~langgraph_kit.core.coordinator.CoordinatorMode`
+    rather than execute mutating operations itself: the bound tool
+    surface is narrowed to ``ToolRisk.READ_ONLY`` capabilities + the
+    delegation ``task`` tool, and the system prompt picks up the
+    coordinator's delegation / synthesis sections.
+
+    All other kwargs are forwarded as-is to
+    :func:`build_reference_deep_agent`, so the same opt-outs
+    (``enable_default_stop_hooks``, ``enable_default_deferred_tools``,
+    ``enable_default_custom_tools``, ``enable_default_extra_providers``)
+    apply.
+    """
+    if "coordinator" in kwargs:
+        msg = (
+            "build_reference_coordinator_agent forces coordinator=True; "
+            "remove the kwarg or call build_reference_deep_agent directly."
+        )
+        raise TypeError(msg)
+    return build_reference_deep_agent(checkpointer, store, coordinator=True, **kwargs)

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -1305,3 +1305,107 @@ def test_reference_no_output_schema_omits_structured_output_middleware(
     create = _build_reference_with_capture(mock_store)
     middleware = create.call_args.kwargs["middleware"]
     assert not any(isinstance(m, StructuredOutputMiddleware) for m in middleware)
+
+
+# ---------------------------------------------------------------------------
+# Coordinator variant
+# ---------------------------------------------------------------------------
+# ``build_reference_coordinator_agent`` is a thin wrapper that forces
+# ``coordinator=True`` on the reference build. The CoordinatorMode
+# implementation (read-only filter, prompt sections) lives in
+# core/coordinator.py and is unit-tested there; these tests pin the
+# wiring at the reference layer.
+
+
+def test_reference_coordinator_narrows_tools_to_read_only(mock_store: Any) -> None:
+    """Coordinator mode strips mutating tools (e.g. save_memory) from the surface."""
+    from langgraph_kit.graphs.reference_deep_agent import (
+        build_reference_coordinator_agent,
+    )
+
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_coordinator_agent(checkpointer=MagicMock(), store=mock_store)
+
+    tools = deepagents_mod.create_deep_agent.call_args.kwargs["tools"]
+    tool_names = {
+        str(getattr(fn, "__name__", getattr(fn, "name", "")) or "") for fn in tools
+    }
+    # save_memory is MUTATING in the standard registration; coordinator
+    # mode must filter it out.
+    assert "save_memory" not in tool_names, (
+        f"save_memory must be stripped in coordinator mode; got {sorted(tool_names)}"
+    )
+
+
+def test_reference_coordinator_includes_delegation_sections(mock_store: Any) -> None:
+    """Coordinator system prompt must include the delegation/synthesis sections."""
+    from langgraph_kit.graphs.reference_deep_agent import (
+        build_reference_coordinator_agent,
+    )
+
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_coordinator_agent(checkpointer=MagicMock(), store=mock_store)
+
+    system_prompt = deepagents_mod.create_deep_agent.call_args.kwargs["system_prompt"]
+    assert "# Coordinator Mode" in system_prompt
+    assert "# Delegation Rules" in system_prompt
+    assert "# Synthesis Discipline" in system_prompt
+
+
+def test_reference_coordinator_uses_distinct_agent_name(mock_store: Any) -> None:
+    """Coordinator build uses ``reference-coordinator`` so logs distinguish profiles."""
+    from langgraph_kit.graphs.reference_deep_agent import (
+        build_reference_coordinator_agent,
+    )
+
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_coordinator_agent(checkpointer=MagicMock(), store=mock_store)
+
+    assert (
+        deepagents_mod.create_deep_agent.call_args.kwargs["name"]
+        == "reference-coordinator"
+    )
+
+
+def test_reference_coordinator_rejects_explicit_coordinator_kwarg(
+    mock_store: Any,
+) -> None:
+    """Passing ``coordinator=`` to the wrapper raises — the wrapper forces True."""
+    from langgraph_kit.graphs.reference_deep_agent import (
+        build_reference_coordinator_agent,
+    )
+
+    with pytest.raises(TypeError, match="forces coordinator=True"):
+        build_reference_coordinator_agent(
+            checkpointer=MagicMock(), store=mock_store, coordinator=False
+        )
+
+
+def test_reference_default_is_not_coordinator(mock_store: Any) -> None:
+    """Default ``build_reference_deep_agent`` does NOT activate coordinator mode."""
+    create = _build_reference_with_capture(mock_store)
+    assert create.call_args.kwargs["name"] == "reference-deep-agent"
+
+    system_prompt = create.call_args.kwargs["system_prompt"]
+    assert "# Coordinator Mode" not in system_prompt


### PR DESCRIPTION
## Summary

- New `build_reference_coordinator_agent` thin wrapper + `coordinator: bool = False` kwarg on `build_reference_deep_agent` give the read-only / delegation-first `CoordinatorMode` profile a callable exemplar.
- The coordinator build identifies as `reference-coordinator` (not `reference-deep-agent`) so logs distinguish profiles.
- Wrapper rejects an explicit `coordinator=` kwarg to keep its contract unambiguous.
- All other reference defaults (stop hooks, deferred tools, custom tools, providers) carry through; only the tool-risk filter and the coordinator prompt sections change.

## Test plan

- [x] `uv run pytest` (1422 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 5 tests — read-only filter strips `save_memory`, delegation/synthesis sections in prompt, distinct agent name, wrapper rejects explicit kwarg, default reference is *not* coordinator.

Fixes #103