### PR TITLE
feat(memory): write-time deduplication via embedding similarity (#9)

### DIFF
--- a/src/langgraph_kit/_config.py
+++ b/src/langgraph_kit/_config.py
@@ -67,6 +67,15 @@ class AgentConfig:
         dataclasses.field(default=None, compare=False)
     )
 
+    # Memory: cosine-similarity threshold for write-time dedup.
+    # When ``memory_embedding_fn`` is set, ``AutoMemoryExtractor``
+    # asks ``PersistentMemoryManager`` to skip new records whose
+    # embedding is at or above this threshold against an existing
+    # record in the same scope. ``None`` (default) defers to the
+    # manager's hardcoded default of 0.92. Tune up for fewer false-
+    # positive merges; tune down to be more aggressive about dedup.
+    memory_dedup_threshold: float | None = None
+
     # Prompt overrides: {section_id → PromptSection} merged into the
     # SectionRegistry by ``build_deep_agent`` after the kit's
     # core/activation/plugin sections register. Caller wins on id

--- a/src/langgraph_kit/core/graph_builder/middleware.py
+++ b/src/langgraph_kit/core/graph_builder/middleware.py
@@ -110,7 +110,12 @@ def build_middleware_stack(
             PressureMiddleware(pressure_monitor, llm=llm),
             ResultPersistenceMiddleware(tool_registry=tool_registry),
             ExtractionMiddleware(
-                AutoMemoryExtractor(memory_mgr, llm), scope=MemoryScope.USER
+                AutoMemoryExtractor(
+                    memory_mgr,
+                    llm,
+                    dedup_threshold=get_config().memory_dedup_threshold,
+                ),
+                scope=MemoryScope.USER,
             ),
             EmptyTurnMiddleware(max_nudges=2),
             CompletionGuardMiddleware(min_tool_calls=1),

--- a/src/langgraph_kit/core/memory/extraction.py
+++ b/src/langgraph_kit/core/memory/extraction.py
@@ -99,11 +99,16 @@ class AutoMemoryExtractor:
         llm: Any,
         *,
         max_candidates: int = _DEFAULT_MAX_CANDIDATES,
+        dedup_threshold: float | None = None,
     ) -> None:
         super().__init__()
         self._memory = memory_manager
         self._llm = llm
         self._max_candidates = max_candidates
+        # ``None`` defers to PersistentMemoryManager's default
+        # threshold; explicit override useful for evals where the
+        # caller wants tighter or looser dedup behavior.
+        self._dedup_threshold = dedup_threshold
 
     async def extract(
         self,
@@ -248,8 +253,27 @@ class AutoMemoryExtractor:
                     body=candidate.get("body", ""),
                     source="auto_extraction",
                 )
