### PR TITLE
feat(triggers): optional audit_store= on webhook/schedule/watcher (#19 v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Trigger surfaces (webhook, schedule, watchers): optional audit
+  emission.** All three trigger entry points
+  (`create_webhook_router`, `ScheduledTriggerRunner`,
+  `StoreWatcherRunner`) now accept an optional `audit_store=`
+  kwarg. When set, each fire writes one
+  `AuditAction.AGENT_INVOKE` entry tagged with
+  `actor=trigger:<source>`, `target=thread:<id>`, and metadata
+  identifying the trigger spec + agent. Closes the audit
+  acceptance criterion on
+  [#19](https://github.com/allada-homelab/langgraph-kit/issues/19);
+  triggers without an audit store remain silent (back-compat
+  default). Helper `emit_trigger_audit` is exported from
+  `langgraph_kit.contrib.schedule` for callers building their own
+  trigger surfaces.
+
 - **Reference deep agent: default audit sink.**
   `build_reference_deep_agent` now wires a
   `ReferenceAuditStopHook` that writes one

--- a/src/langgraph_kit/contrib/schedule.py
+++ b/src/langgraph_kit/contrib/schedule.py
@@ -177,14 +177,19 @@ class ScheduledTriggerRunner:
         registry: ScheduledRegistry,
         *,
         graph_resolver: Callable[[str], Any],
+        audit_store: Any = None,
     ) -> None:
         super().__init__()
         # graph_resolver mirrors the webhook router's signature:
         # ``(agent_id) -> compiled graph``. Anything that quacks
         # like a LangGraph compiled graph works (real graph in
         # production, mock in tests).
+        # ``audit_store`` (optional :class:`AuditStore`) records one
+        # ``AGENT_INVOKE`` entry per fire so ops can answer "what
+        # caused this run". When ``None`` (default), no audit emission.
         self._registry = registry
         self._graph_resolver = graph_resolver
+        self._audit_store = audit_store
         self._scheduler: Any = None
 
     async def __aenter__(self) -> ScheduledTriggerRunner:
@@ -284,11 +289,57 @@ class ScheduledTriggerRunner:
                 "thread_id": thread_id,
             },
         )
+        await emit_trigger_audit(
+            self._audit_store,
+            source="schedule",
+            spec_id=spec.id,
+            agent_id=spec.agent_id,
+            thread_id=thread_id,
+        )
         return thread_id
+
+
+async def emit_trigger_audit(
+    audit_store: Any,
+    *,
+    source: str,
+    spec_id: str,
+    agent_id: str,
+    thread_id: str,
+) -> None:
+    """Emit one AGENT_INVOKE audit entry per fire.
+
+    Defined as a standalone helper rather than a base class so the
+    three trigger modules don't need a shared inheritance hierarchy
+    just for one optional sink. ``audit_store`` is ``Any`` (rather
+    than ``AuditStore``) so callers can disable auditing by passing
+    ``None`` without dragging the audit module into module-level
+    imports of every trigger.
+    """
+    if audit_store is None:
+        return
+    from langgraph_kit.core.audit import AuditAction
+
+    try:
+        await audit_store.write(
+            actor=f"trigger:{source}",
+            action=AuditAction.AGENT_INVOKE,
+            target=f"thread:{thread_id}",
+            metadata={
+                "trigger_source": source,
+                "trigger_spec_id": spec_id,
+                "agent_id": agent_id,
+            },
+        )
+    except Exception:
+        # Audit must never break a fire path; log via the module
+        # logger rather than re-raise.
+        logger.exception("Trigger audit emit failed for %s spec=%s", source, spec_id)
 
 
 __all__ = [
     "ScheduledRegistry",
     "ScheduledSpec",
     "ScheduledTriggerRunner",
+    "emit_trigger_audit",
 ]

--- a/src/langgraph_kit/contrib/watchers.py
+++ b/src/langgraph_kit/contrib/watchers.py
@@ -199,6 +199,7 @@ class StoreWatcherRunner:
         *,
         store: Any,
         graph_resolver: Callable[[str], Any],
+        audit_store: Any = None,
     ) -> None:
         super().__init__()
         self._registry = registry
@@ -206,6 +207,9 @@ class StoreWatcherRunner:
         # graph_resolver mirrors the webhook + scheduled-trigger
         # surfaces: ``(agent_id) -> compiled graph``.
         self._graph_resolver = graph_resolver
