### PR TITLE
feat(testing): public scripted_llm + FakeCheckpointer + pytest11 entry-point (#42 v2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ Homepage = "https://github.com/allada-homelab/langgraph-kit"
 Source = "https://github.com/allada-homelab/langgraph-kit"
 Issues = "https://github.com/allada-homelab/langgraph-kit/issues"
 
+[project.entry-points.pytest11]
+langgraph_kit_testing = "langgraph_kit.testing.pytest_plugin"
+
 [project.optional-dependencies]
 postgres = ["langgraph-checkpoint-postgres>=3.0.5"]
 openai = ["langchain-openai>=1.2.0"]

--- a/src/langgraph_kit/testing/__init__.py
+++ b/src/langgraph_kit/testing/__init__.py
@@ -13,21 +13,23 @@ Currently exposes:
   Store-backed kit code without spinning up SQLite or Postgres.
 - :class:`FakeItem` — the ``aget`` / ``asearch`` return-shape
   (``key`` / ``value`` / ``namespace``).
-- :func:`assert_namespace_contains` — assertion helper for "did the
-  thing-under-test write what I expected to this Store namespace?"
-- :func:`assert_namespace_empty` — assertion helper for the
-  no-side-effect side of the same coin.
+- :class:`FakeCheckpointer` — :class:`InMemorySaver` subclass with
+  ``dump_state`` and ``assert_thread_has_messages`` for tests that
+  need to inspect what a graph wrote.
+- :func:`scripted_llm`, :func:`tool_call_turn`,
+  :func:`multi_tool_call_turn`, :func:`answer` — builders for the
+  :class:`RecordedChatModel` so tests can drive a graph
+  deterministically without touching a real LLM.
+- :func:`assert_tool_invoked`, :func:`last_ai_message` — assertions
+  for inspecting the resulting ``state["messages"]``.
+- :func:`assert_namespace_contains`, :func:`assert_namespace_empty` —
+  assertions for verifying what was written to a Store namespace.
 
-Deferred to follow-ups (each its own small PR):
-
-- ``FakeCheckpointer`` (thin wrapper over ``InMemorySaver`` with
-  ``dump_state`` and ``assert_thread_has_messages`` affordances).
-- ``scripted_llm`` / ``tool_call_turn`` / ``answer`` — the
-  ``RecordedChatModel`` script builders currently in
-  ``tests/e2e/conftest.py``.
-- Pytest ``entry_points.pytest11`` plugin so fixtures auto-register
-  on ``pytest`` invocation; today callers do
-  ``from langgraph_kit.testing import FakeStore`` explicitly.
+Pytest plugin: when this kit is installed in a downstream project,
+the ``langgraph_kit.testing.pytest_plugin`` module is auto-discovered
+via :pep:`517` ``[project.entry-points.pytest11]`` and exposes
+``fake_store``, ``fake_checkpointer``, and ``scripted_llm_factory``
+as fixtures with no explicit conftest wiring required.
 """
 
 from __future__ import annotations
@@ -36,11 +38,27 @@ from langgraph_kit.testing.assertions import (
     assert_namespace_contains,
     assert_namespace_empty,
 )
+from langgraph_kit.testing.checkpointer import FakeCheckpointer
 from langgraph_kit.testing.fakes import FakeItem, FakeStore
+from langgraph_kit.testing.llm import (
+    answer,
+    assert_tool_invoked,
+    last_ai_message,
+    multi_tool_call_turn,
+    scripted_llm,
+    tool_call_turn,
+)
 
 __all__ = [
+    "FakeCheckpointer",
     "FakeItem",
     "FakeStore",
+    "answer",
     "assert_namespace_contains",
     "assert_namespace_empty",
+    "assert_tool_invoked",
+    "last_ai_message",
+    "multi_tool_call_turn",
+    "scripted_llm",
+    "tool_call_turn",
 ]

--- a/src/langgraph_kit/testing/checkpointer.py
+++ b/src/langgraph_kit/testing/checkpointer.py
@@ -1,0 +1,71 @@
+"""In-memory checkpointer with testing-friendly affordances.
+
+A thin wrapper around LangGraph's :class:`InMemorySaver` that adds a
+small assertion / introspection surface for tests. Use as a drop-in
+replacement for ``InMemorySaver``: every kit module that takes a
+``checkpointer`` accepts this unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from langchain_core.runnables import (  # pyright: ignore[reportMissingModuleSource]
+    RunnableConfig,
+)
+from langgraph.checkpoint.memory import (  # pyright: ignore[reportMissingImports]
+    InMemorySaver,
+)
+
+
+class FakeCheckpointer(InMemorySaver):
+    """In-memory checkpointer with ``dump_state`` / assertion helpers.
+
+    All persistence goes through :class:`InMemorySaver` so every code
+    path the kit tests against the real saver runs unchanged here. The
+    extra methods only read state, never alter it.
+    """
+
+    def dump_state(self, thread_id: str) -> dict[str, Any]:
+        """Return the latest checkpoint values for *thread_id*.
+
+        Empty dict if the thread has no checkpoints. Useful for tests
+        that need to inspect what the graph wrote without round-
+        tripping through ``aget_state`` / ``StateSnapshot`` shapes.
+
+        Plain-``dict`` state graphs nest the whole state under the
+        synthetic ``__root__`` channel; ``TypedDict`` state graphs
+        expose each field as its own channel. This unwraps the former
+        so callers see the same shape in both cases.
+        """
+        config = cast("RunnableConfig", {"configurable": {"thread_id": thread_id}})
+        checkpoint = self.get(config)
+        if checkpoint is None:
+            return {}
+        values = checkpoint.get("channel_values", {})
+        if not values:
+            return {}
+        root = values.get("__root__")
+        if isinstance(root, dict) and len(values) == 1:
+            return dict(root)
+        return dict(values)
+
+    def assert_thread_has_messages(self, thread_id: str, n: int) -> None:
+        """Assert *thread_id*'s message list has exactly *n* entries.
+
+        Raises :class:`AssertionError` with the actual count and a
+        truncated summary of message types when the count differs.
+        """
+        values = self.dump_state(thread_id)
+        messages = values.get("messages", [])
+        actual = len(messages)
+        if actual != n:
+            summary = [type(m).__name__ for m in messages[:5]]
+            suffix = "..." if actual > 5 else ""
+            raise AssertionError(
+                f"Expected thread {thread_id!r} to have {n} messages; "
+                f"got {actual} (types: {summary}{suffix})"
+            )
+
+
+__all__ = ["FakeCheckpointer"]

--- a/src/langgraph_kit/testing/checkpointer.py
+++ b/src/langgraph_kit/testing/checkpointer.py
@@ -8,14 +8,16 @@ replacement for ``InMemorySaver``: every kit module that takes a
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
-from langchain_core.runnables import (  # pyright: ignore[reportMissingModuleSource]
-    RunnableConfig,
-)
 from langgraph.checkpoint.memory import (  # pyright: ignore[reportMissingImports]
     InMemorySaver,
 )
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import (  # pyright: ignore[reportMissingModuleSource]
+        RunnableConfig,
+    )
 
 
 class FakeCheckpointer(InMemorySaver):

--- a/src/langgraph_kit/testing/llm.py
+++ b/src/langgraph_kit/testing/llm.py
@@ -1,0 +1,156 @@
+"""Scripted-LLM helpers for kit consumers' tests.
+
+Promotes the e2e layer's ``scripted_llm`` / ``tool_call_turn`` /
+``answer`` builders to public API so downstream agents that build on
+the kit can drive deterministic graph runs without copy-pasting the
+``RecordedChatModel`` scaffolding.
+
+Quick start::
+
+    from langgraph_kit.testing import scripted_llm, tool_call_turn, answer
+
+    llm = scripted_llm([
+        tool_call_turn("search", {"q": "foo"}),
+        answer("Found it."),
+    ])
+    with patch("my_app.build_llm", return_value=llm):
+        graph = build_my_agent(...)
+    result = await graph.ainvoke(...)
+
+For asserting on what the graph *sent* to the LLM (input messages, not
+just outputs), pair with the kit's e2e ``capturing_scripted_llm`` —
+that helper is e2e-internal and intentionally not promoted here; the
+common case is asserting on outputs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+    AIMessage,
+    ToolMessage,
+)
+
+from langgraph_kit.replay import (
+    ConversationRecording,
+    LLMInteraction,
+    RecordedChatModel,
+)
+
+
+def tool_call_turn(
+    tool_name: str,
+    args: dict[str, Any] | None = None,
+    call_id: str | None = None,
+) -> dict[str, Any]:
+    """Build an ``output_message`` dict for a turn that calls one tool.
+
+    The shape matches what :class:`RecordedChatModel` expects:
+    ``{"content": str, "tool_calls": [{"id", "name", "args"}]}``. Use
+    when scripting an LLM turn that should fire a tool call.
+    """
+    return {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id or f"call_{tool_name}",
+                "name": tool_name,
+                "args": args or {},
+            }
+        ],
+    }
+
+
+def multi_tool_call_turn(
+    calls: list[tuple[str, dict[str, Any] | None]],
+) -> dict[str, Any]:
+    """Build an ``output_message`` dict for parallel tool calls.
+
+    Each entry in *calls* is ``(tool_name, args_or_None)``. Call IDs
+    are auto-generated as ``call_<name>_<index>``; tests asserting on
+    specific IDs should build the dict directly.
+    """
+    return {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": f"call_{name}_{i}",
+                "name": name,
+                "args": args or {},
+            }
+            for i, (name, args) in enumerate(calls)
+        ],
+    }
+
+
+def answer(content: str) -> dict[str, Any]:
+    """Build an ``output_message`` dict for a final text response."""
+    return {"content": content, "tool_calls": []}
+
+
+def scripted_llm(turns: list[dict[str, Any]]) -> RecordedChatModel:
+    """Create a :class:`RecordedChatModel` from a list of turns.
+
+    Each ``turns`` element becomes one :class:`LLMInteraction` served
+    in order. When the graph invokes the model more times than
+    ``len(turns)`` the model falls back to fuzzy content matching;
+    when no match is found it raises :class:`ReplayMismatchError`.
+    Tests that expect the LLM to never be called pass ``turns=[]``.
+    """
+    return RecordedChatModel(
+        recording=ConversationRecording(
+            interactions=[
+                LLMInteraction(sequence_num=i + 1, output_message=msg)
+                for i, msg in enumerate(turns)
+            ],
+        )
+    )
+
+
+def _messages(state: Any) -> list[Any]:
+    """Extract the message list from a LangGraph state dict-like."""
+    if hasattr(state, "get"):
+        messages = state.get("messages")
+        if messages is not None:
+            return list(messages)
+    if hasattr(state, "messages"):
+        return list(state.messages)
+    msg = f"Cannot find messages in state of type {type(state).__name__}"
+    raise AssertionError(msg)
+
+
+def assert_tool_invoked(state: Any, tool_name: str) -> ToolMessage:
+    """Assert a ``ToolMessage`` with ``name == tool_name`` exists in *state*.
+
+    Returns the matching message so callers can further assert on its
+    ``content``. Fails with a summary of what was actually present.
+    """
+    messages = _messages(state)
+    for msg in messages:
+        if isinstance(msg, ToolMessage) and getattr(msg, "name", None) == tool_name:
+            return msg
+    summary = [(type(m).__name__, getattr(m, "name", None)) for m in messages]
+    raise AssertionError(
+        f"Expected ToolMessage(name={tool_name!r}) in state; got {summary}"
+    )
+
+
+def last_ai_message(state: Any) -> AIMessage:
+    """Return the last :class:`AIMessage` in *state* or fail with a useful error."""
+    messages = _messages(state)
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            return msg
+    summary = [type(m).__name__ for m in messages]
+    raise AssertionError(f"No AIMessage found in state; got {summary}")
+
+
+__all__ = [
+    "answer",
+    "assert_tool_invoked",
+    "last_ai_message",
+    "multi_tool_call_turn",
+    "scripted_llm",
+    "tool_call_turn",
+]

--- a/src/langgraph_kit/testing/pytest_plugin.py
+++ b/src/langgraph_kit/testing/pytest_plugin.py
@@ -1,0 +1,48 @@
+"""Pytest plugin that auto-registers kit testing fixtures.
+
+Wired up via ``[project.entry-points.pytest11]`` in ``pyproject.toml``.
+Once the kit is installed in a project's venv, ``pytest`` discovers
+this plugin automatically — downstream test suites can use
+``fake_store``, ``fake_checkpointer``, and ``scripted_llm_factory``
+without an explicit conftest import.
+
+Pytest discovery rule: an installed package may register entry points
+under ``pytest11``; the plugin's public hooks and fixtures are then
+loaded for every test session in any environment that has the
+package. https://docs.pytest.org/en/stable/how-to/writing_plugins.html
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langgraph_kit.testing.checkpointer import FakeCheckpointer
+from langgraph_kit.testing.fakes import FakeStore
+from langgraph_kit.testing.llm import scripted_llm
+
+
+@pytest.fixture
+def fake_store() -> FakeStore:
+    """Per-test :class:`FakeStore`. Each test gets a fresh, empty one."""
+    return FakeStore()
+
+
+@pytest.fixture
+def fake_checkpointer() -> FakeCheckpointer:
+    """Per-test :class:`FakeCheckpointer`. Each test gets a fresh saver."""
+    return FakeCheckpointer()
+
+
+@pytest.fixture
+def scripted_llm_factory() -> Any:
+    """Return :func:`scripted_llm` so tests can build a scripted model.
+
+    Naming distinguishes the *factory* fixture (a callable that
+    builds a model from turns) from the *helper function* downstream
+    code imports directly. Both are equivalent — the fixture exists
+    so test code can take ``scripted_llm_factory`` as an argument and
+    not need a top-level import.
+    """
+    return scripted_llm

--- a/tests/testing/test_public_api_v2.py
+++ b/tests/testing/test_public_api_v2.py
@@ -1,0 +1,280 @@
+"""Tests for the v2 additions to ``langgraph_kit.testing`` (#42 v2).
+
+Covers ``FakeCheckpointer``, the promoted ``scripted_llm`` /
+``tool_call_turn`` / ``answer`` / ``last_ai_message`` /
+``assert_tool_invoked`` helpers, and the public API surface.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+from typing import TypedDict
+
+import pytest
+from langchain_core.messages import (  # pyright: ignore[reportMissingModuleSource]
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    ToolMessage,
+)
+
+
+class _ChatState(TypedDict, total=False):
+    messages: list[BaseMessage]
+
+
+class TestPublicApiSurface:
+    """Every promised name imports cleanly from ``langgraph_kit.testing``."""
+
+    def test_v2_names_importable(self) -> None:
+        from langgraph_kit.testing import (
+            FakeCheckpointer,
+            FakeItem,
+            FakeStore,
+            answer,
+            assert_namespace_contains,
+            assert_namespace_empty,
+            assert_tool_invoked,
+            last_ai_message,
+            multi_tool_call_turn,
+            scripted_llm,
+            tool_call_turn,
+        )
+
+        assert callable(FakeCheckpointer)
+        assert callable(FakeItem)
+        assert callable(FakeStore)
+        assert callable(answer)
+        assert callable(assert_namespace_contains)
+        assert callable(assert_namespace_empty)
+        assert callable(assert_tool_invoked)
+        assert callable(last_ai_message)
+        assert callable(multi_tool_call_turn)
+        assert callable(scripted_llm)
+        assert callable(tool_call_turn)
+
+
+class TestScriptedLlmHelpers:
+    """``scripted_llm`` / ``tool_call_turn`` / ``answer`` produce a working model."""
+
+    def test_answer_shape(self) -> None:
+        from langgraph_kit.testing import answer
+
+        out = answer("hi")
+        assert out == {"content": "hi", "tool_calls": []}
+
+    def test_tool_call_turn_default_id(self) -> None:
+        from langgraph_kit.testing import tool_call_turn
+
+        out = tool_call_turn("search", {"q": "foo"})
+        assert out["content"] == ""
+        assert len(out["tool_calls"]) == 1
+        call = out["tool_calls"][0]
+        assert call["name"] == "search"
+        assert call["args"] == {"q": "foo"}
+        assert call["id"] == "call_search"
+
+    def test_tool_call_turn_custom_id(self) -> None:
+        from langgraph_kit.testing import tool_call_turn
+
+        out = tool_call_turn("search", call_id="my-id-1")
+        assert out["tool_calls"][0]["id"] == "my-id-1"
+
+    def test_multi_tool_call_turn_assigns_indexed_ids(self) -> None:
+        from langgraph_kit.testing import multi_tool_call_turn
+
+        out = multi_tool_call_turn([("a", None), ("b", {"x": 1})])
+        ids = [c["id"] for c in out["tool_calls"]]
+        assert ids == ["call_a_0", "call_b_1"]
+
+    def test_scripted_llm_returns_recorded_chat_model(self) -> None:
+        from langgraph_kit.replay import RecordedChatModel
+        from langgraph_kit.replay.models import LLMInteraction
+        from langgraph_kit.testing import answer, scripted_llm
+
+        llm = scripted_llm([answer("first"), answer("second")])
+        assert isinstance(llm, RecordedChatModel)
+        # Two interactions registered, in declared order.
+        interactions = llm.recording.interactions
+        assert len(interactions) == 2
+        assert isinstance(interactions[0], LLMInteraction)
+        assert isinstance(interactions[1], LLMInteraction)
+        assert interactions[0].output_message["content"] == "first"
+        assert interactions[1].output_message["content"] == "second"
+
+    def test_scripted_llm_empty_turns(self) -> None:
+        """``turns=[]`` is the supported way to script "should never call LLM"."""
+        from langgraph_kit.testing import scripted_llm
+
+        llm = scripted_llm([])
+        assert llm.recording.interactions == []
+
+
+class TestStateAssertions:
+    """``assert_tool_invoked`` / ``last_ai_message`` against state shapes."""
+
+    def test_assert_tool_invoked_finds_message(self) -> None:
+        from langgraph_kit.testing import assert_tool_invoked
+
+        state = {
+            "messages": [
+                HumanMessage(content="hi"),
+                ToolMessage(content="42", tool_call_id="x", name="adder"),
+            ]
+        }
+        msg = assert_tool_invoked(state, "adder")
+        assert isinstance(msg, ToolMessage)
+        assert msg.content == "42"
+
+    def test_assert_tool_invoked_raises_with_summary(self) -> None:
+        from langgraph_kit.testing import assert_tool_invoked
+
+        state = {"messages": [HumanMessage(content="hi")]}
+        with pytest.raises(AssertionError, match="Expected ToolMessage"):
+            assert_tool_invoked(state, "missing")
+
+    def test_last_ai_message_returns_most_recent(self) -> None:
+        from langgraph_kit.testing import last_ai_message
+
+        state = {
+            "messages": [
+                AIMessage(content="early"),
+                HumanMessage(content="hi"),
+                AIMessage(content="late"),
+            ]
+        }
+        last = last_ai_message(state)
+        assert last.content == "late"
+
+    def test_last_ai_message_raises_when_absent(self) -> None:
+        from langgraph_kit.testing import last_ai_message
+
+        with pytest.raises(AssertionError, match="No AIMessage"):
+            last_ai_message({"messages": [HumanMessage(content="hi")]})
+
+
+class TestFakeCheckpointer:
+    """``FakeCheckpointer`` behaves like ``InMemorySaver`` plus introspection."""
+
+    def test_dump_state_empty_thread(self) -> None:
+        from langgraph_kit.testing import FakeCheckpointer
+
+        cp = FakeCheckpointer()
+        assert cp.dump_state("nonexistent") == {}
+
+    def test_assert_thread_has_messages_empty(self) -> None:
+        from langgraph_kit.testing import FakeCheckpointer
+
+        cp = FakeCheckpointer()
+        cp.assert_thread_has_messages("nonexistent", 0)
+
+    def test_assert_thread_has_messages_mismatch_raises(self) -> None:
+        from langgraph_kit.testing import FakeCheckpointer
+
+        cp = FakeCheckpointer()
+        with pytest.raises(AssertionError, match="Expected thread"):
+            cp.assert_thread_has_messages("nonexistent", 5)
+
+    async def test_dump_state_after_real_graph_run(self) -> None:
+        """``dump_state`` reads back what a real graph actually wrote.
+
+        Uses a minimal :class:`StateGraph` so the assertion exercises
+        the production save/load path through ``InMemorySaver`` rather
+        than poking at private fields.
+        """
+        from langgraph.graph import (  # pyright: ignore[reportMissingImports]
+            END,
+            START,
+            StateGraph,
+        )
+
+        from langgraph_kit.testing import FakeCheckpointer
+
+        cp = FakeCheckpointer()
+
+        async def _node(state: _ChatState) -> _ChatState:
+            existing = list(state.get("messages") or [])
+            return {"messages": [*existing, AIMessage(content="ok")]}
+
+        graph = StateGraph(_ChatState)
+        graph.add_node("n", _node)
+        graph.add_edge(START, "n")
+        graph.add_edge("n", END)
+        compiled = graph.compile(checkpointer=cp)
+        await compiled.ainvoke(
+            {"messages": [HumanMessage(content="hi")]},
+            config={"configurable": {"thread_id": "t1"}},
+        )
+
+        state = cp.dump_state("t1")
+        assert "messages" in state
+        assert len(state["messages"]) == 2
+
+    async def test_assert_thread_has_messages_after_real_run(self) -> None:
+        """The assertion helper passes when the count matches a real graph run."""
+        from langgraph.graph import (  # pyright: ignore[reportMissingImports]
+            END,
+            START,
+            StateGraph,
+        )
+
+        from langgraph_kit.testing import FakeCheckpointer
+
+        cp = FakeCheckpointer()
+
+        async def _node(state: _ChatState) -> _ChatState:
+            existing = list(state.get("messages") or [])
+            return {"messages": [*existing, AIMessage(content="ok")]}
+
+        graph = StateGraph(_ChatState)
+        graph.add_node("n", _node)
+        graph.add_edge(START, "n")
+        graph.add_edge("n", END)
+        compiled = graph.compile(checkpointer=cp)
+        await compiled.ainvoke(
+            {"messages": [HumanMessage(content="hi")]},
+            config={"configurable": {"thread_id": "t2"}},
+        )
+
+        cp.assert_thread_has_messages("t2", 2)
+        with pytest.raises(AssertionError, match="Expected thread"):
+            cp.assert_thread_has_messages("t2", 99)
+
+
+class TestPytestPluginEntryPoint:
+    """The pytest11 entry point is registered correctly."""
+
+    def test_entry_point_registered(self) -> None:
+        eps = importlib.metadata.entry_points(group="pytest11")
+        names = {ep.name for ep in eps}
+        assert "langgraph_kit_testing" in names
+
+    def test_entry_point_target(self) -> None:
+        eps = importlib.metadata.entry_points(group="pytest11")
+        ours = next(ep for ep in eps if ep.name == "langgraph_kit_testing")
+        # The target value form is "module:object" or just "module".
+        assert ours.value == "langgraph_kit.testing.pytest_plugin"
+
+
+class TestPluginFixturesAreUsable:
+    """Smoke-test the auto-registered fixtures from ``pytest_plugin``."""
+
+    def test_fake_store_fixture(self, fake_store: object) -> None:
+        from langgraph_kit.testing import FakeStore
+
+        assert isinstance(fake_store, FakeStore)
+
+    def test_fake_checkpointer_fixture(self, fake_checkpointer: object) -> None:
+        from langgraph_kit.testing import FakeCheckpointer
+
+        assert isinstance(fake_checkpointer, FakeCheckpointer)
+
+    def test_scripted_llm_factory_builds_a_model(
+        self, scripted_llm_factory: object
+    ) -> None:
+        from langgraph_kit.replay import RecordedChatModel
+        from langgraph_kit.testing import answer
+
+        assert callable(scripted_llm_factory)
+        llm = scripted_llm_factory([answer("ok")])  # pyright: ignore[reportCallIssue]
+        assert isinstance(llm, RecordedChatModel)


### PR DESCRIPTION
## Summary
- Promotes the e2e helpers `scripted_llm`, `tool_call_turn`, `multi_tool_call_turn`, `answer`, plus state-assertions `assert_tool_invoked` and `last_ai_message`, into the public `langgraph_kit.testing` surface.
- Adds `FakeCheckpointer` — an `InMemorySaver` subclass with `dump_state` and `assert_thread_has_messages` for tests that need to inspect what a graph wrote (handles both TypedDict and plain-dict state shapes).
- Wires a pytest11 entry-point so downstream projects auto-discover `fake_store`, `fake_checkpointer`, and `scripted_llm_factory` fixtures without conftest boilerplate.

## Test plan
- [x] `uv run pytest tests/testing/ -q` — 21 new tests pass.
- [x] `uv run pytest -q` — 1476 passing (up from 1455), 1 skipped.
- [x] `uv run basedpyright` — 0 errors.
- [x] `uv run pre-commit run --all-files` — clean.
- [x] Verified entry-point registration via `importlib.metadata.entry_points(group="pytest11")`.
- [x] `FakeCheckpointer.dump_state` round-trips through a real `StateGraph` run.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)