-                saved = await self._memory.create(record)
-                results.append(saved)
+                # Write-time dedup: when an embedding fn is configured
+                # the manager skips near-duplicates and returns a
+                # DuplicateMatch instead of the saved record. The
+                # extractor's contract is "no near-duplicates land
+                # under auto_extraction"; callers explicitly opting
+                # into duplication should call manager.create()
+                # directly.
+                saved = await self._memory.create(
+                    record,
+                    on_duplicate="skip",
+                    threshold=self._dedup_threshold,
+                )
+                if isinstance(saved, MemoryRecord):
+                    results.append(saved)
+                else:
+                    logger.info(
+                        "Skipped duplicate extraction candidate %r (matches %r, sim=%.3f)",
+                        candidate.get("title"),
+                        saved.existing_id,
+                        saved.similarity,
+                    )
 
             except Exception:
                 logger.exception(

--- a/src/langgraph_kit/core/memory/persistent.py
+++ b/src/langgraph_kit/core/memory/persistent.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal, overload
 
 from langgraph_kit.core._vector_math import cosine_similarity
 from langgraph_kit.core.memory.models import (
@@ -14,6 +15,42 @@ from langgraph_kit.core.memory.models import (
     MemoryScope,
     MemoryType,
 )
+
+# Default cosine-similarity threshold above which two records are
+# considered duplicates. Conservative bias: 0.92 trades occasional
+# near-duplicates for never silently merging two distinct memories.
+DEFAULT_DEDUP_THRESHOLD = 0.92
+
+
+@dataclass(frozen=True)
+class DuplicateMatch:
+    """The closest existing record above the dedup threshold.
+
+    Returned by :meth:`PersistentMemoryManager.find_duplicate` when an
+    incoming record's embedding cosine-similarity to an existing
+    record meets or exceeds the configured threshold.
+    """
+
+    existing_id: str
+    similarity: float
+    record: MemoryRecord
+
+
+class DuplicateMemoryError(RuntimeError):
+    """Raised by :meth:`PersistentMemoryManager.create` when a duplicate is found.
+
+    Only fires under ``on_duplicate="raise"`` mode. The exception
+    carries the :class:`DuplicateMatch` so callers can decide whether
+    to merge into the existing record.
+    """
+
+    def __init__(self, match: DuplicateMatch) -> None:
+        super().__init__(
+            f"Duplicate of existing memory {match.existing_id!r} "
+            f"(similarity={match.similarity:.3f})"
+        )
+        self.match = match
+
 
 logger = logging.getLogger(__name__)
 
@@ -131,8 +168,133 @@ class PersistentMemoryManager:
     # CRUD
     # ------------------------------------------------------------------
 
-    async def create(self, record: MemoryRecord) -> MemoryRecord:
-        """Persist a new memory record and return it."""
+    async def find_duplicate(
+        self,
+        record: MemoryRecord,
+        threshold: float = DEFAULT_DEDUP_THRESHOLD,
+    ) -> DuplicateMatch | None:
+        """Return the highest-similarity existing record at or above *threshold*.
+
+        Per-scope only — duplicates across scopes (e.g. a user-scope
+        and a project-scope record with identical text) are
+        intentionally not merged because the scope distinction is
+        load-bearing.
+
+        No-op when ``embedding_fn`` is unset: returns ``None``. There
+        is no keyword-based dedup fallback — false positives at write
+        time would silently merge distinct memories, which is a worse
+        failure mode than missing a near-duplicate.
+        """
+        embedding_fn = self._embedding_fn
+        if embedding_fn is None:
+            return None
+
+        q_vectors = await embedding_fn([_text_for_embedding(record)])
+        if not q_vectors:
+            return None
+        q_vec = list(q_vectors[0])
+
+        ns = self._embedding_namespace(record.scope)
+        items: list[Any] = await self._store.asearch(ns, limit=1000)
+
+        best_sim = -1.0
+        best_id: str | None = None
+        best_type: str = ""
+        for item in items:
+            # Skip the candidate itself if it happens to already be
+            # indexed (e.g. when callers re-run create() defensively).
+            if item.key == record.id:
+                continue
+            payload = item.value
+            vec = payload.get("vector") or []
+            sim = _cosine(q_vec, vec)
+            if sim > best_sim:
+                best_sim = sim
+                best_id = item.key
+                best_type = payload.get("memory_type", "")
+
+        if best_id is None or best_sim < threshold:
+            return None
+
+        mt = MemoryType(best_type) if best_type else None
+        existing = await self.get(best_id, record.scope, mt)
+        if existing is None:
+            # Embedding row outlived the record (out-of-band delete).
+            return None
+        return DuplicateMatch(
+            existing_id=best_id,
+            similarity=best_sim,
+            record=existing,
+        )
+
+    @overload
+    async def create(
+        self,
+        record: MemoryRecord,
+    ) -> MemoryRecord: ...
+
+    @overload
+    async def create(
+        self,
+        record: MemoryRecord,
+        *,
+        on_duplicate: Literal["create"],
+        threshold: float | None = None,
+    ) -> MemoryRecord: ...
+
+    @overload
+    async def create(
+        self,
+        record: MemoryRecord,
+        *,
+        on_duplicate: Literal["skip"],
+        threshold: float | None = None,
+    ) -> MemoryRecord | DuplicateMatch: ...
+
+    @overload
+    async def create(
+        self,
+        record: MemoryRecord,
+        *,
+        on_duplicate: Literal["raise"],
+        threshold: float | None = None,
+    ) -> MemoryRecord: ...
+
+    async def create(
+        self,
+        record: MemoryRecord,
+        *,
+        on_duplicate: Literal["create", "skip", "raise"] = "create",
+        threshold: float | None = None,
+    ) -> MemoryRecord | DuplicateMatch:
+        """Persist a new memory record.
+
+        Modes:
+
+        - ``"create"`` (default) — always write. Preserves the
+          historical contract for callers that already do their own
+          dedup or don't care.
+        - ``"skip"`` — when a duplicate is found, return the
+          :class:`DuplicateMatch` and do not write. Used by
+          :class:`AutoMemoryExtractor` so write-time dedup acts as a
+          safety net behind the LLM-prompted "prefer update".
+        - ``"raise"`` — raise :class:`DuplicateMemoryError`. Used by
+          callers that want a hard failure on accidental duplicates.
+
+        ``threshold`` overrides the default cosine threshold (``0.92``).
+        Has no effect when ``on_duplicate="create"``.
+
+        When ``embedding_fn`` is unset, all modes degrade to plain
+        create — there is no keyword-based dedup fallback.
+        """
+        if on_duplicate != "create":
+            t = threshold if threshold is not None else DEFAULT_DEDUP_THRESHOLD
+            match = await self.find_duplicate(record, threshold=t)
+            if match is not None:
+                if on_duplicate == "raise":
+                    raise DuplicateMemoryError(match)
+                return match
+
         ns = self._namespace(record.scope, record.type)
         await self._store.aput(ns, record.id, record.to_store_value())
         await self._index_record(record)

--- a/tests/test_memory_dedup.py
+++ b/tests/test_memory_dedup.py
@@ -1,0 +1,196 @@
+"""Coverage — write-time memory deduplication via ``find_duplicate``.
+
+When ``embedding_fn`` is configured, ``PersistentMemoryManager`` can
+detect that an incoming :class:`MemoryRecord` is semantically close
+to an existing record in the same scope, and either skip the write
+or raise depending on ``on_duplicate`` mode. Without
+``embedding_fn`` the dedup probe is a no-op (no keyword fallback —
+false positives at write time would silently merge distinct memories,
+which is worse than missing a near-duplicate).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from langgraph_kit.core.memory.models import (
+    MemoryRecord,
+    MemoryScope,
+    MemoryType,
+)
+from langgraph_kit.core.memory.persistent import (
+    DEFAULT_DEDUP_THRESHOLD,
+    DuplicateMatch,
+    DuplicateMemoryError,
+    PersistentMemoryManager,
+)
+from tests.conftest import MockStore
+
+
+def _record(
+    *,
+    title: str,
+    summary: str = "",
+    body: str = "",
+    memory_type: MemoryType = MemoryType.USER,
+    scope: MemoryScope = MemoryScope.USER,
+) -> MemoryRecord:
+    return MemoryRecord(
+        title=title,
+        summary=summary,
+        body=body,
+        type=memory_type,
+        scope=scope,
+    )
+
+
+class _TagEmbedder:
+    """Deterministic embedder over a small tag space.
+
+    Each text gets a vector counting occurrences of the configured
+    tags (case-insensitive). Two texts using the same tags yield the
+    same direction → cosine similarity ~ 1.0. Predictable enough to
+    pin specific similarity values in tests without floating-point
+    fragility.
+    """
+
+    TAGS = ("python", "rust", "ruby")
+
+    async def __call__(self, texts: list[str]) -> list[list[float]]:
+        out: list[list[float]] = []
+        for t in texts:
+            low = t.lower()
+            out.append([float(low.count(tag)) for tag in self.TAGS])
+        return out
+
+
+class TestFindDuplicateNoOpWithoutEmbedding:
+    """No embedding fn → the probe is a no-op for safety."""
+
+    async def test_returns_none_when_embedding_fn_unset(self) -> None:
+        store = MockStore()
+        mgr = PersistentMemoryManager(store)
+        await mgr.create(_record(title="Python tips"))
+
+        match = await mgr.find_duplicate(_record(title="Python tips"))
+        assert match is None
+
+    async def test_create_skip_writes_when_embedding_fn_unset(self) -> None:
+        """Without embeddings, ``on_duplicate="skip"`` degrades to plain create."""
+        store = MockStore()
+        mgr = PersistentMemoryManager(store)
+        first = _record(title="Python tips")
+        second = _record(title="Python tips")  # textually identical
+
+        await mgr.create(first)
+        result = await mgr.create(second, on_duplicate="skip")
+        assert isinstance(result, MemoryRecord)
+        # Both records persisted; without embeddings we can't tell they're dupes.
+        items = await mgr.list_by_scope(MemoryScope.USER, MemoryType.USER)
+        assert len(items) == 2
+
+
+class TestFindDuplicate:
+    """Embedding-backed similarity probe."""
+
+    async def test_finds_match_above_threshold(self) -> None:
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        existing = _record(title="Likes Python", body="Python every day")
+        await mgr.create(existing)
+
+        candidate = _record(title="Python lover", body="Python python python")
+        match = await mgr.find_duplicate(candidate)
+        assert isinstance(match, DuplicateMatch)
+        assert match.existing_id == existing.id
+        assert match.similarity >= DEFAULT_DEDUP_THRESHOLD
+
+    async def test_returns_none_below_threshold(self) -> None:
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        await mgr.create(_record(title="Likes Python", body="python python"))
+
+        candidate = _record(title="Likes Rust", body="rust rust rust")
+        match = await mgr.find_duplicate(candidate)
+        assert match is None
+
+    async def test_threshold_override(self) -> None:
+        """Lowering the threshold lets a less-similar candidate count as dup."""
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        # Mixed-tag record: half python, half rust.
+        await mgr.create(_record(title="Polyglot", body="python rust"))
+
+        # Pure-python candidate: cosine vs (1, 1, 0) is 1/sqrt(2) ~ 0.707.
+        candidate = _record(title="Pythonista", body="python python")
+        assert await mgr.find_duplicate(candidate) is None  # default 0.92 too strict
+        match = await mgr.find_duplicate(candidate, threshold=0.5)
+        assert isinstance(match, DuplicateMatch)
+        assert 0.5 <= match.similarity < DEFAULT_DEDUP_THRESHOLD
+
+    async def test_per_scope_isolation(self) -> None:
+        """Identical text in different scopes is *not* a duplicate."""
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        await mgr.create(_record(title="Python", body="python", scope=MemoryScope.USER))
+        candidate = _record(title="Python", body="python", scope=MemoryScope.PROJECT)
+        match = await mgr.find_duplicate(candidate)
+        assert match is None
+
+
+class TestCreateWithOnDuplicate:
+    """``create(..., on_duplicate=...)`` honors the requested mode."""
+
+    async def test_skip_returns_match_without_writing(self) -> None:
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        existing = _record(title="Likes Python", body="python python")
+        await mgr.create(existing)
+
+        candidate = _record(title="Python lover", body="python python python")
+        result = await mgr.create(candidate, on_duplicate="skip")
+        assert isinstance(result, DuplicateMatch)
+        assert result.existing_id == existing.id
+
+        items = await mgr.list_by_scope(MemoryScope.USER, MemoryType.USER)
+        assert len(items) == 1  # candidate not written
+
+    async def test_create_mode_writes_unconditionally(self) -> None:
+        """Default ``"create"`` preserves backwards compatibility."""
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        await mgr.create(_record(title="Likes Python", body="python python"))
+
+        result = await mgr.create(
+            _record(title="Likes Python", body="python python python")
+        )
+        assert isinstance(result, MemoryRecord)
+        items = await mgr.list_by_scope(MemoryScope.USER, MemoryType.USER)
+        assert len(items) == 2
+
+    async def test_raise_mode(self) -> None:
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+        existing = _record(title="Likes Python", body="python python")
+        await mgr.create(existing)
+
+        candidate = _record(title="Python", body="python python python")
+        with pytest.raises(DuplicateMemoryError) as excinfo:
+            await mgr.create(candidate, on_duplicate="raise")
+        assert excinfo.value.match.existing_id == existing.id
+
+        # No record was written under the raise mode.
+        items = await mgr.list_by_scope(MemoryScope.USER, MemoryType.USER)
+        assert len(items) == 1
+
+    async def test_first_record_in_scope_writes_under_skip(self) -> None:
+        """When there is nothing to dedup against, ``"skip"`` still writes."""
+        store = MockStore()
+        mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+
+        result = await mgr.create(
+            _record(title="Likes Python", body="python python"), on_duplicate="skip"
+        )
+        assert isinstance(result, MemoryRecord)
+        items = await mgr.list_by_scope(MemoryScope.USER, MemoryType.USER)
+        assert len(items) == 1

--- a/tests/test_memory_extraction_consolidation_fixes.py
+++ b/tests/test_memory_extraction_consolidation_fixes.py
@@ -203,3 +203,53 @@ def _msg(role: str, content: str) -> Any:
             self.content = c
 
     return _M(content)
+
+
+class _TagEmbedder:
+    """Tag-counting embedder for write-time dedup tests."""
+
+    TAGS = ("python", "rust")
+
+    async def __call__(self, texts: list[str]) -> list[list[float]]:
+        return [[float(t.lower().count(tag)) for tag in self.TAGS] for t in texts]
+
+
+@pytest.mark.asyncio
+async def test_extractor_skips_near_duplicate_writes() -> None:
+    """When ``embedding_fn`` is configured, the extractor's create
+    path must not write near-duplicates.
+
+    Regression test for #9: previously dedup was prompt-only and the
+    LLM occasionally produced duplicates that got persisted.
+    """
+    store = MockStore()
+    mgr = PersistentMemoryManager(store, embedding_fn=_TagEmbedder())
+    # Seed an existing record about Python.
+    await mgr.create(
+        MemoryRecord(
+            title="Likes Python",
+            summary="enjoys python",
+            body="python python python",
+            type=MemoryType.USER,
+            scope=MemoryScope.USER,
+        )
+    )
+
+    # LLM proposes another Python record — should be detected as a dup.
+    raw = (
+        '[{"action": "create", "title": "Python fan", "type": "user",'
+        ' "scope": "user", "summary": "loves python",'
+        ' "body": "python python python"}]'
+    )
+    extractor = AutoMemoryExtractor(mgr, _FakeLLM(raw))
+
+    results = await extractor.extract(
+        recent_messages=[_msg("human", "I love python")], scope=MemoryScope.USER
+    )
+
+    # Duplicate suppressed → no record returned by the extractor, and
+    # only the original survives in the store.
+    assert results == []
+    items = await mgr.list_by_scope(MemoryScope.USER, MemoryType.USER)
+    assert len(items) == 1
+    assert items[0].title == "Likes Python"


### PR DESCRIPTION
## Summary
- Replaces prompt-only dedup hint with an embedding-similarity probe at write time. ``PersistentMemoryManager.find_duplicate(record)`` returns a ``DuplicateMatch`` when an existing record in the same scope has cosine ≥ 0.92.
- ``create(record, on_duplicate=...)`` adds three modes: ``"create"`` (default, preserves the historical contract), ``"skip"`` (return ``DuplicateMatch`` without writing), ``"raise"`` (throw ``DuplicateMemoryError``).
- ``AutoMemoryExtractor`` passes ``on_duplicate=\"skip\"`` so it no longer persists near-duplicates when an embedding fn is configured. The LLM-prompted "prefer UPDATING" hint stays as a soft instruction; write-time dedup is the safety net behind it.
- ``AgentConfig.memory_dedup_threshold`` lets consumers tune the threshold without subclassing.

No-op without embeddings: when ``embedding_fn`` is unset, all dedup modes degrade to plain create. No keyword-based dedup fallback — false positives at write time would silently merge distinct memories.

## Test plan
- [x] ``uv run pytest tests/test_memory_dedup.py tests/test_memory_extraction_consolidation_fixes.py`` — 16 tests covering: no-op-without-embedding, find-above-threshold, threshold override, per-scope isolation, all three on_duplicate modes, and the extractor wiring.
- [x] ``uv run pytest -q`` — 1487 passing (up from 1476), 1 skipped.
- [x] ``uv run basedpyright`` — 0 errors. Used ``@overload`` so existing ``mgr.create(record)`` callers still type-check as ``MemoryRecord``-returning.
- [x] ``uv run ruff check . && uv run pre-commit run --all-files`` — clean.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)