### PR TITLE
feat(prompt-assembly): PromptVersionRouter + percentage rollout strategy (#18)

### DIFF
--- a/src/langgraph_kit/core/prompt_assembly/__init__.py
+++ b/src/langgraph_kit/core/prompt_assembly/__init__.py
@@ -10,6 +10,13 @@ from .context_providers import (
     ThreadContextProvider,
     ToolContextProvider,
 )
+from .routing import (
+    PromptVersionRouter,
+    RoutingStrategy,
+    RunContext,
+    percentage_rollout,
+    stable_bucket,
+)
 from .sections import PromptSection, SectionRegistry, SectionStability
 
 __all__ = [
@@ -18,8 +25,13 @@ __all__ = [
     "PromptCache",
     "PromptComposer",
     "PromptSection",
+    "PromptVersionRouter",
+    "RoutingStrategy",
+    "RunContext",
     "SectionRegistry",
     "SectionStability",
     "ThreadContextProvider",
     "ToolContextProvider",
+    "percentage_rollout",
+    "stable_bucket",
 ]

--- a/src/langgraph_kit/core/prompt_assembly/routing.py
+++ b/src/langgraph_kit/core/prompt_assembly/routing.py
@@ -1,0 +1,182 @@
+"""A/B routing primitive for ``PromptSection`` versions (#18).
+
+Pairs with the multi-version :class:`SectionRegistry` already shipped
+in :mod:`langgraph_kit.core.prompt_assembly.sections`. Use a router
+when you want to A/B test prompt revisions, run a canary rollout, or
+shadow-test a candidate version against the current one.
+
+Design — keep the router boring. The mapping from
+*run context* → *per-section version* is a callable the caller
+provides; this module just encodes:
+
+- a stable hash-bucketing strategy (so a given user always lands in
+  the same arm);
+- a percentage-rollout strategy that delegates the bucketing to it;
+- the integration point: :py:meth:`PromptVersionRouter.snapshot`
+  returns ``{section_id: version}`` for one run, suitable to thread
+  into :func:`build_agent_run_config(prompt_versions=...)`.
+
+Persistence and feature-flag wiring are intentionally out of scope —
+they're the responsibility of the canary-rollout follow-up. This
+file ships the primitives needed to build either.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from langgraph_kit.core.prompt_assembly.sections import SectionRegistry
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Per-run inputs available to a routing strategy.
+
+    Strategies typically bucket on :attr:`user_id` so a single user
+    sees a stable assignment across runs (avoids "user gets two
+    different prompt versions in one conversation"). :attr:`extra`
+    is a free-form bag for callers that want to bucket on something
+    custom (cohort id, tenant id, region) without subclassing.
+    """
+
+    user_id: str | None = None
+    thread_id: str | None = None
+    agent_id: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# Strategy callable: takes a RunContext, returns {section_id: version}.
+# An empty dict means "use the registry's current version for every
+# section." A dict that omits some section_ids leaves those alone.
+RoutingStrategy = Callable[[RunContext], dict[str, str]]
+
+
+def stable_bucket(key: str, num_buckets: int) -> int:
+    """Return a deterministic bucket index in ``[0, num_buckets)``.
+
+    Uses BLAKE2b-128 of the key — hash collisions don't matter for
+    bucketing, only the integer modulo. ``num_buckets`` must be ``>= 1``;
+    otherwise the function raises :class:`ValueError`.
+
+    Same input always yields the same bucket: the property A/B routing
+    relies on so a user doesn't flip arms run-to-run.
+    """
+    if num_buckets < 1:
+        msg = f"num_buckets must be >= 1, got {num_buckets!r}"
+        raise ValueError(msg)
+    digest = hashlib.blake2b(key.encode(), digest_size=16).digest()
+    return int.from_bytes(digest, "big") % num_buckets
+
+
+def percentage_rollout(
+    section_id: str,
+    *,
+    new_version: str,
+    base_version: str,
+    percent_new: float,
+    bucket_key: Callable[[RunContext], str | None] | None = None,
+) -> RoutingStrategy:
+    """Build a routing strategy that sends *percent_new* of users to *new_version*.
+
+    Bucketing is stable per *bucket_key* — by default
+    :attr:`RunContext.user_id`. When *bucket_key* returns ``None``
+    (e.g. anonymous run), the strategy falls back to *base_version*
+    so anonymous traffic never lands in a canary.
+
+    *percent_new* is a fraction in ``[0.0, 1.0]``. ``0.0`` keeps every
+    bucket on *base_version*; ``1.0`` flips every bucket to
+    *new_version*. Values outside that range raise :class:`ValueError`.
+
+    Returns a strategy callable suitable to pass to
+    :class:`PromptVersionRouter`. The strategy only sets the version
+    for *section_id* — other sections use whatever the registry
+    points at currently.
+    """
+    if not 0.0 <= percent_new <= 1.0:
+        msg = f"percent_new must be in [0.0, 1.0], got {percent_new!r}"
+        raise ValueError(msg)
+    keyfn = bucket_key or (lambda ctx: ctx.user_id)
+    # 10000-bucket grid → 0.01% resolution. Matches the granularity
+    # most rollout tooling exposes; finer than that and the bucketing
+    # noise dominates.
+    n_buckets = 10_000
+    cutoff = int(percent_new * n_buckets)
+
+    def _strategy(ctx: RunContext) -> dict[str, str]:
+        key = keyfn(ctx)
+        if key is None:
+            return {section_id: base_version}
+        bucket = stable_bucket(f"{section_id}:{key}", n_buckets)
+        return {section_id: new_version if bucket < cutoff else base_version}
+
+    return _strategy
+
+
+class PromptVersionRouter:
+    """Resolve per-run section versions from a strategy callable.
+
+    Given a :class:`SectionRegistry` and a :data:`RoutingStrategy`,
+    :py:meth:`snapshot` produces ``{section_id: version}`` for one
+    run. The result is suitable to:
+
+    - thread into ``build_agent_run_config(prompt_versions=...)`` so
+      Langfuse / tracing tags the run with its arm;
+    - feed back into :py:meth:`SectionRegistry.set_current` per-build
+      if you want the new version live for a specific compiled graph
+      (out of scope here — composing with the builder is the canary
+      follow-up's problem).
+
+    The router never mutates the registry. Strategies that name
+    versions which aren't registered would silently produce stale
+    metadata; :py:meth:`snapshot` validates against
+    :py:meth:`SectionRegistry.list_versions` and raises
+    :class:`KeyError` for unknown ``(id, version)`` pairs so a typo
+    in the strategy fails loudly.
+    """
+
+    def __init__(
+        self,
+        registry: SectionRegistry,
+        strategy: RoutingStrategy,
+    ) -> None:
+        super().__init__()
+        self._registry = registry
+        self._strategy = strategy
+
+    def snapshot(self, ctx: RunContext) -> dict[str, str]:
+        """Return ``{section_id: version}`` for the run described by *ctx*.
+
+        Section ids the strategy doesn't mention default to the
+        registry's :py:meth:`current_version`. Section ids the
+        strategy names but the registry doesn't recognize raise
+        :class:`KeyError`; section ids that exist but with an
+        unregistered version do too.
+        """
+        result: dict[str, str] = dict(self._registry.current_versions())
+        overrides = self._strategy(ctx)
+        for section_id, version in overrides.items():
+            known_versions = self._registry.list_versions(section_id)
+            if not known_versions:
+                msg = f"Strategy referenced unknown section id: {section_id!r}"
+                raise KeyError(msg)
+            if version not in known_versions:
+                msg = (
+                    f"Strategy referenced unknown version {version!r} for "
+                    f"section {section_id!r}; known: {sorted(known_versions)}"
+                )
+                raise KeyError(msg)
+            result[section_id] = version
+        return result
+
+
+__all__ = [
+    "PromptVersionRouter",
+    "RoutingStrategy",
+    "RunContext",
+    "percentage_rollout",
+    "stable_bucket",
+]

--- a/tests/test_prompt_version_routing.py
+++ b/tests/test_prompt_version_routing.py
@@ -1,0 +1,216 @@
+"""Tests for ``PromptVersionRouter`` and rollout strategies (#18)."""
+
+from __future__ import annotations
+
+import pytest
+
+from langgraph_kit.core.prompt_assembly import (
+    PromptSection,
+    PromptVersionRouter,
+    RunContext,
+    SectionRegistry,
+    SectionStability,
+    percentage_rollout,
+    stable_bucket,
+)
+
+
+def _section(*, version: str, content: str = "x") -> PromptSection:
+    return PromptSection(
+        id="core_role",
+        content=content,
+        stability=SectionStability.STABLE,
+        priority=100,
+        version=version,
+    )
+
+
+def _registry_with_two_versions() -> SectionRegistry:
+    reg = SectionRegistry()
+    reg.register(_section(version="1", content="v1"))
+    # Stage v2 without promoting it: live traffic stays on v1 unless
+    # the strategy says otherwise.
+    reg.register(_section(version="2", content="v2"), set_current=False)
+    return reg
+
+
+class TestStableBucket:
+    """The stable_bucket helper underlies the rollout strategy."""
+
+    def test_same_input_yields_same_bucket(self) -> None:
+        a = stable_bucket("user-42", 100)
+        b = stable_bucket("user-42", 100)
+        assert a == b
+
+    def test_different_inputs_yield_different_buckets(self) -> None:
+        # Not strictly guaranteed for any pair, but BLAKE2b on these
+        # short distinct strings should disagree at 100 buckets.
+        assert stable_bucket("user-1", 100) != stable_bucket("user-2", 100)
+
+    def test_bucket_in_range(self) -> None:
+        for i in range(50):
+            bucket = stable_bucket(f"user-{i}", 7)
+            assert 0 <= bucket < 7
+
+    def test_zero_buckets_raises(self) -> None:
+        with pytest.raises(ValueError, match=">= 1"):
+            stable_bucket("user-1", 0)
+
+
+class TestPercentageRollout:
+    """``percentage_rollout`` produces stable, percentage-bucketed strategies."""
+
+    def test_zero_percent_keeps_base_for_everyone(self) -> None:
+        strategy = percentage_rollout(
+            "core_role",
+            new_version="2",
+            base_version="1",
+            percent_new=0.0,
+        )
+        for i in range(100):
+            ctx = RunContext(user_id=f"user-{i}")
+            assert strategy(ctx) == {"core_role": "1"}
+
+    def test_one_hundred_percent_flips_everyone(self) -> None:
+        strategy = percentage_rollout(
+            "core_role",
+            new_version="2",
+            base_version="1",
+            percent_new=1.0,
+        )
+        for i in range(100):
+            ctx = RunContext(user_id=f"user-{i}")
+            assert strategy(ctx) == {"core_role": "2"}
+
+    def test_fifty_percent_is_approximately_split(self) -> None:
+        """50% rollout sends ~half to v2; tolerance is generous."""
+        strategy = percentage_rollout(
+            "core_role",
+            new_version="2",
+            base_version="1",
+            percent_new=0.5,
+        )
+        new_count = sum(
+            1
+            for i in range(2000)
+            if strategy(RunContext(user_id=f"user-{i}"))["core_role"] == "2"
+        )
+        # Expected ~1000; allow ±10% slack for hash distribution noise.
+        assert 800 < new_count < 1200, new_count
+
+    def test_anonymous_user_falls_back_to_base(self) -> None:
+        strategy = percentage_rollout(
+            "core_role",
+            new_version="2",
+            base_version="1",
+            percent_new=1.0,  # everyone-on-canary, but anon should still be base
+        )
+        assert strategy(RunContext(user_id=None)) == {"core_role": "1"}
+
+    def test_assignment_is_stable_for_same_user(self) -> None:
+        strategy = percentage_rollout(
+            "core_role",
+            new_version="2",
+            base_version="1",
+            percent_new=0.5,
+        )
+        ctx = RunContext(user_id="user-42")
+        first = strategy(ctx)
+        for _ in range(10):
+            assert strategy(ctx) == first
+
+    def test_invalid_percent_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0\.0, 1\.0\]"):
+            percentage_rollout(
+                "core_role", new_version="2", base_version="1", percent_new=1.5
+            )
+
+    def test_custom_bucket_key(self) -> None:
+        """Bucket on something other than user_id (e.g. tenant)."""
+        strategy = percentage_rollout(
+            "core_role",
+            new_version="2",
+            base_version="1",
+            percent_new=1.0,
+            bucket_key=lambda ctx: ctx.extra.get("tenant"),
+        )
+        # No tenant set → falls back to base.
+        anon = RunContext(user_id="user-1")
+        assert strategy(anon) == {"core_role": "1"}
+        # Tenant set → flips because percent_new=1.0.
+        tenanted = RunContext(user_id="user-1", extra={"tenant": "acme"})
+        assert strategy(tenanted) == {"core_role": "2"}
+
+
+class TestPromptVersionRouter:
+    """``snapshot`` resolves the per-run versions via the strategy."""
+
+    def test_snapshot_returns_current_when_strategy_is_silent(self) -> None:
+        reg = _registry_with_two_versions()
+        # Strategy that returns no overrides — every section uses
+        # whatever the registry's current pointer says.
+        router = PromptVersionRouter(reg, lambda _ctx: {})
+        snap = router.snapshot(RunContext(user_id="u1"))
+        assert snap == {"core_role": "1"}  # v1 is current; v2 was staged
+
+    def test_snapshot_applies_strategy_override(self) -> None:
+        reg = _registry_with_two_versions()
+        router = PromptVersionRouter(
+            reg,
+            percentage_rollout(
+                "core_role",
+                new_version="2",
+                base_version="1",
+                percent_new=1.0,
+            ),
+        )
+        snap = router.snapshot(RunContext(user_id="u1"))
+        assert snap == {"core_role": "2"}
+
+    def test_snapshot_raises_on_unknown_section(self) -> None:
+        reg = SectionRegistry()
+        reg.register(_section(version="1"))
+        router = PromptVersionRouter(reg, lambda _ctx: {"missing": "1"})
+        with pytest.raises(KeyError, match="unknown section id"):
+            router.snapshot(RunContext(user_id="u1"))
+
+    def test_snapshot_raises_on_unknown_version(self) -> None:
+        reg = SectionRegistry()
+        reg.register(_section(version="1"))
+        router = PromptVersionRouter(reg, lambda _ctx: {"core_role": "999"})
+        with pytest.raises(KeyError, match="unknown version"):
+            router.snapshot(RunContext(user_id="u1"))
+
+    def test_snapshot_does_not_mutate_registry(self) -> None:
+        reg = _registry_with_two_versions()
+        before = reg.current_versions()
+        router = PromptVersionRouter(
+            reg,
+            percentage_rollout(
+                "core_role",
+                new_version="2",
+                base_version="1",
+                percent_new=1.0,
+            ),
+        )
+        router.snapshot(RunContext(user_id="u1"))
+        after = reg.current_versions()
+        assert before == after
+
+    def test_snapshot_includes_other_section_currents(self) -> None:
+        """Sections the strategy doesn't touch keep their current version."""
+        reg = SectionRegistry()
+        reg.register(_section(version="1"))
+        reg.register(
+            PromptSection(
+                id="memory_instructions",
+                content="m1",
+                stability=SectionStability.STABLE,
+                priority=50,
+                version="1",
+            )
+        )
+        # Strategy only routes core_role; memory_instructions inherits.
+        router = PromptVersionRouter(reg, lambda _ctx: {"core_role": "1"})
+        snap = router.snapshot(RunContext(user_id="u1"))
+        assert snap == {"core_role": "1", "memory_instructions": "1"}


### PR DESCRIPTION
## Summary
The ``SectionRegistry`` already shipped multi-version sections, ``set_current``, and ``current_versions`` snapshotting; ``build_agent_run_config(prompt_versions=...)`` already tags Langfuse metadata. The missing primitive was an A/B routing helper.

This PR adds:

- ``RunContext`` — frozen dataclass with ``user_id`` / ``thread_id`` / ``agent_id`` / free-form ``extra``.
- ``stable_bucket`` — deterministic hash bucketing (BLAKE2b-128). Same key → same bucket, every time.
- ``percentage_rollout`` — strategy factory that sends a configured fraction of users to a new version. Anonymous traffic falls back to the base so canaries don't silently capture unauthenticated runs. Bucketing key is configurable.
- ``PromptVersionRouter`` — wraps a registry + strategy and produces a per-run ``{section_id: version}`` snapshot. Validates against the registry's known versions; a typo in the strategy raises ``KeyError`` rather than tagging stale metadata.

Composing the router with the graph builder so version overrides actually take effect at compose time belongs to the canary-rollout follow-up (#30) — this PR ships the routing primitive only.

## Test plan
- [x] ``uv run pytest tests/test_prompt_version_routing.py`` — 17 tests covering bucket stability, range validation, 0% / 50% / 100% rollouts, anonymous fallback, custom bucket key, registry-immutability, and unknown-id / unknown-version raising.
- [x] ``uv run pytest -q`` — 1504 passing (up from 1487), 1 skipped.
- [x] ``uv run basedpyright`` — 0 errors.
- [x] ``uv run ruff check . && uv run pre-commit run --all-files`` — clean.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)