+        # ``audit_store`` (optional :class:`AuditStore`) records one
+        # ``AGENT_INVOKE`` entry per fire. ``None`` disables audit.
+        self._audit_store = audit_store
         self._tasks: dict[str, asyncio.Task[None]] = {}
         # Edge-trigger state: ``True`` means the predicate fired
         # last poll and we're waiting for it to flip back to
@@ -336,6 +340,15 @@ class StoreWatcherRunner:
                 "agent_id": spec.agent_id,
                 "thread_id": thread_id,
             },
+        )
+        from langgraph_kit.contrib.schedule import emit_trigger_audit
+
+        await emit_trigger_audit(
+            self._audit_store,
+            source="watcher",
+            spec_id=spec.id,
+            agent_id=spec.agent_id,
+            thread_id=thread_id,
         )
         return thread_id
 

--- a/src/langgraph_kit/contrib/webhook.py
+++ b/src/langgraph_kit/contrib/webhook.py
@@ -210,6 +210,7 @@ def create_webhook_router(
     *,
     graph_resolver: Callable[[str], Any],
     prefix: str = "/webhooks",
+    audit_store: Any = None,
 ) -> "APIRouter":
     # graph_resolver is ``(agent_id: str) -> compiled graph``. The
     # router calls ``graph.ainvoke({"messages": [HumanMessage(...)]})``
@@ -290,6 +291,15 @@ def create_webhook_router(
                 "agent_id": spec.agent_id,
                 "thread_id": thread_id,
             },
+        )
+        from langgraph_kit.contrib.schedule import emit_trigger_audit
+
+        await emit_trigger_audit(
+            audit_store,
+            source="webhook",
+            spec_id=spec.id,
+            agent_id=spec.agent_id,
+            thread_id=thread_id,
         )
         return {"thread_id": thread_id, "agent_id": spec.agent_id}
 

--- a/tests/test_contrib_schedule.py
+++ b/tests/test_contrib_schedule.py
@@ -210,3 +210,51 @@ class TestScheduledTriggerRunner:
             await runner.fire_now("schedule-x")
 
         assert seen == ["agent-y"]
+
+
+# ---------------------------------------------------------------------------
+# Audit emission
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleAudit:
+    @pytest.mark.asyncio
+    async def test_fire_emits_audit_entry_when_audit_store_set(
+        self, mock_store: Any
+    ) -> None:
+        """Each fire writes an AGENT_INVOKE audit entry tagged with the trigger source."""
+        from langgraph_kit.core.audit import AuditAction, AuditStore
+
+        audit_store = AuditStore(mock_store)
+        registry = ScheduledRegistry()
+        registry.register(
+            ScheduledSpec(id="weekly", agent_id="reporter", cron="* * * * *")
+        )
+        async with ScheduledTriggerRunner(
+            registry,
+            graph_resolver=lambda _: _FakeGraph(),
+            audit_store=audit_store,
+        ) as runner:
+            await runner.fire_now("weekly")
+
+        entries = await audit_store.query(action=AuditAction.AGENT_INVOKE, limit=10)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.actor == "trigger:schedule"
+        assert entry.target.startswith("thread:scheduled-weekly-")
+        assert entry.metadata["trigger_source"] == "schedule"
+        assert entry.metadata["trigger_spec_id"] == "weekly"
+        assert entry.metadata["agent_id"] == "reporter"
+
+    @pytest.mark.asyncio
+    async def test_fire_skips_audit_when_audit_store_none(self) -> None:
+        """No audit_store= → no audit emission, no exception."""
+        registry = ScheduledRegistry()
+        registry.register(
+            ScheduledSpec(id="weekly", agent_id="reporter", cron="* * * * *")
+        )
+        async with ScheduledTriggerRunner(
+            registry, graph_resolver=lambda _: _FakeGraph()
+        ) as runner:
+            # Just shouldn't raise.
+            await runner.fire_now("weekly")

--- a/tests/test_contrib_watchers.py
+++ b/tests/test_contrib_watchers.py
@@ -298,3 +298,38 @@ class TestRunnerLifecycle:
             await asyncio.sleep(0.2)
 
         assert len(graph.calls) >= 1
