### PR TITLE
fix(examples): skip real-LLM examples when AGENT_LLM_API_KEY is unset

### DIFF
--- a/examples/basic_deep_agent.py
+++ b/examples/basic_deep_agent.py
@@ -24,6 +24,7 @@ import asyncio
 
 from examples._lib import (
     answer,
+    assert_real_llm_or_skip,
     banner,
     configure_real_llm,
     hermetic,
@@ -46,6 +47,7 @@ async def main() -> None:
             with patch_build_llm(llm):
                 await _run(workspace, user_message)
         else:
+            assert_real_llm_or_skip()
             configure_real_llm(workspace)
             await _run(workspace, user_message)
 

--- a/examples/quickstart_echo.py
+++ b/examples/quickstart_echo.py
@@ -23,6 +23,7 @@ import asyncio
 
 from examples._lib import (
     answer,
+    assert_real_llm_or_skip,
     banner,
     configure_real_llm,
     hermetic,
@@ -47,6 +48,7 @@ async def main() -> None:
             with patch_build_llm(llm):
                 await _run_one_turn(workspace, user_message)
         else:
+            assert_real_llm_or_skip()
             configure_real_llm(workspace)
             await _run_one_turn(workspace, user_message)
 

--- a/examples/reference_deep_agent.py
+++ b/examples/reference_deep_agent.py
@@ -32,6 +32,7 @@ import asyncio
 
 from examples._lib import (
     answer,
+    assert_real_llm_or_skip,
     banner,
     configure_real_llm,
     hermetic,
@@ -60,6 +61,7 @@ async def main() -> None:
             with patch_build_llm(llm):
                 await _run(workspace, user_message)
         else:
+            assert_real_llm_or_skip()
             configure_real_llm(workspace)
             await _run(workspace, user_message)
 

--- a/examples/streaming_sse_events.py
+++ b/examples/streaming_sse_events.py
@@ -37,6 +37,7 @@ from typing import Any
 
 from examples._lib import (
     answer,
+    assert_real_llm_or_skip,
     banner,
     configure_real_llm,
     hermetic,
@@ -78,6 +79,7 @@ async def main() -> None:
             with patch_build_llm(llm):
                 await _stream_one_turn(workspace, user_message)
         else:
+            assert_real_llm_or_skip()
             configure_real_llm(workspace)
             await _stream_one_turn(workspace, user_message)
 


### PR DESCRIPTION
## Summary
- Four hermetic-or-real demos (`basic_deep_agent`, `quickstart_echo`, `reference_deep_agent`, `streaming_sse_events`) called `configure_real_llm()` in their else-branch with no guard, so a missing `AGENT_LLM_API_KEY` aborted the whole nightly run instead of skipping.
- Added the existing `assert_real_llm_or_skip()` call before `configure_real_llm()` in each of the four. The helper exits 0 when the key isn't set, matching the contract documented in [examples/_lib.py](examples/_lib.py).

## Test plan
- [x] `LANGGRAPH_KIT_EXAMPLES_LLM=real uv run python -m examples.{quickstart_echo,basic_deep_agent,reference_deep_agent,streaming_sse_events}` with no key → all four print `skipping: AGENT_LLM_API_KEY not set` and exit 0.
- [x] `uv run python -m examples.quickstart_echo` (hermetic, default) still answers normally.
- [x] `uv run pytest` — 1455 passing, 1 skipped.
- [x] `uv run ruff check . && uv run ruff format --check . && uv run basedpyright && uv run pre-commit run --all-files` — all clean.

Fixes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)