### PR TITLE
feat(cancellation): per-process thread cancellation + cancel endpoint

### DIFF
--- a/src/langgraph_kit/__init__.py
+++ b/src/langgraph_kit/__init__.py
@@ -21,6 +21,11 @@ from langgraph_kit._config import (
     configure_from_settings,
     get_config,
 )
+from langgraph_kit.cancellation import (
+    ThreadCancellationRegistry,
+    cancel_thread,
+    get_cancellation_registry,
+)
 from langgraph_kit.core.coordinator import COORDINATOR_SECTIONS, CoordinatorMode
 from langgraph_kit.core.memory.session import SessionNotebook
 from langgraph_kit.llm import build_llm
@@ -47,14 +52,17 @@ __all__ = [
     "InvokeRequest",
     "InvokeResponse",
     "SessionNotebook",
+    "ThreadCancellationRegistry",
     "UserInfo",
     "build_agent_run_config",
     "build_llm",
+    "cancel_thread",
     "configure",
     "configure_from_settings",
     "create_persistence",
     "get",
     "get_all",
+    "get_cancellation_registry",
     "get_config",
     "get_dispatcher",
     "get_metadata",

--- a/src/langgraph_kit/cancellation.py
+++ b/src/langgraph_kit/cancellation.py
@@ -1,0 +1,153 @@
+"""Per-process cancellation for in-flight agent invocations.
+
+Tracks ``thread_id → asyncio.Task`` for whatever transport happens to
+be driving the run (``contrib.fastapi``'s ``/invoke`` or ``/stream``
+today; CLI / other transports can plug in the same way). External
+callers — typically a ``POST /threads/{tid}/cancel`` endpoint — call
+:func:`cancel_thread` to issue ``Task.cancel()`` against the tracked
+task.
+
+Single-process scope. Multi-worker deployments (uvicorn ``--workers
+N``, k8s replicas) won't see each other's tasks: a cancel issued on
+worker A for a run owned by worker B returns ``False`` and is a
+no-op. Cross-process cancellation needs a sticky-session router or a
+shared signal channel and is intentionally out of scope here.
+
+Cancellation is cooperative: ``Task.cancel()`` raises
+``CancelledError`` in the running task's next ``await``. LangGraph
+checkpointers save state at superstep boundaries, so a cancelled
+thread is generally resumable from the most recent checkpoint —
+the partial work of a single in-progress superstep may be lost.
+That tradeoff is part of the cooperative-cancellation contract; if
+you need at-most-once semantics across cancellation, persist state
+yourself before the await that you might be killed at.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+class ThreadCancellationRegistry:
+    """Maps ``thread_id`` to the ``asyncio.Task`` running that thread.
+
+    Per-process. Construct directly only if you need a separate
+    registry instance (tests). Production code uses the module-level
+    singleton via :func:`get_registry`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._tasks: dict[str, asyncio.Task[object]] = {}
+
+    def register(self, thread_id: str, task: asyncio.Task[object]) -> None:
+        """Associate *task* with *thread_id*.
+
+        Re-registering a thread_id overwrites the prior task. The kit
+        doesn't enforce single-flight per thread; multiple concurrent
+        invocations of the same thread_id (rare and usually a bug)
+        will mean the cancel only reaches the most recent one. A
+        warning is logged on overwrite to make the bug visible.
+        """
+        existing = self._tasks.get(thread_id)
+        if existing is not None and not existing.done():
+            logger.warning(
+                "Thread %r already has a running task; overwriting registration. "
+                "Concurrent invocations of the same thread_id are not supported "
+                "and the prior task will not be reachable for cancellation.",
+                thread_id,
+            )
+        self._tasks[thread_id] = task
+
+    def unregister(self, thread_id: str) -> None:
+        """Drop *thread_id*'s task entry. No-op if absent.
+
+        Idempotent — safe to call from a ``finally`` block whether
+        the task succeeded, raised, or was cancelled.
+        """
+        self._tasks.pop(thread_id, None)
+
+    def cancel(self, thread_id: str) -> bool:
+        """Issue ``Task.cancel()`` against *thread_id*'s task.
+
+        Returns ``True`` if a tracked, not-yet-done task was found
+        and cancellation was issued; ``False`` if no task is
+        registered or the registered task already finished. The
+        return value is "did we ask the task to stop," not "is the
+        task definitely stopped" — cancellation is cooperative and
+        observed asynchronously.
+        """
+        task = self._tasks.get(thread_id)
+        if task is None or task.done():
+            return False
+        return task.cancel()
+
+    def is_running(self, thread_id: str) -> bool:
+        """Return ``True`` when a not-yet-done task is registered for *thread_id*."""
+        task = self._tasks.get(thread_id)
+        return task is not None and not task.done()
+
+    @contextlib.asynccontextmanager
+    async def track(self, thread_id: str) -> AsyncIterator[None]:
+        """Async context manager that registers ``current_task`` for the duration.
+
+        Used at transport entry-points::
+
+            async with get_registry().track(thread_id):
+                result = await graph.ainvoke(...)
+
+        Falls back to a no-op when called outside an asyncio task
+        context (``asyncio.current_task()`` returns ``None``); the
+        runtime contract for kit transports is "always inside a
+        task," so the fallback exists only to avoid crashing in
+        synchronous test setups.
+        """
+        task = asyncio.current_task()
+        if task is None:
+            yield
+            return
+        self.register(thread_id, task)
+        try:
+            yield
+        finally:
+            self.unregister(thread_id)
+
+
+_registry = ThreadCancellationRegistry()
+
+
+def get_cancellation_registry() -> ThreadCancellationRegistry:
+    """Return the process-wide :class:`ThreadCancellationRegistry`.
+
+    All transports share this single instance so a cancel issued by
+    one (e.g. an HTTP ``/cancel`` endpoint) reaches a run started by
+    another (e.g. a CLI invocation) — provided they're in the same
+    process, which is the documented scope.
+    """
+    return _registry
+
+
+def cancel_thread(thread_id: str) -> bool:
+    """Cancel *thread_id*'s in-flight run via the process-wide registry.
+
+    Convenience wrapper for ``get_registry().cancel(thread_id)``. Returns
+    ``True`` when cancellation was issued; ``False`` when no in-flight
+    run is tracked for *thread_id* (which can mean "already finished",
+    "never started", or "running in a different worker process").
+    """
+    return _registry.cancel(thread_id)
+
+
+__all__ = [
+    "ThreadCancellationRegistry",
+    "cancel_thread",
+    "get_cancellation_registry",
+]

--- a/src/langgraph_kit/contrib/fastapi.py
+++ b/src/langgraph_kit/contrib/fastapi.py
@@ -27,6 +27,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 
 from langgraph_kit._config import get_config
+from langgraph_kit.cancellation import get_cancellation_registry
 from langgraph_kit.core.hitl.models import (
     ResumeRequest,
     ThreadStateResponse,
@@ -320,6 +321,24 @@ async def _try_command(agent_id: str, messages: list[ChatMessage]) -> str | None
     return f"data: {json.dumps({'command_result': {'output': result.output}})}\n\ndata: [DONE]\n\n"
 
 
+async def _track_stream(
+    thread_id: str, gen: AsyncGenerator[str, None]
+) -> AsyncGenerator[str, None]:
+    """Yield from *gen* while registering its task in the cancellation registry.
+
+    The streaming handler returns a ``StreamingResponse`` immediately;
+    Starlette drives the generator from a separate task. Registering
+    the request-handler task in :py:meth:`get_cancellation_registry`
+    would cancel the wrong thing — by the time a user issues a
+    cancel, the handler task has already returned. We register the
+    *iterator's* task instead, which is what's actually awaiting on
+    the LLM.
+    """
+    async with get_cancellation_registry().track(thread_id):
+        async for chunk in gen:
+            yield chunk
+
+
 def _get_store(request: Request) -> Any:
     """Get the LangGraph Store from contextvar or app state (fallback)."""
     try:
@@ -441,7 +460,9 @@ def create_agent_router(*, get_current_user: Any) -> APIRouter:
             await _ensure_thread(store, tid, current_user, agent_id, first_msg)
 
         return StreamingResponse(
-            stream_agent_events(graph, input_data, config, store=store),
+            _track_stream(
+                tid, stream_agent_events(graph, input_data, config, store=store)
+            ),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
@@ -479,7 +500,8 @@ def create_agent_router(*, get_current_user: Any) -> APIRouter:
             await _ensure_thread(store, tid, current_user, agent_id, first_msg)
 
         try:
-            result = await graph.ainvoke(input_data, config=config)
+            async with get_cancellation_registry().track(tid):
+                result = await graph.ainvoke(input_data, config=config)
             msgs = result.get("messages") or []
             last = msgs[-1] if msgs else None
             content: str = (
@@ -916,6 +938,35 @@ def create_agent_router(*, get_current_user: Any) -> APIRouter:
             )
         deleted = await mgr.delete(thread_id)
         return {"deleted": deleted}
+
+    @router.post("/{agent_id}/threads/{thread_id}/cancel")
+    async def cancel_thread_run(
+        agent_id: str,  # noqa: ARG001 — included for URL symmetry; not used
+        thread_id: str,
+        current_user: CurrentUser,  # type: ignore[valid-type]
+        http_request: Request,
+    ) -> dict[str, Any]:
+        """Cancel an in-flight run for *thread_id*.
+
+        Single-process scope. A cancel issued on this worker only
+        reaches runs started on this worker. ``cancelled=False``
+        means "no run is tracked here" — which can be "already
+        finished," "never started," or "running on a different
+        worker."
+
+        Idempotent — calling cancel on a not-running thread is not
+        an error.
+        """
+        store = _store_var.get(None) or getattr(http_request.app.state, "store", None)
+        # Allow cancel on unclaimed threads — the run might have
+        # registered before _ensure_thread completed (race window
+        # is small but real).
+        if store is not None:
+            await _verify_thread_owner(
+                store, thread_id, current_user, allow_unclaimed=True
+            )
+        cancelled = get_cancellation_registry().cancel(thread_id)
+        return {"thread_id": thread_id, "cancelled": cancelled}
 
     return router
 

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -1,0 +1,280 @@
+"""Tests for the per-process thread cancellation primitive."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+from langgraph_kit.cancellation import (
+    ThreadCancellationRegistry,
+    cancel_thread,
+    get_cancellation_registry,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+class TestRegistryRegisterCancel:
+    """Direct exercise of ``register`` / ``cancel`` / ``unregister``."""
+
+    async def test_cancel_unknown_returns_false(self) -> None:
+        registry = ThreadCancellationRegistry()
+        assert registry.cancel("nonexistent") is False
+
+    async def test_cancel_running_task_returns_true(self) -> None:
+        registry = ThreadCancellationRegistry()
+
+        async def _runner() -> None:
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_runner())
+        registry.register("t1", task)
+        try:
+            assert registry.cancel("t1") is True
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            if not task.done():
+                task.cancel()
+
+    async def test_cancel_completed_task_returns_false(self) -> None:
+        """Re-cancellation after the task has finished is a no-op."""
+        registry = ThreadCancellationRegistry()
+
+        async def _quick() -> str:
+            return "done"
+
+        task = asyncio.create_task(_quick())
+        registry.register("t1", task)
+        await task  # let it finish
+
+        assert registry.cancel("t1") is False
+
+    async def test_unregister_is_idempotent(self) -> None:
+        registry = ThreadCancellationRegistry()
+        registry.unregister("never-registered")  # no-op, no raise
+
+        async def _runner() -> None:
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_runner())
+        registry.register("t1", task)
+        registry.unregister("t1")
+        registry.unregister("t1")  # second call is also a no-op
+
+        # After unregister the cancel API can't reach the task.
+        assert registry.cancel("t1") is False
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    async def test_is_running_reports_state(self) -> None:
+        registry = ThreadCancellationRegistry()
+        assert registry.is_running("t1") is False
+
+        async def _runner() -> None:
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_runner())
+        registry.register("t1", task)
+        assert registry.is_running("t1") is True
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # Task is now done; is_running should reflect that.
+        assert registry.is_running("t1") is False
+
+    async def test_register_overwrite_logs_and_replaces(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Concurrent register on the same thread_id loses the prior task."""
+        import logging
+
+        registry = ThreadCancellationRegistry()
+
+        async def _runner() -> None:
+            await asyncio.sleep(60)
+
+        first = asyncio.create_task(_runner())
+        second = asyncio.create_task(_runner())
+        registry.register("t1", first)
+        with caplog.at_level(logging.WARNING, logger="langgraph_kit.cancellation"):
+            registry.register("t1", second)
+
+        # The warning fires only when the prior task is still alive.
+        assert any("already has a running task" in r.message for r in caplog.records)
+
+        # Cancel reaches second, not first.
+        registry.cancel("t1")
+        with pytest.raises(asyncio.CancelledError):
+            await second
+        assert first.done() is False  # first is still running, untouched
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+
+class TestTrackContextManager:
+    """The ``track`` async context manager registers ``current_task``."""
+
+    async def test_track_registers_and_unregisters(self) -> None:
+        registry = ThreadCancellationRegistry()
+        assert registry.is_running("t1") is False
+
+        async with registry.track("t1"):
+            assert registry.is_running("t1") is True
+
+        assert registry.is_running("t1") is False
+
+    async def test_track_unregisters_on_exception(self) -> None:
+        registry = ThreadCancellationRegistry()
+
+        class _Boom(RuntimeError):
+            pass
+
+        with pytest.raises(_Boom):
+            async with registry.track("t1"):
+                raise _Boom
+
+        assert registry.is_running("t1") is False
+
+    async def test_track_cancellation_propagates_to_caller(self) -> None:
+        """A cancel issued from outside ``track`` raises in the tracked task."""
+        registry = ThreadCancellationRegistry()
+        entered = asyncio.Event()
+        exited = asyncio.Event()
+
+        async def _worker() -> None:
+            try:
+                async with registry.track("t1"):
+                    entered.set()
+                    await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                exited.set()
+                raise
+
+        task = asyncio.create_task(_worker())
+        await entered.wait()
+
+        # Cancel via the registry — the worker's CancelledError handler fires.
+        assert registry.cancel("t1") is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert exited.is_set()
+        # And the registry is clean afterwards.
+        assert registry.is_running("t1") is False
+
+
+class TestModuleSingleton:
+    """``get_cancellation_registry`` and ``cancel_thread`` use the singleton."""
+
+    async def test_singleton_identity(self) -> None:
+        a = get_cancellation_registry()
+        b = get_cancellation_registry()
+        assert a is b
+
+    async def test_cancel_thread_helper_uses_singleton(self) -> None:
+        registry = get_cancellation_registry()
+
+        async def _runner() -> None:
+            await asyncio.sleep(60)
+
+        task = asyncio.create_task(_runner())
+        try:
+            registry.register("singleton-t", task)
+            assert cancel_thread("singleton-t") is True
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            registry.unregister("singleton-t")
+
+    async def test_cancel_thread_unknown_returns_false_via_singleton(self) -> None:
+        # Use a clearly unique thread_id to avoid collision with any
+        # other test that may have registered something on the singleton.
+        assert cancel_thread("nonexistent-zzz-001") is False
+
+
+class TestCancellationDuringInvocation:
+    """End-to-end: register a long-running task, cancel it, observe rollback."""
+
+    async def test_simulated_invoke_cancellation(self) -> None:
+        registry = ThreadCancellationRegistry()
+        ran_to_completion = asyncio.Event()
+        observed_cancel = asyncio.Event()
+
+        async def _simulated_graph_ainvoke() -> None:
+            try:
+                await asyncio.sleep(60)
+                ran_to_completion.set()
+            except asyncio.CancelledError:
+                observed_cancel.set()
+                raise
+
+        async def _invoke_handler(thread_id: str) -> None:
+            async with registry.track(thread_id):
+                await _simulated_graph_ainvoke()
+
+        task = asyncio.create_task(_invoke_handler("t-slow"))
+        # Yield so the handler enters the ``track`` block.
+        await asyncio.sleep(0)
+        # Round-trip several times to let the inner sleep actually start.
+        for _ in range(3):
+            await asyncio.sleep(0)
+
+        assert registry.cancel("t-slow") is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert observed_cancel.is_set()
+        assert not ran_to_completion.is_set()
+        assert registry.is_running("t-slow") is False
+
+
+class TestStreamWrapperPattern:
+    """Mirrors the pattern :func:`_track_stream` uses in contrib.fastapi.
+
+    A separate test (rather than spinning up the FastAPI integration)
+    so the contract is pinned at the registry level: registering
+    ``current_task`` from inside an async generator's iteration loop
+    captures the *iterator's* task, which is what we want to cancel.
+    """
+
+    async def test_async_generator_iterator_is_what_gets_cancelled(self) -> None:
+        registry = ThreadCancellationRegistry()
+        observed_cancel = asyncio.Event()
+
+        async def _producer() -> AsyncGenerator[str, None]:
+            for i in range(1000):
+                await asyncio.sleep(0.01)
+                yield f"chunk-{i}"
+
+        async def _wrapped() -> AsyncGenerator[str, None]:
+            try:
+                async with registry.track("t-stream"):
+                    async for chunk in _producer():
+                        yield chunk
+            except asyncio.CancelledError:
+                observed_cancel.set()
+                raise
+
+        async def _consumer() -> list[str]:
+            chunks: list[str] = []
+            async for chunk in _wrapped():
+                chunks.append(chunk)
+            return chunks
+
+        task = asyncio.create_task(_consumer())
+        # Let the producer get going.
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+
+        assert registry.cancel("t-stream") is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert observed_cancel.is_set()
+        assert registry.is_running("t-stream") is False

--- a/tests/test_fastapi_thread_cancel.py
+++ b/tests/test_fastapi_thread_cancel.py
@@ -1,0 +1,170 @@
+"""End-to-end tests for ``POST /agents/{id}/threads/{tid}/cancel``."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from typing import Annotated, Any
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from langgraph_kit.cancellation import get_cancellation_registry
+from langgraph_kit.contrib.fastapi import create_agent_router
+from langgraph_kit.core.threads import ThreadManager
+
+from .conftest import MockStore
+
+
+class _User:
+    def __init__(self, uid: str) -> None:
+        self.id = uid
+        self.email = f"{uid}@example.test"
+
+
+def _make_app(store: Any, user_id: str = "alice") -> FastAPI:
+    """Build a FastAPI app wired with the agent router and a fixed user."""
+
+    def _get_user() -> _User:
+        return _User(user_id)
+
+    current_user: Any = Annotated[_User, Depends(_get_user)]
+    app = FastAPI()
+    app.state.store = store
+    app.include_router(
+        create_agent_router(get_current_user=current_user), prefix="/api/v1"
+    )
+    return app
+
+
+class TestCancelEndpoint:
+    """The cancel endpoint maps cleanly to the cancellation registry."""
+
+    def test_cancel_no_running_run_returns_false(self) -> None:
+        store = MockStore()
+        # Pre-claim the thread so the owner check passes.
+        asyncio.run(
+            ThreadManager(store).ensure_thread(
+                thread_id="t-idle",
+                user_id="alice",
+                agent_id="a1",
+                first_message="hi",
+            )
+        )
+
+        client = TestClient(_make_app(store))
+        resp = client.post("/api/v1/agents/a1/threads/t-idle/cancel")
+        assert resp.status_code == 200
+        assert resp.json() == {"thread_id": "t-idle", "cancelled": False}
+
+    def test_cancel_running_run_returns_true(self) -> None:
+        """Register a long-running task on the singleton and cancel it via HTTP."""
+        store = MockStore()
+        asyncio.run(
+            ThreadManager(store).ensure_thread(
+                thread_id="t-busy",
+                user_id="alice",
+                agent_id="a1",
+                first_message="hi",
+            )
+        )
+
+        registry = get_cancellation_registry()
+        # Use a fresh event loop to host the task while the TestClient
+        # talks to the app via its own loop. That mirrors the
+        # multi-task production setup where the cancelling request
+        # hits a worker that has the task registered on a different
+        # call frame.
+        loop = asyncio.new_event_loop()
+
+        async def _runner() -> None:
+            await asyncio.sleep(60)
+
+        task = loop.create_task(_runner())
+        # Spin once so the task is actually started.
+        loop.call_soon(loop.stop)
+        loop.run_forever()
+
+        try:
+            registry.register("t-busy", task)
+            client = TestClient(_make_app(store))
+            resp = client.post("/api/v1/agents/a1/threads/t-busy/cancel")
+            assert resp.status_code == 200
+            assert resp.json() == {"thread_id": "t-busy", "cancelled": True}
+
+            # Drive the loop briefly so the cancellation propagates.
+            with suppress(asyncio.CancelledError):
+                loop.run_until_complete(asyncio.wait_for(task, timeout=1.0))
+            assert task.cancelled() or task.done()
+        finally:
+            registry.unregister("t-busy")
+            if not task.done():
+                task.cancel()
+            loop.close()
+
+    def test_cancel_other_users_thread_returns_404(self) -> None:
+        """Owner check uses the same 404-not-403 pattern as other endpoints."""
+        store = MockStore()
+        asyncio.run(
+            ThreadManager(store).ensure_thread(
+                thread_id="t-bobs",
+                user_id="bob",
+                agent_id="a1",
+                first_message="hi",
+            )
+        )
+
+        # Caller is alice, not bob.
+        client = TestClient(_make_app(store, user_id="alice"))
+        resp = client.post("/api/v1/agents/a1/threads/t-bobs/cancel")
+        assert resp.status_code == 404
+
+    def test_cancel_unclaimed_thread_returns_false(self) -> None:
+        """``allow_unclaimed`` semantics: not 404, but ``cancelled=False``.
+
+        A run can register before ``_ensure_thread`` claims it (small
+        race window). The cancel endpoint allows this so the user can
+        still kill an in-flight start; if no run is registered, it
+        idempotently returns ``cancelled=False``.
+        """
+        store = MockStore()
+        # No ensure_thread call — the thread is unclaimed.
+        client = TestClient(_make_app(store))
+        resp = client.post("/api/v1/agents/a1/threads/t-pristine/cancel")
+        assert resp.status_code == 200
+        assert resp.json() == {"thread_id": "t-pristine", "cancelled": False}
+
+
+@pytest.mark.asyncio
+async def test_invoke_registers_task_for_cancellation() -> None:
+    """The invoke handler wraps its work in ``track`` so a cancel issued
+    mid-invoke propagates to the LLM call.
+
+    This test simulates what the actual handler does — exercising the
+    real handler requires standing up a graph + LLM, which is beyond
+    a fast unit test.
+    """
+    registry = get_cancellation_registry()
+    observed_cancel = asyncio.Event()
+
+    async def _fake_invoke_handler(thread_id: str) -> None:
+        try:
+            async with registry.track(thread_id):
+                await asyncio.sleep(60)  # stand-in for graph.ainvoke
+        except asyncio.CancelledError:
+            observed_cancel.set()
+            raise
+
+    task = asyncio.create_task(_fake_invoke_handler("t-invoke-cancel"))
+    # Wait for the handler to enter ``track``.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    try:
+        assert registry.cancel("t-invoke-cancel") is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert observed_cancel.is_set()
+    finally:
+        registry.unregister("t-invoke-cancel")


### PR DESCRIPTION
## Summary
Adds the ability to stop an in-flight agent invocation. Three layers:

- **Transport-agnostic primitive** — ``langgraph_kit.cancellation.ThreadCancellationRegistry`` maps ``thread_id → asyncio.Task`` and ships ``register`` / ``unregister`` / ``cancel`` / ``is_running`` plus an async ``track`` context manager. A module-level singleton, ``get_cancellation_registry()``, and ``cancel_thread(tid)`` cover the common path.
- **FastAPI integration** — ``/invoke`` and ``/stream`` wrap their work in ``track`` so the running task is reachable. Stream registration uses the iterator's task, not the request-handler's (which has already returned by the time Starlette pulls SSE chunks).
- **HTTP endpoint** — ``POST /agents/{agent_id}/threads/{thread_id}/cancel``, authenticated, owner-checked, idempotent. Returns ``{"thread_id", "cancelled"}``. ``cancelled=False`` is not an error and covers "already finished", "never started", and "running on another worker".

## Scope and tradeoffs
- **Single-process only.** Multi-worker deployments (uvicorn ``--workers N``, k8s replicas) need a sticky-session router or a shared signal channel and are intentionally out of scope. Documented on the registry class so consumers know what they're getting.
- **Cooperative cancellation.** ``Task.cancel()`` raises ``CancelledError`` in the task's next ``await``. LangGraph checkpoints save at superstep boundaries, so a cancelled thread is generally resumable from the most recent checkpoint; the partial work of a single in-progress superstep may be lost.

## Test plan
- [x] ``uv run pytest tests/test_cancellation.py tests/test_fastapi_thread_cancel.py -q`` — 19 tests covering register/cancel/unregister, ``is_running``, overwrite-warns, ``track`` register-and-clean, exception cleanup, cancellation propagating to caller, the singleton helpers, and the HTTP endpoint (running task → 200 + ``cancelled=true``; idle thread → 200 + ``cancelled=false``; other user's thread → 404; unclaimed thread → 200 + ``cancelled=false``).
- [x] ``uv run pytest -q`` — 1523 passing (up from 1504), 1 skipped.
- [x] ``uv run basedpyright`` — 0 errors.
- [x] ``uv run ruff check . && uv run pre-commit run --all-files`` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)