### PR TITLE
docs(cli): typed-client recipe for openapi + shell slash commands (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **CLI reference docs for `openapi` + `shell`.** Adds the typed-client
+  recipe (Python via `openapi-python-client`, TS via
+  `openapi-generator-cli`) the `openapi` subcommand was always
+  meant to anchor, plus a slash-command table for the REPL.
+  Closes the docs acceptance criterion on
+  [#39](https://github.com/allada-homelab/langgraph-kit/issues/39).
+
 - **`langgraph-kit shell`: `/info` slash command.** The interactive
   REPL now responds to `/info` with the active agent id, thread
   id, user id, and user-supplied module path — without invoking

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -74,3 +74,58 @@ def build_graph(checkpointer, store):
 ```
 
 After generating, register the agent in `graphs/__init__.py` to include it in `register_all()`.
+
+### openapi
+
+Dump the FastAPI agent router's OpenAPI specification to stdout or a file. Useful for generating typed clients without spinning up a live server.
+
+```bash
+uv run python -m langgraph_kit.cli openapi [--output spec.json] [--indent 2]
+```
+
+| Argument | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `--output` | No | stdout | Write the spec to this path instead of stdout |
+| `--indent` | No | `2` | JSON indent for the dumped spec (`0` for compact) |
+
+**What gets exported:** the full router from `langgraph_kit.contrib.fastapi.create_agent_router()` mounted on a temporary `FastAPI` app. The spec covers `/agents`, `/invoke`, `/stream`, and any other routes the router declares, with all Pydantic request/response models referenced under `components.schemas`.
+
+#### Generating a typed client
+
+The dumped spec feeds into any OpenAPI client generator. Two recipes — pick the one that matches your stack.
+
+**Python client via [`openapi-python-client`](https://github.com/openapi-generators/openapi-python-client):**
+
+```bash
+# 1. Dump the spec.
+uv run python -m langgraph_kit.cli openapi --output spec.json
+
+# 2. Generate a typed client package next to your app.
+uvx --from openapi-python-client openapi-python-client generate --path spec.json
+```
+
+The generator writes a package whose `Client` class wraps every endpoint with typed `attrs`-style models. Drop it into your app and call `Client(base_url=...).agents_get_invoke(...)`.
+
+**TypeScript / JS client via [`openapi-generator-cli`](https://github.com/OpenAPITools/openapi-generator-cli):**
+
+```bash
+uv run python -m langgraph_kit.cli openapi --output spec.json
+npx @openapitools/openapi-generator-cli generate \
+    -i spec.json \
+    -g typescript-fetch \
+    -o ./gen/langgraph-kit-client
+```
+
+#### Notes
+
+- **SSE doesn't model cleanly in OpenAPI.** The `/stream` endpoint declares `text/event-stream` as its response content type; concrete SSE event payload schemas are referenced from `components.schemas` so generated clients can still type the events even though the transport itself is opaque.
+- **No live server required.** The CLI mounts the router on a temporary `FastAPI()` and calls `app.openapi()`; nothing binds to a port. Safe to run in CI to keep a generated SDK up to date.
+
+### shell
+
+Interactive REPL for a registered agent. See `langgraph-kit shell --help` for the full flag list.
+
+| Slash command | Effect |
+|---------------|--------|
+| `/exit`, `/quit`, `/q` | End the session (or `Ctrl-D` / `Ctrl-C`). |
+| `/info` | Print the active agent id, thread id, user id, and module path without invoking the agent. |


### PR DESCRIPTION
## Summary

- Adds the typed-client recipe \`#39\` was meant to anchor: how to run \`langgraph-kit openapi\` and feed the spec into \`openapi-python-client\` or \`openapi-generator-cli\` to get a generated SDK.
- Documents the SSE caveat (transport is opaque to OpenAPI but event schemas live under \`components.schemas\` so generated clients can still type events) and the no-live-server property.
- Adds a shell slash-command table covering \`/exit\` + \`/info\` (the latter shipped in #37).
- Code unchanged; this is the docs-side acceptance criterion on #39.

## Test plan

- [x] \`uv run pytest\` (1449 passed, 1 skipped)
- [x] \`uv run pre-commit run --all-files\`
- Existing \`tests/test_cli_openapi.py\` already pins the JSON-shape contract of the \`openapi\` subcommand.

Fixes #39