### PR TITLE
feat(reference): llm_callbacks= integration point for cost / tracing (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: `llm_callbacks=` integration point.**
+  `build_reference_deep_agent` (and `build_deep_agent`) now accept
+  `llm_callbacks: list | None = None`; the kit binds them via
+  `llm.with_config({"callbacks": [...]})` so callbacks participate
+  in every LLM call. This is the integration point for cost/budget
+  instrumentation (`TokenTrackingCallback`), Langfuse handlers, and
+  any other LangChain async callback. Caller owns the callback
+  object for post-run inspection; pair with `BudgetManager` for
+  per-thread budget enforcement on the Store. Closes
+  [#105](https://github.com/allada-homelab/langgraph-kit/issues/105).
+
 - **Reference deep agent: default HITL demo tool.**
   `build_reference_deep_agent` now ships
   `confirm_destructive_demo`, a no-op stub whose capability sets

--- a/src/langgraph_kit/graphs/_builder.py
+++ b/src/langgraph_kit/graphs/_builder.py
@@ -159,6 +159,7 @@ def build_deep_agent(
     recursion_limit: int = DEFAULT_RECURSION_LIMIT,
     output_schema: type[BaseModel] | None = None,
     coordinator: bool = False,
+    llm_callbacks: list[Any] | None = None,
 ) -> tuple[Any, Any]:
     """Build a deep agent with the standard skeleton.
 
@@ -226,6 +227,12 @@ def build_deep_agent(
     )
 
     llm = build_llm()
+    if llm_callbacks:
+        # Bind callbacks via with_config so they participate in every
+        # LLM call the graph makes — TokenTrackingCallback / Langfuse
+        # callbacks live here. Caller owns the callback object so they
+        # can poll counters after invocation.
+        llm = llm.with_config({"callbacks": list(llm_callbacks)})
     memory_mgr = PersistentMemoryManager(
         store, embedding_fn=get_config().memory_embedding_fn
     )

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -136,6 +136,7 @@ def build_reference_deep_agent(
     extra_providers: list[Any] | None = None,
     output_schema: type[BaseModel] | None = None,
     coordinator: bool = False,
+    llm_callbacks: list[Any] | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -223,6 +224,17 @@ def build_reference_deep_agent(
     prompt sections are merged. Use the
     :func:`build_reference_coordinator_agent` convenience wrapper
     when you want this profile by default.
+
+    ``llm_callbacks`` are bound to the LLM via ``with_config`` so they
+    participate in every model call the graph makes. Use this entry
+    point for cost / budget instrumentation
+    (:class:`~langgraph_kit.core.cost.callback.TokenTrackingCallback`),
+    Langfuse handlers, or any other LangChain
+    :class:`~langchain_core.callbacks.AsyncCallbackHandler`. The
+    caller owns the callback object so they can poll its counters
+    after the run; pair with
+    :class:`~langgraph_kit.core.cost.budget.BudgetManager` for
+    per-thread budget enforcement on the Store.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
@@ -270,6 +282,7 @@ def build_reference_deep_agent(
         extra_providers=providers or None,
         output_schema=output_schema,
         coordinator=coordinator,
+        llm_callbacks=llm_callbacks,
     )
 
 

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -1478,3 +1478,107 @@ def test_reference_hitl_demo_disabled_keeps_custom_tools(mock_store: Any) -> Non
     }
     assert "current_environment" in tool_names
     assert "confirm_destructive_demo" not in tool_names
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: llm_callbacks wiring
+# ---------------------------------------------------------------------------
+# ``llm_callbacks=`` is the integration point for cost / budget /
+# tracing callbacks. The kit binds them onto the LLM via
+# ``with_config`` so they participate in every model call. Caller owns
+# the callback object for post-run inspection.
+
+
+def test_reference_llm_callbacks_bound_to_model(mock_store: Any) -> None:
+    """``llm_callbacks=[cb]`` flows into ``llm.with_config({"callbacks": ...})``."""
+    from langgraph_kit.core.cost.callback import TokenTrackingCallback
+
+    tracker = TokenTrackingCallback()
+
+    fake_llm = MagicMock(name="fake_llm")
+    # ``with_config`` returns a wrapped LLM; test that the wrapper's
+    # constructor was called with our callback in the dict.
+    wrapped = MagicMock(name="wrapped_llm")
+    fake_llm.with_config.return_value = wrapped
+
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=fake_llm,
+        ),
+    ):
+        build_reference_deep_agent(
+            checkpointer=MagicMock(),
+            store=mock_store,
+            llm_callbacks=[tracker],
+        )
+
+    fake_llm.with_config.assert_called_once_with({"callbacks": [tracker]})
+    # The wrapped LLM (not the raw one) reaches deepagents.
+    assert deepagents_mod.create_deep_agent.call_args.kwargs["model"] is wrapped
+
+
+def test_reference_no_llm_callbacks_skips_with_config(mock_store: Any) -> None:
+    """No ``llm_callbacks=`` → builder doesn't wrap the LLM."""
+    fake_llm = MagicMock(name="fake_llm")
+
+    module_patches, deepagents_mod, _ = _mock_deepagents_env()
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=fake_llm,
+        ),
+    ):
+        build_reference_deep_agent(
+            checkpointer=MagicMock(),
+            store=mock_store,
+        )
+
+    # The raw LLM (no with_config wrap) reaches deepagents.
+    assert deepagents_mod.create_deep_agent.call_args.kwargs["model"] is fake_llm
+    fake_llm.with_config.assert_not_called()
+
+
+def test_reference_token_tracking_records_usage_via_callback(mock_store: Any) -> None:
+    """Round-trip: callback's on_llm_end records into the tracker.
+
+    Smoke-tests the wiring at the callback level: feeding a synthetic
+    ``LLMResult`` through the bound callback exercises the same path
+    the LLM would take during a real run, without requiring a live
+    model.
+    """
+    import asyncio
+
+    from langchain_core.outputs import (
+        ChatGeneration,
+        LLMResult,
+    )
+    from langchain_openai import ChatOpenAI
+
+    from langgraph_kit.core.cost.callback import TokenTrackingCallback
+
+    tracker = TokenTrackingCallback()
+
+    # Build a real ChatOpenAI shell (no key needed for with_config) and
+    # bind the callback — this proves the kit's wiring contract works
+    # against a real LangChain model surface, not just a MagicMock.
+    base = ChatOpenAI.model_construct(model="x", api_key="dummy")
+    bound = base.with_config({"callbacks": [tracker]})
+
+    # ``with_config`` returns a RunnableBinding whose .config carries
+    # the callbacks; assert they're there.
+    binding_callbacks = getattr(bound, "config", {}).get("callbacks", [])
+    assert tracker in binding_callbacks
+
+    # Fire the callback directly with a synthetic OpenAI-style result.
+    fake_response = LLMResult(
+        generations=[[ChatGeneration(message=AIMessage(content="ok"))]],
+        llm_output={"token_usage": {"prompt_tokens": 7, "completion_tokens": 3}},
+    )
+    asyncio.run(tracker.on_llm_end(fake_response, run_id=None))
+    total = tracker.get_total()
+    assert total.input_tokens == 7
+    assert total.output_tokens == 3


### PR DESCRIPTION
## Summary

- Threads a new `llm_callbacks: list | None = None` kwarg through `build_deep_agent` (and `build_reference_deep_agent`) — the kit binds them via `llm.with_config({"callbacks": [...]})` so they participate in every model call.
- This is the public integration point for `TokenTrackingCallback`, Langfuse handlers, and any other LangChain async callback. Caller owns the callback object so they can poll counters after invocation; pair with `BudgetManager` for per-thread budget enforcement on the Store.
- Scope-conscious: no auto-installed tracker, no new middleware, no breaking change. The cost subsystem already exists; this PR just gives it a callable seam in the reference build.

## Test plan

- [x] `uv run pytest` (1429 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 3 tests — callbacks reach `with_config`, no callbacks skips the wrap, and a round-trip test that fires `on_llm_end` against a real `TokenTrackingCallback` bound to a `ChatOpenAI` shell to confirm the end-to-end shape.

Fixes #105