### PR TITLE
feat(fastapi): validate AgentConfig at lifespan startup (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **`create_app_lifespan` validates `AgentConfig` at startup.** The
+  FastAPI lifespan now calls `validate_config` before any other
+  initialization. Errors raise `RuntimeError` with a readable list
+  of failures so misconfiguration aborts startup loud and early
+  instead of throwing obscure exceptions deep in the stack.
+  Warnings (e.g. half-set Langfuse credentials) are logged but
+  don't block startup. Closes the lifespan acceptance criterion on
+  [#41](https://github.com/allada-homelab/langgraph-kit/issues/41);
+  the standalone `validate_config` function and CLI subcommand
+  shipped earlier.
+
 - **CLI reference docs for `openapi` + `shell`.** Adds the typed-client
   recipe (Python via `openapi-python-client`, TS via
   `openapi-generator-cli`) the `openapi` subcommand was always

--- a/src/langgraph_kit/contrib/fastapi.py
+++ b/src/langgraph_kit/contrib/fastapi.py
@@ -123,8 +123,22 @@ def create_app_lifespan(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+        from langgraph_kit._config import validate_config
         from langgraph_kit.observability import init_langfuse, shutdown_langfuse
         from langgraph_kit.persistence import create_persistence
+
+        # Fail loud and early on bad config — bad ``database_url`` schemes,
+        # negative budgets, mismatched Langfuse credentials. Errors raise
+        # ``RuntimeError`` so the FastAPI startup phase aborts with a
+        # readable message instead of throwing obscure exceptions deep in
+        # the stack later. Warnings are logged but don't block startup.
+        report = validate_config(get_config())
+        for warning in report.warnings:
+            logger.warning("AgentConfig warning: %s", warning)
+        if not report.is_ok:
+            joined = "; ".join(report.errors)
+            msg = f"AgentConfig failed validation: {joined}"
+            raise RuntimeError(msg)
 
         init_langfuse()
         mcp_mgr = None

--- a/tests/test_fastapi_lifespan_validation.py
+++ b/tests/test_fastapi_lifespan_validation.py
@@ -28,8 +28,9 @@ def _restore_config() -> Any:
     configure(original)
 
 
+@pytest.mark.usefixtures("_restore_config")
 @pytest.mark.asyncio
-async def test_lifespan_raises_on_invalid_database_url(_restore_config: Any) -> None:
+async def test_lifespan_raises_on_invalid_database_url() -> None:
     """A bad ``database_url`` scheme aborts startup with a readable message."""
     configure(AgentConfig(database_url="mysql://localhost/db"))
     lifespan_factory = create_app_lifespan(register_agents=lambda *_a, **_kw: None)
@@ -39,8 +40,9 @@ async def test_lifespan_raises_on_invalid_database_url(_restore_config: Any) -> 
             pass
 
 
+@pytest.mark.usefixtures("_restore_config")
 @pytest.mark.asyncio
-async def test_lifespan_raises_on_negative_token_budget(_restore_config: Any) -> None:
+async def test_lifespan_raises_on_negative_token_budget() -> None:
     """A negative ``token_budget_per_thread`` aborts startup."""
     configure(AgentConfig(token_budget_per_thread=-1))
     lifespan_factory = create_app_lifespan(register_agents=lambda *_a, **_kw: None)
@@ -50,9 +52,10 @@ async def test_lifespan_raises_on_negative_token_budget(_restore_config: Any) ->
             pass
 
 
+@pytest.mark.usefixtures("_restore_config")
 @pytest.mark.asyncio
 async def test_lifespan_logs_warnings_but_does_not_raise(
-    caplog: pytest.LogCaptureFixture, _restore_config: Any
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Warnings (e.g. half-set Langfuse credentials) log but don't abort startup.
 
@@ -63,13 +66,15 @@ async def test_lifespan_logs_warnings_but_does_not_raise(
     configure(AgentConfig(langfuse_public_key="pk_only"))
     lifespan_factory = create_app_lifespan(register_agents=lambda *_a, **_kw: None)
 
-    with caplog.at_level(logging.WARNING, logger="langgraph_kit.contrib.fastapi"):
-        # Real persistence will eventually try to connect; that's
-        # outside the scope of this test. Suppress whatever it raises
-        # so we can inspect the warning that fired before it.
-        with suppress(Exception):
-            async with lifespan_factory(FastAPI()):
-                pass
+    # Real persistence will eventually try to connect; that's outside
+    # the scope of this test. Suppress whatever it raises so we can
+    # inspect the warning that fired before it.
+    with (
+        caplog.at_level(logging.WARNING, logger="langgraph_kit.contrib.fastapi"),
+        suppress(Exception),
+    ):
+        async with lifespan_factory(FastAPI()):
+            pass
 
     warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
     assert any("AgentConfig warning:" in w for w in warnings), warnings

--- a/tests/test_fastapi_lifespan_validation.py
+++ b/tests/test_fastapi_lifespan_validation.py
@@ -1,0 +1,75 @@
+"""Tests for ``create_app_lifespan`` config-validation gating (issue #41).
+
+The lifespan now calls ``validate_config`` at startup and raises
+``RuntimeError`` on errors (warnings just log). These tests pin that
+contract without spinning up a live DB / Langfuse / MCP stack — we
+short-circuit the lifespan via the ``register_agents`` callback (the
+validation check runs before that callback).
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import suppress
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+
+from langgraph_kit._config import AgentConfig, configure, get_config
+from langgraph_kit.contrib.fastapi import create_app_lifespan
+
+
+@pytest.fixture
+def _restore_config() -> Any:
+    """Restore the original AgentConfig after each test mutates it."""
+    original = get_config()
+    yield
+    configure(original)
+
+
+@pytest.mark.asyncio
+async def test_lifespan_raises_on_invalid_database_url(_restore_config: Any) -> None:
+    """A bad ``database_url`` scheme aborts startup with a readable message."""
+    configure(AgentConfig(database_url="mysql://localhost/db"))
+    lifespan_factory = create_app_lifespan(register_agents=lambda *_a, **_kw: None)
+
+    with pytest.raises(RuntimeError, match="AgentConfig failed validation"):
+        async with lifespan_factory(FastAPI()):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_raises_on_negative_token_budget(_restore_config: Any) -> None:
+    """A negative ``token_budget_per_thread`` aborts startup."""
+    configure(AgentConfig(token_budget_per_thread=-1))
+    lifespan_factory = create_app_lifespan(register_agents=lambda *_a, **_kw: None)
+
+    with pytest.raises(RuntimeError, match="AgentConfig failed validation"):
+        async with lifespan_factory(FastAPI()):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_lifespan_logs_warnings_but_does_not_raise(
+    caplog: pytest.LogCaptureFixture, _restore_config: Any
+) -> None:
+    """Warnings (e.g. half-set Langfuse credentials) log but don't abort startup.
+
+    We let the lifespan attempt the real persistence path, catch any
+    downstream failure (since we're not connecting to a real DB), and
+    only assert that the warning was emitted before that point.
+    """
+    configure(AgentConfig(langfuse_public_key="pk_only"))
+    lifespan_factory = create_app_lifespan(register_agents=lambda *_a, **_kw: None)
+
+    with caplog.at_level(logging.WARNING, logger="langgraph_kit.contrib.fastapi"):
+        # Real persistence will eventually try to connect; that's
+        # outside the scope of this test. Suppress whatever it raises
+        # so we can inspect the warning that fired before it.
+        with suppress(Exception):
+            async with lifespan_factory(FastAPI()):
+                pass
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("AgentConfig warning:" in w for w in warnings), warnings


### PR DESCRIPTION
## Summary

- \`create_app_lifespan\` now runs \`validate_config\` before any other initialization. Errors raise \`RuntimeError\` with a readable list of failures so misconfiguration aborts FastAPI startup loud and early.
- Warnings (half-set Langfuse credentials, etc.) log via the \`langgraph_kit.contrib.fastapi\` logger but don't block startup, matching the two-tier \`ValidationReport\` contract.
- The standalone \`validate_config\` function and the \`langgraph-kit validate-config\` CLI subcommand shipped earlier; this PR closes the lifespan-startup acceptance criterion on #41.

## Test plan

- [x] \`uv run pytest\` (1452 passed, 1 skipped)
- [x] \`uv run basedpyright\` (0 errors)
- [x] \`uv run pre-commit run --all-files\`
- New: 3 tests — invalid \`database_url\` raises, negative token-budget raises, warnings log but startup proceeds.

Fixes #41