+
+
+class TestWatcherAudit:
+    @pytest.mark.asyncio
+    async def test_fire_emits_audit_entry_when_audit_store_set(
+        self, mock_store: Any
+    ) -> None:
+        """Edge-triggered fire writes an AGENT_INVOKE entry tagged ``trigger:watcher``."""
+        from langgraph_kit.core.audit import AuditAction, AuditStore
+
+        # Pre-populate the watched namespace so the predicate fires.
+        ns = ("alerts", "unhandled")
+        for i in range(3):
+            await mock_store.aput(ns, f"a{i}", {"i": i})
+
+        registry = StoreWatcherRegistry()
+        registry.register(_spec(spec_id="batch", namespace=ns, threshold=3))
+        audit_store = AuditStore(mock_store)
+
+        async with StoreWatcherRunner(
+            registry,
+            store=mock_store,
+            graph_resolver=lambda _: _FakeGraph(),
+            audit_store=audit_store,
+        ) as runner:
+            fired = await runner.poll_now("batch")
+
+        assert fired
+        entries = await audit_store.query(action=AuditAction.AGENT_INVOKE, limit=10)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.actor == "trigger:watcher"
+        assert entry.metadata["trigger_source"] == "watcher"
+        assert entry.metadata["trigger_spec_id"] == "batch"
+        assert entry.metadata["agent_id"] == "batcher"

--- a/tests/test_contrib_webhook.py
+++ b/tests/test_contrib_webhook.py
@@ -42,12 +42,17 @@ class _FakeGraph:
 
 
 def _build_app(
-    registry: WebhookRegistry, graphs: dict[str, _FakeGraph]
+    registry: WebhookRegistry,
+    graphs: dict[str, _FakeGraph],
+    *,
+    audit_store: object = None,
 ) -> tuple[FastAPI, dict[str, _FakeGraph]]:
     app = FastAPI()
     app.include_router(
         create_webhook_router(
-            registry, graph_resolver=lambda agent_id: graphs[agent_id]
+            registry,
+            graph_resolver=lambda agent_id: graphs[agent_id],
+            audit_store=audit_store,
         )
     )
     return app, graphs
@@ -344,3 +349,44 @@ class TestWebhookRouter:
         )
         assert resp1.status_code == resp2.status_code == 200
         assert resp1.json()["thread_id"] != resp2.json()["thread_id"]
+
+
+class TestWebhookAudit:
+    def test_fire_emits_audit_entry_when_audit_store_set(self, mock_store: Any) -> None:
+        """A successful webhook fire writes an AGENT_INVOKE audit entry."""
+        import asyncio
+
+        from langgraph_kit.core.audit import AuditAction, AuditStore
+
+        audit_store = AuditStore(mock_store)
+        spec = WebhookSpec(
+            id="github-push",
+            agent_id="reviewer",
+            secret="whsec_audit",
+            payload_template="A new event arrived: {event}",
+        )
+        registry = WebhookRegistry()
+        registry.register(spec)
+        app, _ = _build_app(
+            registry, {"reviewer": _FakeGraph()}, audit_store=audit_store
+        )
+        client = TestClient(app)
+
+        body = b'{"event":"push"}'
+        sig = compute_signature(spec.secret, body)
+        resp = client.post(
+            f"/webhooks/{spec.id}",
+            content=body,
+            headers={spec.signature_header: sig, "content-type": "application/json"},
+        )
+        assert resp.status_code == 200
+
+        entries = asyncio.run(
+            audit_store.query(action=AuditAction.AGENT_INVOKE, limit=10)
+        )
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.actor == "trigger:webhook"
+        assert entry.metadata["trigger_source"] == "webhook"
+        assert entry.metadata["trigger_spec_id"] == "github-push"
+        assert entry.metadata["agent_id"] == "reviewer"


### PR DESCRIPTION
## Summary

- All three trigger entry points (`create_webhook_router`, `ScheduledTriggerRunner`, `StoreWatcherRunner`) now accept an optional `audit_store=` kwarg. When set, each fire writes one `AGENT_INVOKE` audit entry tagged \`actor=trigger:<source>\`.
- Helper \`emit_trigger_audit\` lives in `contrib.schedule` and is reused by the other two modules so the audit shape stays consistent. Exported via `__all__`.
- When \`audit_store=None\` (default), no audit emission and no exception — full back-compat with the v1 modules.
- Closes the audit acceptance criterion on #19. The fuller `TriggerDispatcher` abstraction in the original plan is intentionally deferred — the three modules already work standalone and the abstraction adds inheritance complexity for cosmetic shared dispatch.

## Test plan

- [x] `uv run pytest` (1439 passed)
- [x] `uv run basedpyright` on touched files (0 errors)
- [x] `uv run pre-commit run --all-files`
- New: 4 audit tests — schedule fire emits + skips; webhook fire emits; watcher edge-trigger fire emits.

Fixes #19