### PR TITLE
feat(prompts): prompt_overrides lifecycle + orchestration sections (#43 v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Added
 
+- **`AgentConfig.prompt_overrides` lifecycle integration + curated
+  orchestration sections (#43 v2).**
+  `build_deep_agent` now consults `AgentConfig.prompt_overrides`
+  (a `dict[str, PromptSection]`) after every other section
+  registration path (core / activation / plugin / extra_sections /
+  tool_guidance) so user-supplied overrides win on id collisions —
+  closing the lifecycle gap left by the v1 prompt-templates ship.
+  Three new curated sections in
+  `langgraph_kit.prompt_templates.orchestration`:
+  `delegation_discipline`, `synthesis_discipline`,
+  `parallel_workers` — `CONDITIONAL` on the
+  `"orchestration"` key so they activate only when the build
+  registers it. Closes
+  [#43](https://github.com/allada-homelab/langgraph-kit/issues/43).
+
 - **`create_app_lifespan` validates `AgentConfig` at startup.** The
   FastAPI lifespan now calls `validate_config` before any other
   initialization. Errors raise `RuntimeError` with a readable list

--- a/src/langgraph_kit/_config.py
+++ b/src/langgraph_kit/_config.py
@@ -6,6 +6,11 @@ import dataclasses
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+# Runtime (not TYPE_CHECKING) import so the ``prompt_overrides``
+# field annotation resolves under ruff's F821 undefined-name check
+# on dataclass fields.
+from langgraph_kit.core.prompt_assembly.sections import PromptSection
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
@@ -60,6 +65,18 @@ class AgentConfig:
     # the only signal that semantic search is enabled.
     memory_embedding_fn: Callable[[list[str]], Awaitable[list[list[float]]]] | None = (
         dataclasses.field(default=None, compare=False)
+    )
+
+    # Prompt overrides: {section_id → PromptSection} merged into the
+    # SectionRegistry by ``build_deep_agent`` after the kit's
+    # core/activation/plugin sections register. Caller wins on id
+    # collisions — same upsert-by-id precedence as plugin tools. Pairs
+    # with the curated ``langgraph_kit.prompt_templates`` library so
+    # consumers can swap any shipped prompt without forking the kit.
+    # ``compare=False`` so the dict (unhashable) doesn't break
+    # AgentConfig's frozen-dataclass hashability.
+    prompt_overrides: dict[str, PromptSection] = dataclasses.field(
+        default_factory=dict, compare=False
     )
 
     # Security: inbound prompt-injection scanner mode.

--- a/src/langgraph_kit/graphs/_builder.py
+++ b/src/langgraph_kit/graphs/_builder.py
@@ -298,6 +298,15 @@ def build_deep_agent(
             )
         )
 
+    # ``AgentConfig.prompt_overrides`` lands LAST so user-supplied
+    # overrides win against every other registration path
+    # (core, activation, plugin, extra_sections, tool_guidance). The
+    # registry upserts on (id, version), so an override under the same
+    # id replaces the shipped section's current version.
+    overrides = get_config().prompt_overrides
+    if overrides:
+        section_registry.register_many(list(overrides.values()))
+
     providers: list[Any] = [
         ThreadContextProvider(),
         MemoryContextProvider(),

--- a/src/langgraph_kit/prompt_templates/__init__.py
+++ b/src/langgraph_kit/prompt_templates/__init__.py
@@ -65,6 +65,11 @@ from langgraph_kit.prompt_templates.diff import diff_section
 from langgraph_kit.prompt_templates.memory import (
     memory_awareness,
 )
+from langgraph_kit.prompt_templates.orchestration import (
+    delegation_discipline,
+    parallel_workers,
+    synthesis_discipline,
+)
 from langgraph_kit.prompt_templates.safety import (
     error_handling,
     output_format_natural,
@@ -76,11 +81,14 @@ __all__ = [
     "be_concise",
     "completion_signal",
     "core_identity",
+    "delegation_discipline",
     "diff_section",
     "error_handling",
     "memory_awareness",
     "operate_carefully",
     "output_format_natural",
     "output_format_structured",
+    "parallel_workers",
+    "synthesis_discipline",
     "tool_use_discipline",
 ]

--- a/src/langgraph_kit/prompt_templates/orchestration.py
+++ b/src/langgraph_kit/prompt_templates/orchestration.py
@@ -1,0 +1,91 @@
+"""Multi-agent / coordinator orchestration sections.
+
+Curated counterparts to the ad-hoc orchestration prompts that ship
+inline today (``CoordinatorMode`` in
+``langgraph_kit.core.coordinator``, the
+``orchestration_instructions`` section in
+``reference_deep_agent``). Same shape as the rest of the
+``prompt_templates`` library — ``CONDITIONAL`` sections gated on
+``"orchestration"`` so they activate only when the build registers
+the condition.
+
+Use these when assembling a custom agent that should delegate work
+or coordinate sub-workers but doesn't otherwise want to inherit
+``CoordinatorMode``'s strict read-only-tool surface.
+"""
+
+from __future__ import annotations
+
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionStability,
+)
+
+delegation_discipline = PromptSection(
+    id="delegation_discipline",
+    version="1",
+    content=(
+        "# Delegation Discipline\n"
+        "When you delegate work to a sub-worker:\n"
+        "- Brief them like a colleague who hasn't seen the conversation.\n"
+        "- Include: the goal, relevant context, what success looks like.\n"
+        "- Keep delegations bounded — concrete tasks with clear exit conditions.\n"
+        "- Never delegate understanding — read worker results yourself first."
+    ),
+    stability=SectionStability.CONDITIONAL,
+    priority=80,
+    condition="orchestration",
+)
+"""Briefing-quality discipline for delegations.
+
+Drop in when the agent has a ``task`` (or equivalent) tool and you
+want it to write good worker prompts instead of one-line dispatches.
+"""
+
+synthesis_discipline = PromptSection(
+    id="synthesis_discipline",
+    version="1",
+    content=(
+        "# Synthesis Discipline\n"
+        "When workers return results:\n"
+        "1. Read and understand the findings yourself.\n"
+        "2. Identify gaps, contradictions, or next steps.\n"
+        "3. Synthesize into a clear answer for the user.\n"
+        "Do NOT relay worker output verbatim. Add value through integration."
+    ),
+    stability=SectionStability.CONDITIONAL,
+    priority=78,
+    condition="orchestration",
+)
+"""Forces the agent to integrate worker output rather than echo it.
+
+Tracks the same intent as ``CoordinatorMode``'s synthesis section
+but lives in the curated library so non-coordinator agents can
+adopt it without inheriting the read-only tool filter.
+"""
+
+parallel_workers = PromptSection(
+    id="parallel_workers",
+    version="1",
+    content=(
+        "# Parallel Workers\n"
+        "When delegations are independent (no data flowing between them), "
+        "fire them in parallel rather than sequentially. Sequential delegation "
+        "is appropriate when worker B depends on worker A's findings."
+    ),
+    stability=SectionStability.CONDITIONAL,
+    priority=70,
+    condition="orchestration",
+)
+"""Pushes the agent to parallelise independent delegations.
+
+Pairs with the kit's ``task`` tool which accepts a list of
+delegations.
+"""
+
+
+__all__ = [
+    "delegation_discipline",
+    "parallel_workers",
+    "synthesis_discipline",
+]

--- a/tests/test_prompt_overrides.py
+++ b/tests/test_prompt_overrides.py
@@ -1,0 +1,134 @@
+"""Tests for ``AgentConfig.prompt_overrides`` lifecycle wiring (#43 v2)."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from langgraph_kit._config import AgentConfig, configure, get_config
+from langgraph_kit.core.prompt_assembly.sections import (
+    PromptSection,
+    SectionStability,
+)
+from langgraph_kit.graphs._builder import build_deep_agent
+
+
+def _mock_deepagents_env() -> tuple[dict[str, MagicMock], MagicMock, MagicMock]:
+    fake_graph = MagicMock(name="compiled_graph")
+    fake_graph.with_config.return_value = fake_graph
+    deepagents_mod = MagicMock()
+    deepagents_mod.create_deep_agent.return_value = fake_graph
+
+    backends_mod = MagicMock()
+    return (
+        {
+            "deepagents": deepagents_mod,
+            "deepagents.backends": backends_mod,
+            "deepagents.backends.composite": backends_mod.composite,
+            "deepagents.backends.state": backends_mod.state,
+            "deepagents.backends.store": backends_mod.store,
+        },
+        deepagents_mod,
+        fake_graph,
+    )
+
+
+def test_prompt_override_replaces_shipped_section(mock_store: Any) -> None:
+    """An override under a shipped section's id replaces it in the composed prompt.
+
+    Verifies the lifecycle path: ``AgentConfig.prompt_overrides`` is
+    consulted by ``build_deep_agent`` after every other registration
+    so the override wins.
+    """
+    sentinel_marker = "OVERRIDE_SENTINEL_MARKER_KZKZKZ"
+    override = PromptSection(
+        id="core_identity",
+        version="custom-1",
+        content=f"You are a custom override agent. {sentinel_marker}",
+        stability=SectionStability.STABLE,
+        priority=100,
+    )
+
+    original_cfg = get_config()
+    try:
+        configure(AgentConfig(prompt_overrides={"core_identity": override}))
+
+        module_patches, deepagents_mod, _ = _mock_deepagents_env()
+        with (
+            patch.dict(sys.modules, module_patches),
+            patch(
+                "langgraph_kit.graphs._builder.build_llm",
+                return_value=MagicMock(name="fake_llm"),
+            ),
+        ):
+            build_deep_agent(
+                agent_name="override-test",
+                core_sections=[
+                    PromptSection(
+                        id="core_identity",
+                        content="You are a default agent.",
+                        stability=SectionStability.STABLE,
+                        priority=100,
+                    )
+                ],
+                subagents=[],
+                checkpointer=MagicMock(),
+                store=mock_store,
+            )
+    finally:
+        configure(original_cfg)
+
+    system_prompt = deepagents_mod.create_deep_agent.call_args.kwargs["system_prompt"]
+    assert sentinel_marker in system_prompt, system_prompt[:400]
+    assert "You are a default agent." not in system_prompt
+
+
+def test_no_overrides_leaves_shipped_sections_intact(mock_store: Any) -> None:
+    """Without any overrides, the shipped section content reaches the prompt unchanged."""
+    original_cfg = get_config()
+    try:
+        configure(AgentConfig())  # default — empty prompt_overrides
+
+        module_patches, deepagents_mod, _ = _mock_deepagents_env()
+        with (
+            patch.dict(sys.modules, module_patches),
+            patch(
+                "langgraph_kit.graphs._builder.build_llm",
+                return_value=MagicMock(name="fake_llm"),
+            ),
+        ):
+            build_deep_agent(
+                agent_name="no-override",
+                core_sections=[
+                    PromptSection(
+                        id="core_identity",
+                        content="DEFAULT_CONTENT_AAAAA",
+                        stability=SectionStability.STABLE,
+                        priority=100,
+                    )
+                ],
+                subagents=[],
+                checkpointer=MagicMock(),
+                store=mock_store,
+            )
+    finally:
+        configure(original_cfg)
+
+    system_prompt = deepagents_mod.create_deep_agent.call_args.kwargs["system_prompt"]
+    assert "DEFAULT_CONTENT_AAAAA" in system_prompt
+
+
+def test_prompt_overrides_field_is_independent_per_config_instance() -> None:
+    """Two AgentConfig instances must not share the same prompt_overrides dict.
+
+    ``field(default_factory=dict)`` per-instance — regression guard
+    against accidentally using a shared mutable default.
+    """
+    a = AgentConfig()
+    b = AgentConfig()
+    assert a.prompt_overrides is not b.prompt_overrides
+    a.prompt_overrides["x"] = PromptSection(
+        id="x", content="x", stability=SectionStability.STABLE, priority=1
+    )
+    assert "x" not in b.prompt_overrides


### PR DESCRIPTION
## Summary

- \`build_deep_agent\` now consults \`AgentConfig.prompt_overrides\` (\`dict[str, PromptSection]\`) after every other section registration path — user-supplied overrides win against shipped/plugin/extra sections on id collisions.
- Three new curated sections in \`langgraph_kit.prompt_templates.orchestration\`: \`delegation_discipline\`, \`synthesis_discipline\`, \`parallel_workers\`. \`CONDITIONAL\` on the \`\"orchestration\"\` key so they activate only when the build registers it.
- Closes the two items #43 v1 (PR #91) explicitly deferred: \`AgentConfig.prompt_overrides\` lifecycle integration + the orchestration family of curated sections.

## Test plan

- [x] \`uv run pytest\` (1455 passed, 1 skipped)
- [x] \`uv run basedpyright\` (0 errors on touched files)
- [x] \`uv run pre-commit run --all-files\`
- New: 3 tests — override replaces shipped section, no overrides leaves shipped intact, per-instance dict isolation (regression guard against shared mutable default).

Fixes #43