### PR TITLE
fix(tracing): sequence-mode renders nested chain spans (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- **`trace_to_mermaid` sequence-mode now renders nested chain
+  spans.** The pre-fix `depth == 0` gate silently dropped any
+  `kind="chain"` span deeper than the root from sequence diagrams,
+  so sub-graphs and worker invocations disappeared from the
+  rendered trace. Nested chains now render as
+  `Note over Agent: chain (...)` so they appear in the diagram
+  without breaking the outer User↔Agent request/response framing.
+  Both renderers also honor a new `max_depth` kwarg
+  (`DEFAULT_MAX_DEPTH = 10`) — past the cap, sequence emits a
+  `Note ... truncated at depth N` and flowchart emits a single
+  `...truncated` node, so pathological deep traces don't bloat
+  diagrams unboundedly. Closes
+  [#21](https://github.com/allada-homelab/langgraph-kit/issues/21).
+
 ### Added
 
 - **Multi-agent negotiation primitives (`propose` / `accept` /

--- a/src/langgraph_kit/core/tracing/mermaid.py
+++ b/src/langgraph_kit/core/tracing/mermaid.py
@@ -4,8 +4,19 @@ from __future__ import annotations
 
 from langgraph_kit.core.tracing.models import TraceRecord, TraceSpan
 
+#: Hard cap on recursion depth for sequence/flowchart rendering. Caps
+#: pathological traces (e.g. a deep-agent run that goes 50+ levels into
+#: nested workers) so the rendered Mermaid stays readable and diagrams
+#: don't blow past mermaid.live's parser limits.
+DEFAULT_MAX_DEPTH: int = 10
 
-def trace_to_mermaid(trace: TraceRecord, *, style: str = "sequence") -> str:
+
+def trace_to_mermaid(
+    trace: TraceRecord,
+    *,
+    style: str = "sequence",
+    max_depth: int = DEFAULT_MAX_DEPTH,
+) -> str:
     """Convert a trace to a Mermaid diagram string.
 
     Parameters
@@ -14,13 +25,17 @@ def trace_to_mermaid(trace: TraceRecord, *, style: str = "sequence") -> str:
         The execution trace to visualize.
     style:
         ``"sequence"`` for a sequence diagram, ``"flowchart"`` for a flowchart.
+    max_depth:
+        Hard cap on recursion depth. Spans beyond ``max_depth`` are
+        truncated and an ellipsis note is emitted in their place so
+        the diagram doesn't grow unboundedly on deeply-nested traces.
     """
     if style == "flowchart":
-        return _flowchart(trace)
-    return _sequence(trace)
+        return _flowchart(trace, max_depth=max_depth)
+    return _sequence(trace, max_depth=max_depth)
 
 
-def _sequence(trace: TraceRecord) -> str:
+def _sequence(trace: TraceRecord, *, max_depth: int) -> str:
     """Generate a Mermaid sequence diagram."""
     lines = ["sequenceDiagram"]
     lines.append("    participant User")
@@ -29,13 +44,36 @@ def _sequence(trace: TraceRecord) -> str:
     lines.append("    participant Tool")
 
     for span in trace.spans:
-        _sequence_span(span, lines)
+        _sequence_span(span, lines, depth=0, max_depth=max_depth)
 
     return "\n".join(lines)
 
 
-def _sequence_span(span: TraceSpan, lines: list[str], depth: int = 0) -> None:
-    """Recursively add sequence diagram entries for a span and its children."""
+def _sequence_span(
+    span: TraceSpan,
+    lines: list[str],
+    *,
+    depth: int,
+    max_depth: int,
+) -> None:
+    """Recursively add sequence diagram entries for a span and its children.
+
+    Renders chain spans at any depth — depth-0 chains use the
+    canonical ``User → Agent`` request/response framing; nested
+    chains render as a ``Note over Agent`` so they appear in the
+    sequence without breaking the request/response framing of the
+    outer chain. Stops recursing once *depth* exceeds *max_depth* and
+    emits a single truncation note rather than dropping the subtree
+    silently.
+    """
+    if depth > max_depth:
+        note = (
+            f"    Note over Agent: ...({_safe_name(span.name)}) "
+            + f"truncated at depth {max_depth}"
+        )
+        lines.append(note)
+        return
+
     duration = f" ({span.duration_ms:.0f}ms)" if span.duration_ms else ""
     name = _safe_name(span.name)
 
@@ -45,24 +83,32 @@ def _sequence_span(span: TraceSpan, lines: list[str], depth: int = 0) -> None:
     elif span.kind == "tool":
         lines.append(f"    Agent->>Tool: {name}{duration}")
         lines.append("    Tool-->>Agent: result")
-    elif span.kind == "chain" and depth == 0:
-        lines.append(f"    User->>Agent: invoke ({name})")
+    elif span.kind == "chain":
+        if depth == 0:
+            lines.append(f"    User->>Agent: invoke ({name})")
+        else:
+            # Nested chains (sub-workers / inner graphs / etc.) render
+            # as a note so they appear in the diagram without breaking
+            # the outer User↔Agent request/response framing.
+            lines.append(f"    Note over Agent: chain ({name}){duration}")
 
     for child in span.children:
-        _sequence_span(child, lines, depth + 1)
+        _sequence_span(child, lines, depth=depth + 1, max_depth=max_depth)
 
     if span.kind == "chain" and depth == 0:
         lines.append(f"    Agent-->>User: response{duration}")
 
 
-def _flowchart(trace: TraceRecord) -> str:
+def _flowchart(trace: TraceRecord, *, max_depth: int) -> str:
     """Generate a Mermaid flowchart including parent→child edges."""
     lines = ["flowchart TD"]
     counter = [0]  # unique node-id generator shared across recursion
     root_ids: list[str] = []
 
     for span in trace.spans:
-        root_id = _flowchart_span(span, lines, counter, parent_node_id=None)
+        root_id = _flowchart_span(
+            span, lines, counter, parent_node_id=None, depth=0, max_depth=max_depth
+        )
         root_ids.append(root_id)
 
     # Connect sequential root spans (keeps the prior top-level ordering).
@@ -77,10 +123,15 @@ def _flowchart_span(
     lines: list[str],
     counter: list[int],
     parent_node_id: str | None,
+    *,
+    depth: int,
+    max_depth: int,
 ) -> str:
     """Add a flowchart node for ``span`` plus edges to its children.
 
-    Returns the generated node_id so callers can wire edges.
+    Returns the generated node_id so callers can wire edges. Children
+    beyond ``max_depth`` are collapsed into a single
+    ``...truncated`` node so deep traces don't bloat the diagram.
     """
     node_id = f"n{counter[0]}"
     counter[0] += 1
@@ -98,10 +149,24 @@ def _flowchart_span(
     if parent_node_id is not None:
         lines.append(f"    {parent_node_id} --> {node_id}")
 
+    if depth >= max_depth and span.children:
+        trunc_id = f"n{counter[0]}"
+        counter[0] += 1
+        lines.append(f'    {trunc_id}["...truncated at depth {max_depth}"]')
+        lines.append(f"    {node_id} --> {trunc_id}")
+        return node_id
+
     # Recurse. Prior implementation only drew root spans — all nesting
     # was silently dropped from the flowchart.
     for child in span.children:
-        _flowchart_span(child, lines, counter, parent_node_id=node_id)
+        _flowchart_span(
+            child,
+            lines,
+            counter,
+            parent_node_id=node_id,
+            depth=depth + 1,
+            max_depth=max_depth,
+        )
 
     return node_id
 

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -74,3 +74,84 @@ class TestTraceToMermaid:
         assert "sequenceDiagram" in seq
         flow = trace_to_mermaid(trace, style="flowchart")
         assert "flowchart TD" in flow
+
+
+class TestSequenceNestedRendering:
+    """Sequence-mode child rendering — regression tests for the
+    pre-fix ``depth == 0`` gate that dropped nested chain spans."""
+
+    def test_nested_chain_is_rendered_as_note(self) -> None:
+        """A chain inside a chain shows up as a Note rather than being dropped."""
+        outer = TraceSpan(
+            span_id="outer",
+            kind="chain",
+            name="outer_chain",
+            duration_ms=100.0,
+            children=[
+                TraceSpan(
+                    span_id="inner",
+                    kind="chain",
+                    name="inner_subgraph",
+                    duration_ms=40.0,
+                ),
+            ],
+        )
+        trace = _make_trace(outer)
+        result = trace_to_mermaid(trace, style="sequence")
+
+        assert "User->>Agent: invoke (outer_chain)" in result
+        assert "Note over Agent: chain (inner_subgraph)" in result
+        assert "Agent-->>User: response" in result
+
+    def test_deeply_nested_llm_span_under_chains_is_rendered(self) -> None:
+        """An LLM span at depth > 0 must reach the diagram (regression for the gate)."""
+        deep = TraceSpan(
+            span_id="root",
+            kind="chain",
+            name="root",
+            children=[
+                TraceSpan(
+                    span_id="mid",
+                    kind="chain",
+                    name="mid",
+                    children=[
+                        TraceSpan(
+                            span_id="leaf",
+                            kind="llm",
+                            name="claude-opus",
+                            duration_ms=250.0,
+                        ),
+                    ],
+                ),
+            ],
+        )
+        trace = _make_trace(deep)
+        result = trace_to_mermaid(trace, style="sequence")
+
+        # Leaf LLM call rendered even though it's nested two chains deep.
+        assert "Agent->>LLM: claude-opus" in result
+
+    def test_max_depth_truncates_with_explicit_note(self) -> None:
+        """Past max_depth, render a truncation note instead of recursing forever."""
+        # Build a chain 5 levels deep.
+        leaf = TraceSpan(span_id="l5", kind="chain", name="leaf")
+        for i in range(4, 0, -1):
+            leaf = TraceSpan(
+                span_id=f"l{i}", kind="chain", name=f"l{i}", children=[leaf]
+            )
+        trace = _make_trace(leaf)
+
+        seq = trace_to_mermaid(trace, style="sequence", max_depth=2)
+        assert "truncated at depth 2" in seq
+
+    def test_flowchart_max_depth_truncates_with_node(self) -> None:
+        """Flowchart honors max_depth too — emits a single ...truncated node."""
+        leaf = TraceSpan(span_id="l5", kind="tool", name="deep_tool")
+        for i in range(4, 0, -1):
+            leaf = TraceSpan(
+                span_id=f"l{i}", kind="chain", name=f"l{i}", children=[leaf]
+            )
+        trace = _make_trace(leaf)
+
+        flow = trace_to_mermaid(trace, style="flowchart", max_depth=2)
+        assert "...truncated at depth 2" in flow


### PR DESCRIPTION
## Summary

- Removes the \`depth == 0\` gate in \`_sequence_span\` that silently dropped any chain span deeper than the root from sequence diagrams. Sub-graphs and worker invocations now appear as \`Note over Agent: chain (...)\` notes.
- Both renderers (sequence + flowchart) honor a new \`max_depth\` kwarg (\`DEFAULT_MAX_DEPTH = 10\`). Past the cap, sequence emits a \`Note ... truncated\` line; flowchart emits a single \`...truncated\` node — pathological deep traces no longer balloon mermaid.live's parser.

## Test plan

- [x] \`uv run pytest\` (1448 passed, 1 skipped)
- [x] \`uv run basedpyright\` (0 errors)
- [x] \`uv run pre-commit run --all-files\`
- New: 4 tests — nested-chain renders as Note, deeply-nested LLM span reaches diagram (regression for the gate), max_depth truncates sequence, max_depth truncates flowchart.

Fixes #21