### PR TITLE
feat(shell): /info slash command for the interactive REPL (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **`langgraph-kit shell`: `/info` slash command.** The interactive
+  REPL now responds to `/info` with the active agent id, thread
+  id, user id, and user-supplied module path — without invoking
+  the agent. Closes one of the deferred items on
+  [#37](https://github.com/allada-homelab/langgraph-kit/issues/37);
+  the shell already had `/exit` and full thread/user-id plumbing.
+
 ### Fixed
 
 - **`trace_to_mermaid` sequence-mode now renders nested chain

--- a/src/langgraph_kit/shell.py
+++ b/src/langgraph_kit/shell.py
@@ -190,6 +190,7 @@ async def run_shell(
 
     write_output(f"langgraph-kit shell — agent={agent_id!r} thread={thread_id!r}")
     write_output("Type your message; '/exit' (or Ctrl-D / Ctrl-C) to quit.")
+    write_output("Built-in slash commands: /exit, /info.")
 
     while True:
         try:
@@ -201,6 +202,14 @@ async def run_shell(
             continue
         if user_input.strip().lower() in _EXIT_COMMANDS:
             return 0
+        if user_input.strip().lower() == "/info":
+            write_output(
+                f"  agent_id  = {agent_id}\n"
+                f"  thread_id = {thread_id}\n"
+                f"  user_id   = {user_id}\n"
+                f"  module    = {user_module or '(built-in)'}"
+            )
+            continue
         try:
             reply = await _invoke_once(graph, user_input, config)
         except Exception:

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -258,3 +258,27 @@ class TestRunShell:
         )
         assert rc == 0
         assert any("ok" in line for line in outputs)
+
+    @pytest.mark.asyncio
+    async def test_info_slash_command_prints_session_metadata(self) -> None:
+        """``/info`` reports agent / thread / user / module without invoking the agent."""
+        graph = _ScriptedGraph(reply="ignored")
+        registry.register("test-agent", graph)
+        outputs: list[str] = []
+        await run_shell(
+            "test-agent",
+            thread_id="my-thread",
+            user_id="me",
+            input_fn=_StubInputs(["/info"]),
+            output_fn=outputs.append,
+        )
+
+        info_lines = [line for line in outputs if "agent_id" in line]
+        assert info_lines, outputs
+        info = info_lines[0]
+        assert "test-agent" in info
+        assert "my-thread" in info
+        assert "me" in info
+        # /info must not invoke the graph — that would burn budget on a
+        # cosmetic introspection command.
+        assert graph.calls == []


### PR DESCRIPTION
## Summary

- Adds \`/info\` to the \`langgraph-kit shell\` REPL: prints agent id, thread id, user id, and the user-supplied module path without invoking the graph. Closes one of the v1-deferred items on #37.
- Tests pin that \`/info\` does not call into the graph — surfacing session metadata shouldn't burn the token budget on a cosmetic introspection command.

## Test plan

- [x] \`uv run pytest\` (1449 passed, 1 skipped)
- [x] \`uv run pre-commit run --all-files\`
- New: 1 test asserting /info output and the no-invoke contract.

Fixes #37