### PR TITLE
feat(reference): graph_callbacks= for full-coverage tracing (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Reference deep agent: `graph_callbacks=` for full-coverage
+  tracing.** `build_deep_agent` (and `build_reference_deep_agent`)
+  now accept `graph_callbacks: list | None = None`. The kit binds
+  them at the graph level via `with_config({"callbacks": [...]})` so
+  `on_chain_*`, `on_tool_*`, and `on_llm_*` events all propagate to
+  the handler — the integration point for `TraceCallbackHandler`
+  (which needs full event coverage rather than just LLM events from
+  `llm_callbacks=`). Pair with `TraceStore` to persist traces by
+  thread. Closes
+  [#106](https://github.com/allada-homelab/langgraph-kit/issues/106).
+
 - **Reference deep agent: `llm_callbacks=` integration point.**
   `build_reference_deep_agent` (and `build_deep_agent`) now accept
   `llm_callbacks: list | None = None`; the kit binds them via

--- a/src/langgraph_kit/graphs/_builder.py
+++ b/src/langgraph_kit/graphs/_builder.py
@@ -160,6 +160,7 @@ def build_deep_agent(
     output_schema: type[BaseModel] | None = None,
     coordinator: bool = False,
     llm_callbacks: list[Any] | None = None,
+    graph_callbacks: list[Any] | None = None,
 ) -> tuple[Any, Any]:
     """Build a deep agent with the standard skeleton.
 
@@ -411,4 +412,11 @@ def build_deep_agent(
     # default survives the ``astream_events`` codepath — see that helper's
     # docstring for the langchain_core/langgraph config-merge interaction.
     graph = bind_kit_defaults(graph, recursion_limit=recursion_limit)
+    if graph_callbacks:
+        # Bind callbacks at the graph level so on_chain_*, on_tool_*,
+        # and on_llm_* events all propagate to the handler. This is
+        # the integration point for TraceCallbackHandler and any
+        # other callback that needs full event coverage rather than
+        # just LLM events (use ``llm_callbacks=`` for the latter).
+        graph = graph.with_config({"callbacks": list(graph_callbacks)})
     return graph, command_dispatcher

--- a/src/langgraph_kit/graphs/reference_deep_agent.py
+++ b/src/langgraph_kit/graphs/reference_deep_agent.py
@@ -137,6 +137,7 @@ def build_reference_deep_agent(
     output_schema: type[BaseModel] | None = None,
     coordinator: bool = False,
     llm_callbacks: list[Any] | None = None,
+    graph_callbacks: list[Any] | None = None,
 ) -> Any:
     """Build the reference deep agent with all kit features wired together.
 
@@ -235,6 +236,15 @@ def build_reference_deep_agent(
     after the run; pair with
     :class:`~langgraph_kit.core.cost.budget.BudgetManager` for
     per-thread budget enforcement on the Store.
+
+    ``graph_callbacks`` are bound at the graph level via
+    ``with_config`` so ``on_chain_*``, ``on_tool_*``, and
+    ``on_llm_*`` events all propagate to the handler. Use this entry
+    point for full-coverage tracing
+    (:class:`~langgraph_kit.core.tracing.TraceCallbackHandler`).
+    Caller owns the callback object so they can call ``get_trace()``
+    after the run and persist it via
+    :class:`~langgraph_kit.core.tracing.TraceStore` if desired.
     """
     stop_hooks: list[Any] = []
     if enable_default_stop_hooks:
@@ -283,6 +293,7 @@ def build_reference_deep_agent(
         output_schema=output_schema,
         coordinator=coordinator,
         llm_callbacks=llm_callbacks,
+        graph_callbacks=graph_callbacks,
     )
 
 

--- a/tests/test_reference_deep_agent.py
+++ b/tests/test_reference_deep_agent.py
@@ -1582,3 +1582,95 @@ def test_reference_token_tracking_records_usage_via_callback(mock_store: Any) ->
     total = tracker.get_total()
     assert total.input_tokens == 7
     assert total.output_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# build_reference_deep_agent: graph_callbacks wiring
+# ---------------------------------------------------------------------------
+# ``graph_callbacks=`` is the integration point for tracing handlers
+# (TraceCallbackHandler) — callbacks bound at the graph level so chain
+# / tool / LLM events all propagate to them.
+
+
+def test_reference_graph_callbacks_bound_to_compiled_graph(mock_store: Any) -> None:
+    """``graph_callbacks=[handler]`` flows into ``graph.with_config``."""
+    from langgraph_kit.core.tracing import TraceCallbackHandler
+
+    handler = TraceCallbackHandler(agent_id="ref-test", thread_id="t1")
+
+    fake_graph = MagicMock(name="compiled_graph")
+    fake_graph.with_config.return_value = fake_graph
+    deepagents_mod = MagicMock()
+    deepagents_mod.create_deep_agent.return_value = fake_graph
+
+    backends_mod = MagicMock()
+    module_patches = {
+        "deepagents": deepagents_mod,
+        "deepagents.backends": backends_mod,
+        "deepagents.backends.composite": backends_mod.composite,
+        "deepagents.backends.state": backends_mod.state,
+        "deepagents.backends.store": backends_mod.store,
+    }
+
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_deep_agent(
+            checkpointer=MagicMock(),
+            store=mock_store,
+            graph_callbacks=[handler],
+        )
+
+    # Two ``with_config`` calls happen: one in ``bind_kit_defaults``
+    # for recursion_limit, then one for callbacks. Verify the
+    # callbacks call is among them.
+    call_args_list = fake_graph.with_config.call_args_list
+    callback_calls = [
+        c for c in call_args_list if "callbacks" in (c.args[0] if c.args else {})
+    ]
+    assert callback_calls, (
+        f"Expected a with_config call with callbacks=; got {call_args_list!r}"
+    )
+    assert callback_calls[0].args[0]["callbacks"] == [handler]
+
+
+def test_reference_no_graph_callbacks_skips_callbacks_with_config(
+    mock_store: Any,
+) -> None:
+    """No ``graph_callbacks=`` → the callbacks ``with_config`` is not made."""
+    fake_graph = MagicMock(name="compiled_graph")
+    fake_graph.with_config.return_value = fake_graph
+    deepagents_mod = MagicMock()
+    deepagents_mod.create_deep_agent.return_value = fake_graph
+
+    backends_mod = MagicMock()
+    module_patches = {
+        "deepagents": deepagents_mod,
+        "deepagents.backends": backends_mod,
+        "deepagents.backends.composite": backends_mod.composite,
+        "deepagents.backends.state": backends_mod.state,
+        "deepagents.backends.store": backends_mod.store,
+    }
+
+    with (
+        patch.dict(sys.modules, module_patches),
+        patch(
+            "langgraph_kit.graphs._builder.build_llm",
+            return_value=MagicMock(name="fake_llm"),
+        ),
+    ):
+        build_reference_deep_agent(checkpointer=MagicMock(), store=mock_store)
+
+    # ``bind_kit_defaults`` makes one ``with_config({"recursion_limit": 100})``
+    # call; the callback wiring must not add any other.
+    call_args_list = fake_graph.with_config.call_args_list
+    callback_calls = [
+        c for c in call_args_list if "callbacks" in (c.args[0] if c.args else {})
+    ]
+    assert not callback_calls, (
+        f"Expected no callbacks with_config call; got {callback_calls!r}"
+    )


### PR DESCRIPTION
## Summary

- Threads a new `graph_callbacks: list | None = None` kwarg through `build_deep_agent` and `build_reference_deep_agent` — bound at the **graph** level via `with_config({"callbacks": [...]})` after `bind_kit_defaults` runs.
- This is the public integration point for `TraceCallbackHandler` (which needs `on_chain_*` / `on_tool_*` / `on_llm_*` coverage). `llm_callbacks=` from #105 only carries LLM events; `graph_callbacks=` covers the rest.
- Caller owns the handler so they can call `.get_trace()` and persist via `TraceStore` after the run.

## Test plan

- [x] `uv run pytest` (1431 passed, 1 skipped)
- [x] `uv run basedpyright` (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 2 tests — handler reaches `with_config({"callbacks": [...]})` when set, and no callback `with_config` call is made when unset (`bind_kit_defaults`'s `recursion_limit` call is unaffected).

Fixes #106