### PR TITLE
feat(reference): default interrupt_before tool to drive AutoInterrupt (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: default HITL demo tool.**
+  `build_reference_deep_agent` now ships
+  `confirm_destructive_demo`, a no-op stub whose capability sets
+  `interrupt_before=True` so `AutoInterruptMiddleware` fires its
+  pause-and-prompt path on every call. The middleware was always in
+  the stack but had no shipped tool to drive it, leaving the HITL
+  gating path dead in the showcase. New kwarg
+  `enable_default_hitl_demo` (default `True`) toggles this
+  independently of `enable_default_custom_tools`. Closes
+  [#104](https://github.com/allada-homelab/langgraph-kit/issues/104).
+
 - **Coordinator variant of the reference agent.** New
   `build_reference_coordinator_agent` (and a `coordinator: bool =
   False` kwarg on `build_reference_deep_agent`) flips the build into

--- a/src/langgraph_kit/graphs/_reference_custom_tools.py
+++ b/src/langgraph_kit/graphs/_reference_custom_tools.py
@@ -1,13 +1,21 @@
-"""Demo custom tool wired into the reference deep agent.
+"""Demo custom tools wired into the reference deep agent.
 
 This module exists to give cloners of ``reference_deep_agent`` an
 in-tree, minimal exemplar of the ``configure_tools=`` extension point.
 ``coding_agent`` ships a production-shaped example (worktree tools);
-this is the no-domain version: a single read-only tool that reports
-basic process metadata.
+this is the no-domain version. Two demos:
 
-The tool is intentionally narrow — clone the registration helper and
-swap the body when adding your own.
+- ``current_environment`` — read-only tool reporting Python version,
+  OS, kit version, and whether the working directory is a git repo.
+  Demonstrates a typical ``configure_tools=`` registration via the
+  ``register_tool`` helper.
+- ``confirm_destructive_demo`` — a no-op stub representing a
+  destructive action whose capability declares
+  ``interrupt_before=True``. Demonstrates HITL gating via
+  :class:`~langgraph_kit.core.hitl.auto_interrupt.AutoInterruptMiddleware`.
+
+The tools are intentionally narrow — clone the registration helper
+and swap the bodies when adding your own.
 """
 
 from __future__ import annotations
@@ -17,7 +25,7 @@ from pathlib import Path
 from typing import Any
 
 from langgraph_kit.core.graph_builder.tools import register_tool
-from langgraph_kit.core.tools.capability import ToolRisk
+from langgraph_kit.core.tools.capability import ToolCapability, ToolRisk
 from langgraph_kit.core.tools.registry import ToolRegistry
 
 
@@ -44,8 +52,20 @@ async def current_environment() -> str:
     )
 
 
+async def confirm_destructive_demo(target: str) -> str:
+    """Simulate a destructive action against ``target`` and return a confirmation string.
+
+    HITL demo: the capability registered for this tool sets
+    ``interrupt_before=True``, so ``AutoInterruptMiddleware`` pauses
+    the run and surfaces an approval prompt before this body executes.
+    The body itself is a no-op — replace it with a real destructive
+    action when adapting the pattern.
+    """
+    return f"[demo] would perform destructive action against: {target}"
+
+
 def register_reference_custom_tools(registry: ToolRegistry) -> None:
-    """Register the demo ``current_environment`` tool on ``registry``."""
+    """Register the read-only ``current_environment`` demo tool on ``registry``."""
     register_tool(
         registry,
         current_environment,
@@ -61,20 +81,61 @@ def register_reference_custom_tools(registry: ToolRegistry) -> None:
     )
 
 
+def register_reference_hitl_demo_tool(registry: ToolRegistry) -> None:
+    """Register the ``confirm_destructive_demo`` tool with ``interrupt_before=True``.
+
+    The kit's ``register_tool`` helper does not currently forward
+    ``interrupt_before`` (its primary use is in the ``__init__`` of
+    each tool builder, where the flag is rarely needed). Register
+    directly via ``ToolCapability`` so the HITL gating flag flows
+    through to ``AutoInterruptMiddleware``.
+    """
+    registry.register(
+        ToolCapability(
+            id="reference_confirm_destructive_demo",
+            name="confirm_destructive_demo",
+            description=(
+                "Demo HITL-gated tool. The agent must declare a target; "
+                "the user is then prompted to approve before the action "
+                "runs. The body is a no-op — replace with a real "
+                "destructive action when adapting this pattern."
+            ),
+            fn=confirm_destructive_demo,
+            tags=["reference", "hitl", "demo"],
+            risk=ToolRisk.MUTATING,
+            interrupt_before=True,
+            prompt_guidance=(
+                "Use confirm_destructive_demo to demonstrate the HITL "
+                "approval flow. The middleware will pause execution and "
+                "ask the user to approve before the action runs."
+            ),
+        )
+    )
+
+
 def make_reference_configure_tools(
     extra: Any | None = None,
+    *,
+    include_hitl_demo: bool = True,
 ) -> Any:
     """Build a ``configure_tools=`` callback for the reference build.
 
-    The callback registers the default demo tool first, then runs the
-    optional ``extra`` callback. ``ToolRegistry.register`` is an upsert
-    on capability id, so anything ``extra`` registers under the demo's
-    id (``"reference_current_environment"``) overrides the demo —
-    matching the documented "caller wins on collisions" precedence.
+    The callback registers the default demo tools (read-only +
+    optional HITL-gated), then runs the optional ``extra`` callback.
+    ``ToolRegistry.register`` is an upsert on capability id, so
+    anything ``extra`` registers under a default id overrides the
+    demo — matching the documented "caller wins on collisions"
+    precedence.
+
+    ``include_hitl_demo`` toggles the HITL-gated tool independently
+    from the read-only demo so callers can keep the read-only tool
+    while opting out of the interrupt flow.
     """
 
     def _configure(registry: ToolRegistry) -> None:
         register_reference_custom_tools(registry)
+        if include_hitl_demo:
+            register_reference_hitl_demo_tool(registry)
         if extra is not None:
             extra(registry)
 

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -131,6 +131,7 @@ def build_reference_deep_agent(
     extra_deferred_tools: Any | None = None,
     enable_default_custom_tools: bool = True,
     extra_configure_tools: Any | None = None,
+    enable_default_hitl_demo: bool = True,
     enable_default_extra_providers: bool = True,
     extra_providers: list[Any] | None = None,
     output_schema: type[BaseModel] | None = None,
@@ -185,6 +186,15 @@ def build_reference_deep_agent(
     registration so caller registrations under matching ids override
     the defaults — same upsert-by-id precedence as plugin tools.
 
+    ``enable_default_hitl_demo`` (default ``True``) registers a
+    ``confirm_destructive_demo`` capability whose
+    ``interrupt_before=True`` flag triggers
+    :class:`~langgraph_kit.core.hitl.auto_interrupt.AutoInterruptMiddleware`
+    on every call — exercising the HITL gating path that otherwise
+    has no shipped tool to drive it. Toggleable independently from
+    ``enable_default_custom_tools`` so callers who want the
+    diagnostic tool but no HITL flow can opt out.
+
     ``enable_default_extra_providers`` (default ``True``) registers a
     :class:`~langgraph_kit.core.prompt_assembly.system_context.SystemContextProvider`
     on the prompt composer, mirroring how ``coding_agent`` ships
@@ -230,7 +240,10 @@ def build_reference_deep_agent(
         configure_deferred_tools = None
 
     if enable_default_custom_tools:
-        configure_tools = make_reference_configure_tools(extra=extra_configure_tools)
+        configure_tools = make_reference_configure_tools(
+            extra=extra_configure_tools,
+            include_hitl_demo=enable_default_hitl_demo,
+        )
     elif extra_configure_tools is not None:
         configure_tools = extra_configure_tools
     else:

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -860,6 +860,7 @@ def _build_reference_with_capture(
     extra_deferred_tools: Any | None = None,
     enable_default_custom_tools: bool | None = None,
     extra_configure_tools: Any | None = None,
+    enable_default_hitl_demo: bool | None = None,
     enable_default_extra_providers: bool | None = None,
     extra_providers: list[Any] | None = None,
 ) -> MagicMock:
@@ -882,6 +883,8 @@ def _build_reference_with_capture(
         kwargs["enable_default_custom_tools"] = enable_default_custom_tools
     if extra_configure_tools is not None:
         kwargs["extra_configure_tools"] = extra_configure_tools
+    if enable_default_hitl_demo is not None:
+        kwargs["enable_default_hitl_demo"] = enable_default_hitl_demo
     if enable_default_extra_providers is not None:
         kwargs["enable_default_extra_providers"] = enable_default_extra_providers
     if extra_providers is not None:
@@ -1409,3 +1412,69 @@ def test_reference_default_is_not_coordinator(mock_store: Any) -> None:
 
     system_prompt = create.call_args.kwargs["system_prompt"]
     assert "# Coordinator Mode" not in system_prompt
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: HITL demo tool wiring
+# ---------------------------------------------------------------------------
+# AutoInterruptMiddleware is always in the stack but only fires when a
+# tool's capability sets ``interrupt_before=True``. Without a shipped
+# tool wearing the flag, the middleware path was dead in the showcase.
+# The reference now ships ``confirm_destructive_demo`` as the trigger.
+
+
+def test_reference_default_hitl_demo_tool_is_registered(mock_store: Any) -> None:
+    """Default build registers ``confirm_destructive_demo`` on the bound tool surface."""
+    create = _build_reference_with_capture(mock_store)
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {
+        str(getattr(fn, "__name__", getattr(fn, "name", "")) or "") for fn in tools
+    }
+    assert "confirm_destructive_demo" in tool_names
+
+
+def test_reference_default_hitl_demo_tool_can_be_disabled(mock_store: Any) -> None:
+    """``enable_default_hitl_demo=False`` strips the HITL demo from the surface."""
+    create = _build_reference_with_capture(mock_store, enable_default_hitl_demo=False)
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {
+        str(getattr(fn, "__name__", getattr(fn, "name", "")) or "") for fn in tools
+    }
+    assert "confirm_destructive_demo" not in tool_names
+    # The other reference defaults must still be present so the
+    # toggle is independent.
+    assert "current_environment" in tool_names
+
+
+def test_reference_hitl_demo_capability_has_interrupt_before(mock_store: Any) -> None:
+    """The registered capability for the demo tool must carry ``interrupt_before=True``.
+
+    Without that flag, ``AutoInterruptMiddleware`` is a no-op and the
+    HITL gating path stays dead — that is exactly the regression the
+    demo guards against.
+    """
+    from langgraph_kit.core.tools.registry import ToolRegistry
+    from langgraph_kit.graphs._reference_custom_tools import (
+        register_reference_hitl_demo_tool,
+    )
+
+    registry = ToolRegistry()
+    register_reference_hitl_demo_tool(registry)
+    cap = registry.find_by_tool_name("confirm_destructive_demo")
+    assert cap is not None
+    assert cap.interrupt_before is True
+    assert cap.risk.value == "mutating"
+
+
+def test_reference_hitl_demo_disabled_keeps_custom_tools(mock_store: Any) -> None:
+    """Disabling HITL demo doesn't strip ``current_environment`` (independent toggle)."""
+    create = _build_reference_with_capture(mock_store, enable_default_hitl_demo=False)
+
+    tools = create.call_args.kwargs["tools"]
+    tool_names = {
+        str(getattr(fn, "__name__", getattr(fn, "name", "")) or "") for fn in tools
+    }
+    assert "current_environment" in tool_names
+    assert "confirm_destructive_demo" not in tool_names


### PR DESCRIPTION
## Summary

- Reference build now ships `confirm_destructive_demo` — a no-op stub whose capability declares `interrupt_before=True` so `AutoInterruptMiddleware` fires its HITL pause-and-prompt path. The middleware was always in the stack but had no shipped tool to drive it; the gating flow was dead in the showcase.
- Capability is registered directly via `ToolCapability(...)` because `register_tool` doesn't currently forward `interrupt_before`. A `register_reference_hitl_demo_tool(registry)` helper makes it easy to clone.
- New kwarg `enable_default_hitl_demo` (default `True`) toggles this independently from `enable_default_custom_tools`, so callers wanting the read-only demo without the HITL flow can opt out.

## Test plan

- [x] `uv run pytest` (1426 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 4 tests — bound surface contains `confirm_destructive_demo` by default; opt-out strips it but keeps `current_environment`; the registered capability carries `interrupt_before=True` + `risk=MUTATING`; toggles are independent.

Fixes #104