### PR TITLE
feat(orchestration): negotiation primitives over AgentMailbox (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **Multi-agent negotiation primitives (`propose` / `accept` /
+  `reject`).** Three thin helpers in
+  `langgraph_kit.core.orchestration.negotiation` that wrap the
+  existing `AgentMailbox` so a pair of agents can run a
+  propose/accept-reject conversation without re-deriving the
+  `AgentMessage` shape per caller. The helpers fix the message
+  `kind` and the `in_reply_to` chain; durable proposal state
+  belongs to `AgentWorkspace` if needed. Closes the negotiation
+  acceptance criterion on
+  [#20](https://github.com/allada-homelab/langgraph-kit/issues/20)
+  (workspace + mailbox already shipped).
+
 - **Trigger surfaces (webhook, schedule, watchers): optional audit
   emission.** All three trigger entry points
   (`create_webhook_router`, `ScheduledTriggerRunner`,

--- a/src/langgraph_kit/core/orchestration/negotiation.py
+++ b/src/langgraph_kit/core/orchestration/negotiation.py
@@ -1,0 +1,153 @@
+"""Negotiation primitives over :class:`AgentMailbox`.
+
+Three thin helpers — :func:`propose`, :func:`accept`,
+:func:`reject` — that wrap the existing mailbox so a pair of agents
+can run a propose/accept-reject conversation without re-deriving the
+``AgentMessage`` shape per caller. The actual delivery, FIFO order,
+and persistence semantics belong to ``AgentMailbox``; this module
+only fixes the message ``kind`` and the ``in_reply_to`` chain.
+
+Usage::
+
+    from langgraph_kit.core.orchestration.messaging import AgentMailbox
+    from langgraph_kit.core.orchestration.negotiation import (
+        propose, accept, reject,
+    )
+
+    mailbox = AgentMailbox(store)
+
+    # Agent A initiates.
+    proposal_id = await propose(
+        mailbox,
+        sender="agent-a",
+        recipient="agent-b",
+        action="merge_branch",
+        terms={"branch": "feature/x", "into": "main"},
+    )
+
+    # Agent B receives the propose, decides, replies.
+    inbox = await mailbox.arecv("agent-b")
+    for msg in inbox:
+        if msg.kind == "propose":
+            await accept(mailbox, msg, replier="agent-b")
+        await mailbox.amark_read("agent-b", msg.id)
+
+    # Agent A reads the reply later.
+    replies = await mailbox.arecv("agent-a")
+
+The state machine (``pending`` → ``accepted | rejected``) is
+implicit in the mailbox traffic — there's no separate proposal
+store. Callers wanting durable proposal state should layer it on top
+(e.g. via :class:`AgentWorkspace`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langgraph_kit.core.orchestration.messaging import AgentMessage
+
+if TYPE_CHECKING:
+    from langgraph_kit.core.orchestration.messaging import AgentMailbox
+
+
+async def propose(
+    mailbox: AgentMailbox,
+    *,
+    sender: str,
+    recipient: str,
+    action: str,
+    terms: dict[str, Any] | None = None,
+    in_reply_to: str | None = None,
+) -> str:
+    """Send a ``propose`` message and return the proposal id.
+
+    The proposal id IS the message id — replies thread through
+    ``in_reply_to`` so receivers can match accept/reject back to the
+    original propose. ``action`` is a free-form string identifying
+    what's being proposed; ``terms`` is the payload the recipient
+    inspects to decide.
+    """
+    message = AgentMessage(
+        sender=sender,
+        recipient=recipient,
+        kind="propose",
+        payload={"action": action, "terms": terms or {}},
+        in_reply_to=in_reply_to,
+    )
+    await mailbox.asend(message)
+    return message.id
+
+
+async def accept(
+    mailbox: AgentMailbox,
+    proposal: AgentMessage,
+    *,
+    replier: str,
+    notes: str | None = None,
+) -> str:
+    """Reply to *proposal* with an ``accept`` message; return its id.
+
+    ``proposal.kind`` must be ``"propose"``; the reply's
+    ``in_reply_to`` is set to ``proposal.id`` and the recipient is
+    set to ``proposal.sender`` so the conversation threads back to
+    the original proposer.
+    """
+    if proposal.kind != "propose":
+        msg = (
+            f"accept() expects a propose message; got kind={proposal.kind!r} "
+            f"id={proposal.id!r}"
+        )
+        raise ValueError(msg)
+    payload: dict[str, Any] = {"action": proposal.payload.get("action")}
+    if notes is not None:
+        payload["notes"] = notes
+    reply = AgentMessage(
+        sender=replier,
+        recipient=proposal.sender,
+        kind="accept",
+        payload=payload,
+        in_reply_to=proposal.id,
+    )
+    await mailbox.asend(reply)
+    return reply.id
+
+
+async def reject(
+    mailbox: AgentMailbox,
+    proposal: AgentMessage,
+    *,
+    replier: str,
+    reason: str,
+) -> str:
+    """Reply to *proposal* with a ``reject`` message; return its id.
+
+    ``reason`` is required — a reject without a reason wastes the
+    proposer's debug-time. ``in_reply_to`` is set to ``proposal.id``
+    so the proposer can match the rejection back.
+    """
+    if proposal.kind != "propose":
+        msg = (
+            f"reject() expects a propose message; got kind={proposal.kind!r} "
+            f"id={proposal.id!r}"
+        )
+        raise ValueError(msg)
+    reply = AgentMessage(
+        sender=replier,
+        recipient=proposal.sender,
+        kind="reject",
+        payload={
+            "action": proposal.payload.get("action"),
+            "reason": reason,
+        },
+        in_reply_to=proposal.id,
+    )
+    await mailbox.asend(reply)
+    return reply.id
+
+
+__all__ = [
+    "accept",
+    "propose",
+    "reject",
+]

--- a/tests/test_orchestration_negotiation.py
+++ b/tests/test_orchestration_negotiation.py
@@ -84,9 +84,7 @@ async def test_reject_requires_reason_and_threads_back(mock_store: Any) -> None:
 async def test_accept_rejects_non_propose_input(mock_store: Any) -> None:
     """accept() guards against being handed a non-propose message."""
     mailbox = AgentMailbox(mock_store)
-    proposal_id = await propose(
-        mailbox, sender="agent-a", recipient="agent-b", action="x"
-    )
+    await propose(mailbox, sender="agent-a", recipient="agent-b", action="x")
     proposal = (await mailbox.arecv("agent-b"))[0]
     await accept(mailbox, proposal, replier="agent-b")
     accept_msg = (await mailbox.arecv("agent-a"))[0]

--- a/tests/test_orchestration_negotiation.py
+++ b/tests/test_orchestration_negotiation.py
@@ -1,0 +1,109 @@
+"""Tests for ``langgraph_kit.core.orchestration.negotiation`` (issue #20)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph_kit.core.orchestration.messaging import AgentMailbox
+from langgraph_kit.core.orchestration.negotiation import accept, propose, reject
+
+
+@pytest.mark.asyncio
+async def test_propose_threads_through_mailbox(mock_store: Any) -> None:
+    """A propose() lands in the recipient's inbox with the right shape."""
+    mailbox = AgentMailbox(mock_store)
+    proposal_id = await propose(
+        mailbox,
+        sender="agent-a",
+        recipient="agent-b",
+        action="merge_branch",
+        terms={"branch": "feature/x"},
+    )
+
+    inbox = await mailbox.arecv("agent-b")
+    assert len(inbox) == 1
+    msg = inbox[0]
+    assert msg.id == proposal_id
+    assert msg.kind == "propose"
+    assert msg.sender == "agent-a"
+    assert msg.payload["action"] == "merge_branch"
+    assert msg.payload["terms"] == {"branch": "feature/x"}
+
+
+@pytest.mark.asyncio
+async def test_accept_threads_back_to_proposer(mock_store: Any) -> None:
+    """accept() replies to the proposer with kind=accept and in_reply_to set."""
+    mailbox = AgentMailbox(mock_store)
+    proposal_id = await propose(
+        mailbox,
+        sender="agent-a",
+        recipient="agent-b",
+        action="merge_branch",
+    )
+    inbox = await mailbox.arecv("agent-b")
+    proposal = inbox[0]
+
+    reply_id = await accept(mailbox, proposal, replier="agent-b", notes="LGTM")
+
+    a_inbox = await mailbox.arecv("agent-a")
+    assert len(a_inbox) == 1
+    reply = a_inbox[0]
+    assert reply.id == reply_id
+    assert reply.kind == "accept"
+    assert reply.in_reply_to == proposal_id
+    assert reply.recipient == "agent-a"
+    assert reply.payload["action"] == "merge_branch"
+    assert reply.payload["notes"] == "LGTM"
+
+
+@pytest.mark.asyncio
+async def test_reject_requires_reason_and_threads_back(mock_store: Any) -> None:
+    """reject() lands a reject message with a reason in the proposer's inbox."""
+    mailbox = AgentMailbox(mock_store)
+    proposal_id = await propose(
+        mailbox,
+        sender="agent-a",
+        recipient="agent-b",
+        action="merge_branch",
+    )
+    proposal = (await mailbox.arecv("agent-b"))[0]
+
+    await reject(mailbox, proposal, replier="agent-b", reason="conflicts on file X")
+
+    a_inbox = await mailbox.arecv("agent-a")
+    assert len(a_inbox) == 1
+    reply = a_inbox[0]
+    assert reply.kind == "reject"
+    assert reply.in_reply_to == proposal_id
+    assert reply.payload["reason"] == "conflicts on file X"
+
+
+@pytest.mark.asyncio
+async def test_accept_rejects_non_propose_input(mock_store: Any) -> None:
+    """accept() guards against being handed a non-propose message."""
+    mailbox = AgentMailbox(mock_store)
+    proposal_id = await propose(
+        mailbox, sender="agent-a", recipient="agent-b", action="x"
+    )
+    proposal = (await mailbox.arecv("agent-b"))[0]
+    await accept(mailbox, proposal, replier="agent-b")
+    accept_msg = (await mailbox.arecv("agent-a"))[0]
+
+    # Passing the accept reply back into accept() must fail loudly.
+    with pytest.raises(ValueError, match="expects a propose message"):
+        await accept(mailbox, accept_msg, replier="agent-c")
+
+
+@pytest.mark.asyncio
+async def test_reject_rejects_non_propose_input(mock_store: Any) -> None:
+    """reject() guards against being handed a non-propose message."""
+    mailbox = AgentMailbox(mock_store)
+    await propose(mailbox, sender="agent-a", recipient="agent-b", action="x")
+    proposal = (await mailbox.arecv("agent-b"))[0]
+    await accept(mailbox, proposal, replier="agent-b")
+    accept_msg = (await mailbox.arecv("agent-a"))[0]
+
+    with pytest.raises(ValueError, match="expects a propose message"):
+        await reject(mailbox, accept_msg, replier="agent-c", reason="nope")


### PR DESCRIPTION
## Summary

- New \`langgraph_kit.core.orchestration.negotiation\` module ships three thin helpers — \`propose\`, \`accept\`, \`reject\` — that wrap the existing \`AgentMailbox\` so a pair of agents can run a propose/accept-reject conversation without re-deriving the \`AgentMessage\` shape per caller.
- The helpers fix the message \`kind\` and the \`in_reply_to\` chain; \`accept\` / \`reject\` raise \`ValueError\` if handed a non-propose message so misuse fails loudly.
- The state machine (pending → accepted | rejected) is implicit in mailbox traffic; no separate proposal store. \`AgentWorkspace\` already ships for callers wanting durable proposal state.
- Closes the negotiation acceptance criterion on #20 (workspace + mailbox shipped earlier).

## Test plan

- [x] \`uv run pytest\` (1444 passed, 1 skipped)
- [x] \`uv run basedpyright\` (0 errors)
- [x] \`uv run pre-commit run --all-files\`
- New: 5 tests — propose lands in inbox; accept threads back with in_reply_to; reject carries reason; accept/reject reject non-propose input.

Fixes #20